### PR TITLE
Import piff version file

### DIFF
--- a/piff/__init__.py
+++ b/piff/__init__.py
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # The version is stored in _version.py as recommended here:
 # http://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
-from _version import __version__, __version_info__
+from ._version import __version__, __version_info__
 
 # Also let piff.version show the version.
 version = __version__


### PR DESCRIPTION
In my setup, doing

`import piff`

returned the following:

```
>>> import piff
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/hd/gogrean/code/Piff/piff/__init__.py", line 48, in <module>
    from _version import __version__, __version_info__
ImportError: cannot import name '__version_info__'
```

That's because Python is going for the wrong version file:

```
>>> inspect.getfile(_version)
'/mnt/hd/gogrean/anaconda3/lib/python3.4/site-packages/_version.py' 
```

This line in __init__.py

`from _version import __version__, __version_info__`

should probably be changed to

`from ._version import __version__, __version_info__`

to avoid such issues.