### PR TITLE
StarCatalogs

### DIFF
--- a/piff/input.py
+++ b/piff/input.py
@@ -45,16 +45,35 @@ def process_input(config, logger):
     input_handler = input_handler_class(**kwargs)
 
     images = input_handler.readImages()
-    stars = input_handler.readStarCatalogs()
+    coordinates = input_handler.readCoordinates()
 
-    return images, stars
+    config_star_catalog = {'images': images,
+                           'coordinates': coordinates,
+                           'image_name': input_handler.image_name,
+                           'coordinate_names': input_handler.coordinate_names}
+
+    # update the input with any extra starcatalog config keys
+    if 'star_catalog' in config:
+        config_star_catalog.update(config['star_catalog'])
+
+    # return starcatalog
+    return StarCatalog(config_star_catalog)
 
 class InputHandler(object):
     """The base class for handling inputs for building a Piff model.
 
     This is essentially an abstract base class intended to define the methods that should be
     implemented by any derived class.
+
+    :param image_name: string representing what kind of image we have (pixel,
+                       pca, moments, et cetera)
+    :param coordinate_names: a list of names indicating what the different
+                             coordinate columns mean
     """
+    def __init__(self, image_name, coordinate_names):
+        self.image_name = image_name
+        self.coordinate_names = coordinate_names
+
     @classmethod
     def parseKwargs(cls, config_input):
         """Parse the input field of a configuration dict and return the kwargs to use for
@@ -76,7 +95,7 @@ class InputHandler(object):
         """
         raise NotImplemented("Derived classes must define the readImages function")
 
-    def readStarCatalogs(self):
+    def readCoordinates(self):
         """Read in the star catalogs and return lists of positions for each star in each image.
 
         :returns: a list of lists of galsim.PositionD instances
@@ -95,17 +114,19 @@ class InputFiles(InputHandler):
     :param ycol:        The name of the Y column in the input catalogs. [default: 'y']
     :param image_hdu:   The hdu to use in the image files. [default: None, which means use either
                         0 or 1 as typical given the compression sceme of the file]
-    :param cat_hdu:     The hdu to use in the catalgo files. [default: 1]
+    :param cat_hdu:     The hdu to use in the catalog files. [default: 1]
     """
     def __init__(self, images, cats, xcol='x', ycol='y', image_hdu=None, cat_hdu=1):
+        super(InputFiles, self).__init__(image_name='pixel', coordinate_names=[xcol, ycol, 'ccd'])
         if isinstance(images, basestring):
-            self.image_files = glob.glob(images)
+            self.image_files = sorted(glob.glob(images))
         else:
             self.image_files = images
         if isinstance(cats, basestring):
-            self.cat_files = glob.glob(cats)
+            self.cat_files = sorted(glob.glob(cats))
         else:
             self.cat_files = cats
+
         self.xcol = xcol
         self.ycol = ycol
         self.image_hdu = image_hdu
@@ -120,18 +141,60 @@ class InputFiles(InputHandler):
         images = [ galsim.fits.read(fname, hdu=self.image_hdu) for fname in self.image_files ]
         return images
 
-    def readStarCatalogs(self):
+    def readCoordinates(self):
         """Read in the star catalogs and return lists of positions for each star in each image.
 
-        :returns: a list of lists of galsim.PositionD instances
+        :returns: a list of coordinates
         """
         import fitsio
-        cats = []
+        coords = []
         # assuming that the order of cat_files corresponds in some way to the ccd
         for ccd, fname in enumerate(self.cat_files):
             fits = fitsio.FITS(fname)
             xlist = fits[self.cat_hdu].read_column(self.xcol)
             ylist = fits[self.cat_hdu].read_column(self.ycol)
             for x,y in zip(xlist,ylist):
-                cats += [x, y, ccd]
-        return cats
+                coords += [x, y, ccd]
+        return coords
+
+class StarCatalog(object):
+    """A catalog of stars that combines the image with the coordinates
+
+    :param images: representation of the image (initially pixels, can be other
+                  things like gaussian moments).
+    :param image_name: string representing what kind of image we have (pixel,
+                       pca, moments, et cetera)
+    :param coordinates: representation of the image location (just needs to be
+                        a list)
+    :param coordinate_names: a list of names indicating what the different
+                              coordinate columns mean
+
+    We can envision other parameters too, such as:
+        weights for each image
+
+    The main point of this catalog is to keep the images and coordinates
+    together and to also keep track of what is the meaning of each
+
+    """
+
+    def __init__(self, config):
+        if 'images' in config:
+            self.images = config['images']
+        else:
+            raise Exception('Stars need Images!')
+        if 'image_name' in config:
+            self.image_name = config['image_name']
+        else:
+            raise Exception('Stars need image_names!')
+        if 'coordinates' in config:
+            self.coordinates = config['coordinates']
+        else:
+            raise Exception('Stars need Coordinate!')
+        if 'coordinate_names' in config:
+            self.coordinate_names = config['coordinate_names']
+        else:
+            raise Exception('Stars need coordinate_names!')
+
+        ## put in other config parameters if you need
+        if 'weights' in config:
+            self.weights = config['weights']

--- a/piff/input.py
+++ b/piff/input.py
@@ -116,6 +116,7 @@ class InputFiles(InputHandler):
 
         :returns: a list of galsim.Image instances
         """
+        import galsim
         images = [ galsim.fits.read(fname, hdu=self.image_hdu) for fname in self.image_files ]
         return images
 
@@ -125,12 +126,12 @@ class InputFiles(InputHandler):
         :returns: a list of lists of galsim.PositionD instances
         """
         import fitsio
-        import galsim
         cats = []
-        for fname in self.cat_files:
+        # assuming that the order of cat_files corresponds in some way to the ccd
+        for ccd, fname in enumerate(self.cat_files):
             fits = fitsio.FITS(fname)
             xlist = fits[self.cat_hdu].read_column(self.xcol)
             ylist = fits[self.cat_hdu].read_column(self.ycol)
-            cats.append([ galsim.PositionD(float(x),float(y)) for x,y in zip(xlist,ylist) ])
+            for x,y in zip(xlist,ylist):
+                cats += [x, y, ccd]
         return cats
-


### PR DESCRIPTION
3 changes:

1. Created a StarCatalog object, which keeps images and coordinates together. The StarCatalog object also has image_name and coordinate_names to keep track of what each is. For example, we can envision going from coordinates that are [x_image, y_image, ccd] to [x_focal_plane, y_focal_plane], and it might be nice to be able to check between the two. Similarly, we might represent our psf model as being in pixels, or having wcs transformations applied to them.
2. renamed readCatalog to readCoordinates, since I have created the starcatalog object (which would make it confusing) and we are currently only pulling coordinates out for that function anyways.
3. coordinates are now a flat list. In the future we should implement extracting cutouts and weights for each set of coordinates. This would entail adding some sort of keyword "size_x", "size_y" and padding.