### PR TITLE
Don't use pyplot or numpy.random state machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,8 @@ cache:
     - $HOME/GalSim-1.4.2
     - $HOME/tmv-0.73
     - $HOME/boost_1_61_0
-    - $HOME/.cache/matplotlib
+    - $HOME/.cache
+    - $HOME/.matplotlib
 
 install:
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
 
     # Workaround for fitsio bug that has been fixed on master, but not pip yet.
     - pushd $HOME
-    - git clone https://github.com/esheldon/fitsio.git
+    - if ! test -d fitsio || ! test -f fitsio/setup.py; then git clone https://github.com/esheldon/fitsio.git ; else echo Using cached fitsio; fi
     - cd fitsio
     - python setup.py install --prefix=$PYHOME
     - popd
@@ -74,9 +74,9 @@ cache:
     pip: true
     directories:
     - $HOME/GalSim-1.4.2
+    - $HOME/fitsio
     - $HOME/tmv-0.73
     - $HOME/boost_1_61_0
-    - $HOME/.cache
     - $HOME/.matplotlib
 
 install:

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -117,6 +117,8 @@ class Stats(object):
         :param logger:      A logger object for logging debug info. [default: None]
         :param **kwargs:    Optionally, provide extra kwargs for the matplotlib plot command.
         """
+        from matplotlib.backends.backend_agg import FigureCanvasAgg
+
         if logger:
             logger.info("Creating plot for %s", self.__class__.__name__)
         fig, ax = self.plot(logger=logger, **kwargs)
@@ -128,7 +130,11 @@ class Stats(object):
 
         if logger:
             logger.warning("Writing %s plot to file %s",self.__class__.__name__,file_name)
-        fig.savefig(file_name)
+
+        canvas = FigureCanvasAgg(fig)
+        # Do this after we've set the canvas to use Agg to avoid warning.
+        fig.set_tight_layout(True)
+        canvas.print_figure(file_name, dpi=100)
 
     def measureShapes(self, psf, stars, logger=None):
         """Compare PSF and true star shapes with HSM algorithm
@@ -239,16 +245,20 @@ class ShapeHistogramsStats(Stats):
 
         :returns: fig, ax
         """
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            import matplotlib
-            matplotlib.use('Agg')
-            import matplotlib.pyplot as plt
-
         if not hasattr(self, 'T'):
             raise RuntimeError("Shape Histogram has not been computed yet.  Cannot plot.")
 
-        fig, axs = plt.subplots(ncols=3, nrows=2, figsize=(15, 10))
+        from matplotlib.figure import Figure
+        fig = Figure(figsize = (15,10))
+        # In matplotlib 2.0, this will be
+        # axs = fig.subplots(ncols=3, nrows=2)
+        axs = [[ fig.add_subplot(2,3,1),
+                 fig.add_subplot(2,3,2),
+                 fig.add_subplot(2,3,3) ],
+               [ fig.add_subplot(2,3,4),
+                 fig.add_subplot(2,3,5),
+                 fig.add_subplot(2,3,6) ]]
+        axs = np.array(axs, dtype=object)
 
         # some defaults for the kwargs
         if 'histtype' not in kwargs:
@@ -396,12 +406,14 @@ class RhoStats(Stats):
         # Leaving this version here in case useful, but I (MJ) have a new version of this
         # below based on the figures I made for the DES SV shear catalog paper that I think
         # looks a bit nicer.
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            import matplotlib
-            matplotlib.use('Agg')
-            import matplotlib.pyplot as plt
-        fig, axs = plt.subplots(ncols=2, figsize=(10, 5))
+        from matplotlib.figure import Figure
+        fig = Figure(figsize = (10,5))
+        # In matplotlib 2.0, this will be
+        # axs = fig.subplots(ncols=2)
+        axs = [ fig.add_subplot(1,2,1),
+                fig.add_subplot(1,2,2) ]
+        axs = np.array(axs, dtype=object)
+
 
         # axs[0] gets rho1 rho3 and rho4
         # axs[1] gets rho2 and rho5
@@ -440,7 +452,6 @@ class RhoStats(Stats):
                 ax.plot(r[neg], -xi[neg], linestyle=linestyle_neg, color=color, **kwargs)
             ax.legend(loc='upper right')
 
-        fig.set_tight_layout(True)
         return fig, axs
 
     def _plot_single(self, ax, rho, color, marker, offset=0.):
@@ -464,41 +475,42 @@ class RhoStats(Stats):
         :returns: fig, ax
         """
         # MJ: Based on the code I used for the plot in the DES SV paper:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            import matplotlib
-            matplotlib.use('Agg')
-            import matplotlib.pyplot as plt
-        fig, ax = plt.subplots(ncols=2, figsize=(10, 5))
+        from matplotlib.figure import Figure
+        fig = Figure(figsize = (10,5))
+        # In matplotlib 2.0, this will be
+        # axs = fig.subplots(ncols=2)
+        axs = [ fig.add_subplot(1,2,1),
+                fig.add_subplot(1,2,2) ]
+        axs = np.array(axs, dtype=object)
+
 
         # Left plot is rho1,3,4
-        rho1 = self._plot_single(ax[0], self.rho1, 'blue', 'o')
-        rho3 = self._plot_single(ax[0], self.rho3, 'green', 's', 0.1)
-        rho4 = self._plot_single(ax[0], self.rho4, 'red', '^', 0.2)
+        rho1 = self._plot_single(axs[0], self.rho1, 'blue', 'o')
+        rho3 = self._plot_single(axs[0], self.rho3, 'green', 's', 0.1)
+        rho4 = self._plot_single(axs[0], self.rho4, 'red', '^', 0.2)
 
-        ax[0].legend([rho1, rho3, rho4],
+        axs[0].legend([rho1, rho3, rho4],
                      [r'$\rho_1(\theta)$', r'$\rho_3(\theta)$', r'$\rho_4(\theta)$'],
                      loc='upper right', fontsize=12)
-        ax[0].set_ylim(1.e-9, None)
-        ax[0].set_xlim(self.tckwargs['min_sep'], self.tckwargs['max_sep'])
-        ax[0].set_xlabel(r'$\theta$ (arcmin)')
-        ax[0].set_ylabel(r'$\rho(\theta)$')
-        ax[0].set_xscale('log')
-        ax[0].set_yscale('log', nonposy='clip')
+        axs[0].set_ylim(1.e-9, None)
+        axs[0].set_xlim(self.tckwargs['min_sep'], self.tckwargs['max_sep'])
+        axs[0].set_xlabel(r'$\theta$ (arcmin)')
+        axs[0].set_ylabel(r'$\rho(\theta)$')
+        axs[0].set_xscale('log')
+        axs[0].set_yscale('log', nonposy='clip')
 
         # Right plot is rho2,5
-        rho2 = self._plot_single(ax[1], self.rho2, 'blue', 'o')
-        rho5 = self._plot_single(ax[1], self.rho5, 'green', 's', 0.1)
+        rho2 = self._plot_single(axs[1], self.rho2, 'blue', 'o')
+        rho5 = self._plot_single(axs[1], self.rho5, 'green', 's', 0.1)
 
-        ax[1].legend([rho2, rho5],
+        axs[1].legend([rho2, rho5],
                      [r'$\rho_2(\theta)$', r'$\rho_5(\theta)$'],
                      loc='upper right', fontsize=12)
-        ax[1].set_ylim(1.e-7, None)
-        ax[1].set_xlim(self.tckwargs['min_sep'], self.tckwargs['max_sep'])
-        ax[1].set_xlabel(r'$\theta$ (arcmin)')
-        ax[1].set_ylabel(r'$\rho(\theta)$')
-        ax[1].set_xscale('log')
-        ax[1].set_yscale('log', nonposy='clip')
+        axs[1].set_ylim(1.e-7, None)
+        axs[1].set_xlim(self.tckwargs['min_sep'], self.tckwargs['max_sep'])
+        axs[1].set_xlabel(r'$\theta$ (arcmin)')
+        axs[1].set_ylabel(r'$\rho(\theta)$')
+        axs[1].set_xscale('log')
+        axs[1].set_yscale('log', nonposy='clip')
 
-        fig.set_tight_layout(True)
-        return fig, ax
+        return fig, axs

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -117,6 +117,9 @@ class Stats(object):
         :param logger:      A logger object for logging debug info. [default: None]
         :param **kwargs:    Optionally, provide extra kwargs for the matplotlib plot command.
         """
+        # Note: don't import matplotlib.pyplot, since that can mess around with the user's
+        # pyplot state.  Better to do everything with the matplotlib object oriented API.
+        # cf. http://www.dalkescientific.com/writings/diary/archive/2005/04/23/matplotlib_without_gui.html
         from matplotlib.backends.backend_agg import FigureCanvasAgg
 
         if logger:

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -402,7 +402,7 @@ class RhoStats(Stats):
         self.rho5 = treecorr.GGCorrelation(self.tckwargs)
         self.rho5.process(cat_g, cat_gdTT)
 
-    def alt_plot(self, logger=None, **kwargs):
+    def alt_plot(self, logger=None, **kwargs):  # pragma: no cover
         # Leaving this version here in case useful, but I (MJ) have a new version of this
         # below based on the figures I made for the DES SV shear catalog paper that I think
         # looks a bit nicer.

--- a/piff/twod_stats.py
+++ b/piff/twod_stats.py
@@ -150,13 +150,21 @@ class TwoDHistStats(Stats):
 
         :returns: fig, ax
         """
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            import matplotlib
-            matplotlib.use('Agg')
-            import matplotlib.pyplot as plt
+        from matplotlib.figure import Figure
+        fig = Figure(figsize=(12,9))
+        # In matplotlib 2.0, this will be
+        # axs = fig.subplots(ncols=3, nrows=3)
+        axs = [[ fig.add_subplot(3,3,1),
+                 fig.add_subplot(3,3,2),
+                 fig.add_subplot(3,3,3) ],
+               [ fig.add_subplot(3,3,4),
+                 fig.add_subplot(3,3,5),
+                 fig.add_subplot(3,3,6) ],
+               [ fig.add_subplot(3,3,7),
+                 fig.add_subplot(3,3,8),
+                 fig.add_subplot(3,3,9) ]]
+        axs = np.array(axs, dtype=object)
 
-        fig, axs = plt.subplots(ncols=3, nrows=3, figsize=(12, 9))
         # left column gets the Y coordinate label
         axs[0, 0].set_ylabel('v')
         axs[1, 0].set_ylabel('v')
@@ -264,8 +272,6 @@ class TwoDHistStats(Stats):
         ax.set_ylim(min(self.bins_v), max(self.bins_v))
         fig.colorbar(IM, ax=ax)
 
-        plt.tight_layout()
-
         return fig, axs
 
     def _array_to_2dhist(self, z, indx_u, indx_v, unique_indx):
@@ -284,21 +290,17 @@ class TwoDHistStats(Stats):
         return C
 
     def _shift_cmap(self, vmin, vmax):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            import matplotlib
-            matplotlib.use('Agg')
-            import matplotlib.pyplot as plt
+        from matplotlib import cm
         midpoint = (0 - vmin) / (vmax - vmin)
 
         # if b <= 0, then we want Blues_r
         if vmax <= 0:
-            return plt.cm.Blues_r
+            return cm.Blues_r
         # if a >= 0, then we want Reds
         elif vmin >= 0:
-            return plt.cm.Reds
+            return cm.Reds
         else:
-            return self._shiftedColorMap(plt.cm.RdBu_r, midpoint=midpoint)
+            return self._shiftedColorMap(cm.RdBu_r, midpoint=midpoint)
 
     def _shiftedColorMap(self, cmap, start=0, midpoint=0.5, stop=1.0,
                          name='shiftedcmap'):
@@ -330,12 +332,8 @@ class TwoDHistStats(Stats):
               Defaults to 1.0 (no upper ofset). Should be between
               `midpoint` and 1.0.
         '''
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            import matplotlib
-            matplotlib.use('Agg')
-            import matplotlib.pyplot as plt
-            from matplotlib.colors import LinearSegmentedColormap
+        from matplotlib.colors import LinearSegmentedColormap
+        from matplotlib import cm
         cdict = {
             'red': [],
             'green': [],
@@ -367,7 +365,7 @@ class TwoDHistStats(Stats):
         newcmap.set_over(color='m', alpha=0.75)
         newcmap.set_under(color='c', alpha=0.75)
 
-        plt.register_cmap(cmap=newcmap)
+        cm.register_cmap(cmap=newcmap)
 
         return newcmap
 
@@ -510,13 +508,19 @@ class WhiskerStats(Stats):
 
         :returns: fig, ax
         """
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore")
-            import matplotlib
-            matplotlib.use('Agg')
-            import matplotlib.pyplot as plt
+        from matplotlib.figure import Figure
+        fig = Figure()
+        # In matplotlib 2.0, this will be
+        # axs = fig.subplots(1, 2, sharey=True, subplot_kw={'aspect' : 'equal'})
+        ax0 = fig.add_subplot(1,2,1, aspect='equal')
+        ax1 = fig.add_subplot(1,2,2, sharey=ax0, aspect='equal')
 
-        fig, axs = plt.subplots(1, 2, sharey=True, subplot_kw={'aspect' : 'equal'})
+        for label in ax1.get_yticklabels():
+            label.set_visible(False)
+        ax1.yaxis.offsetText.set_visible(False)
+
+        axs = np.array([ax0, ax1], dtype=object)
+
         axs[0].set_xlabel('u')
         axs[0].set_ylabel('v')
         axs[1].set_xlabel('u')
@@ -563,8 +567,6 @@ class WhiskerStats(Stats):
         # quiverkey
         ax.quiverkey(Q, 0.90, 0.10, 0.03, 'de = 0.03', coordinates='axes', color='darkred',
                      labelcolor='darkred', labelpos='S')
-
-        plt.tight_layout()
 
         return fig, axs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pyyaml
 treecorr
 sklearn
 lmfit
-matplotlib
+matplotlib==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pyyaml
 treecorr
 sklearn
 lmfit
-matplotlib==1.5.0
+matplotlib

--- a/tests/test_gsobject_model.py
+++ b/tests/test_gsobject_model.py
@@ -242,7 +242,6 @@ def test_interp():
          # Draw stars on a 2d grid of "focal plane" with 0<=u,v<=1
         positions = np.linspace(0.,1.,10.)
         stars = []
-        np.random.seed(1234)
         rng = galsim.BaseDeviate(1234)
         for u in positions:
             for v in positions:
@@ -304,7 +303,7 @@ def test_missing():
         positions = np.linspace(0.,1.,4)
         influx = 150.
         stars = []
-        np.random.seed(1234)
+        np_rng = np.random.RandomState(1234)
         rng = galsim.BaseDeviate(1234)
         for u in positions:
             for v in positions:
@@ -313,7 +312,7 @@ def test_missing():
                               noise=0.1, pix_scale=0.5, fpu=u, fpv=v, rng=rng, include_pixel=False)
                 s = mod.initialize(s)
                 # Kill 10% of each star's pixels
-                bad = np.random.rand(*s.image.array.shape) < 0.1
+                bad = np_rng.rand(*s.image.array.shape) < 0.1
                 s.weight.array[bad] = 0.
                 s.image.array[bad] = -999.
                 s = mod.reflux(s, fit_center=False) # Start with a sensible flux
@@ -382,7 +381,6 @@ def test_gradient():
         positions = np.linspace(0.,1.,4)
         influx = 150.
         stars = []
-        np.random.seed(1234)
         rng = galsim.BaseDeviate(1234)
         for u in positions:
             # Put gradient in pixel size
@@ -465,7 +463,6 @@ def test_gradient_center():
         positions = np.linspace(0.,1.,4)
         influx = 150.
         stars = []
-        np.random.seed(1234)
         rng = galsim.BaseDeviate(1234)
         for u in positions:
             # Put gradient in pixel size

--- a/tests/test_knn_interp.py
+++ b/tests/test_knn_interp.py
@@ -28,8 +28,9 @@ attr_target = list(range(5))
 
 def generate_data(n_samples=100):
     # generate as Norm(0, 1) for all parameters
-    X = np.random.normal(0, 1, size=(n_samples, len(attr_interp)))
-    y = np.random.normal(0, 1, size=(n_samples, len(attr_target)))
+    np_rng = np.random.RandomState(1234)
+    X = np_rng.normal(0, 1, size=(n_samples, len(attr_interp)))
+    y = np_rng.normal(0, 1, size=(n_samples, len(attr_target)))
 
     star_list = []
     for Xi, yi in zip(X, y):
@@ -190,7 +191,8 @@ def test_decam_wavefront():
     knn = piff.des.DECamWavefront(file_name, extname, logger=logger)
 
     n_samples = 2000
-    ccdnums = np.random.randint(1, 63, n_samples)
+    np_rng = np.random.RandomState(1234)
+    ccdnums = np_rng.randint(1, 63, n_samples)
 
     star_list = []
     for ccdnum in ccdnums:
@@ -199,8 +201,8 @@ def test_decam_wavefront():
         wcs = galsim.JacobianWCS(0.26, 0.05, -0.08, -0.29)
         image = galsim.Image(64,64, wcs=wcs)
         # set icen and jcen
-        icen = np.random.randint(100, 2048)
-        jcen = np.random.randint(100, 4096)
+        icen = np_rng.randint(100, 2048)
+        jcen = np_rng.randint(100, 4096)
         image.setCenter(icen, jcen)
         image_pos = image.center()
 
@@ -253,9 +255,10 @@ def test_decam_disk():
 def test_decaminfo():
     # test switching between focal and pixel coordinates
     n_samples = 500000
-    chipnums = np.random.randint(1, 63, n_samples)
-    icen = np.random.randint(1, 2048, n_samples)
-    jcen = np.random.randint(1, 4096, n_samples)
+    np_rng = np.random.RandomState(1234)
+    chipnums = np_rng.randint(1, 63, n_samples)
+    icen = np_rng.randint(1, 2048, n_samples)
+    jcen = np_rng.randint(1, 4096, n_samples)
 
     decaminfo = piff.des.DECamInfo()
     xPos, yPos = decaminfo.getPosition(chipnums, icen, jcen)

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -170,7 +170,6 @@ def test_interp():
     positions = np.linspace(0.,1.,10.)
     influx = 150.
     stars = []
-    np.random.seed(1234)
     rng = galsim.BaseDeviate(1234)
     for u in positions:
         for v in positions:
@@ -230,7 +229,7 @@ def test_missing():
     positions = np.linspace(0.,1.,4)
     influx = 150.
     stars = []
-    np.random.seed(1234)
+    np_rng = np.random.RandomState(1234)
     rng = galsim.BaseDeviate(1234)
     for u in positions:
         for v in positions:
@@ -238,7 +237,7 @@ def test_missing():
             s = make_gaussian_data(1.0, 0., 0., influx, noise=0.1, du=0.5, fpu=u, fpv=v, rng=rng)
             s = mod.initialize(s)
             # Kill 10% of each star's pixels
-            bad = np.random.rand(*s.image.array.shape) < 0.1
+            bad = np_rng.rand(*s.image.array.shape) < 0.1
             s.weight.array[bad] = 0.
             s.image.array[bad] = -999.
             s = mod.reflux(s, fit_center=False) # Start with a sensible flux
@@ -314,7 +313,6 @@ def test_gradient():
     positions = np.linspace(0.,1.,4)
     influx = 150.
     stars = []
-    np.random.seed(1234)
     rng = galsim.BaseDeviate(1234)
     for u in positions:
         # Put gradient in pixel size
@@ -389,12 +387,12 @@ def test_undersamp():
     positions = np.linspace(0.,1.,4)
     influx = 150.
     stars = []
-    np.random.seed(1234)
+    np_rng = np.random.RandomState(1234)
     rng = galsim.BaseDeviate(1234)
     for u in positions:
         for v in positions:
             # Dither centers by 1 pixel
-            phase = (0.5 - np.random.rand(2))*du
+            phase = (0.5 - np_rng.rand(2))*du
             if u==0. and v==0.:
                 phase=(0.,0.)
             s = make_gaussian_data(1.0, 0., 0., influx, noise=0.1, du=du, fpu=u, fpv=v,
@@ -470,13 +468,13 @@ def test_undersamp_shift():
     # Draw stars on a 2d grid of "focal plane" with 0<=u,v<=1
     positions = np.linspace(0.,1.,8)
     stars = []
-    np.random.seed(1234)
+    np_rng = np.random.RandomState(1234)
     rng = galsim.BaseDeviate(1234)
     for u in positions:
         for v in positions:
             # Nominal star centers move by +-1/2 pix, real centers another 1/2 pix
-            phase1 = (0.5 - np.random.rand(2))*du
-            phase2 = (0.5 - np.random.rand(2))*du
+            phase1 = (0.5 - np_rng.rand(2))*du
+            phase2 = (0.5 - np_rng.rand(2))*du
             if u==0. and v==0.:
                 phase1 = phase2 =(0.,0.)
             s = make_gaussian_data(1.0, phase2[0], phase2[1], influx, noise=0.1, du=du,
@@ -544,13 +542,13 @@ def do_undersamp_drift(fit_centers=False):
     # Draw stars on a 2d grid of "focal plane" with 0<=u,v<=1
     positions = np.linspace(0.,1.,8)
     stars = []
-    np.random.seed(1234)
+    np_rng = np.random.RandomState(1234)
     rng = galsim.BaseDeviate(1234)
     for u in positions:
         for v in positions:
             # Nominal star centers move by +-1/2 pix
-            phase1 = (0.5 - np.random.rand(2))*du
-            phase2 = (0.5 - np.random.rand(2))*du
+            phase1 = (0.5 - np_rng.rand(2))*du
+            phase2 = (0.5 - np_rng.rand(2))*du
             if u==0. and v==0.:
                 phase1 = phase2 =(0.,0.)
             # PSF center will drift with v; size drifts with u
@@ -604,7 +602,7 @@ def test_single_image():
     """
     import os
     import fitsio
-    np.random.seed(1234)
+    np_rng = np.random.RandomState(1234)
 
     # Make the image
     image = galsim.Image(2048, 2048, scale=0.2)
@@ -615,12 +613,12 @@ def test_single_image():
     x_list, y_list = np.meshgrid(xvals, yvals)
     x_list = x_list.flatten()
     y_list = y_list.flatten()
-    x_list = x_list + (np.random.rand(len(x_list)) - 0.5)
-    y_list = y_list + (np.random.rand(len(x_list)) - 0.5)
+    x_list = x_list + (np_rng.rand(len(x_list)) - 0.5)
+    y_list = y_list + (np_rng.rand(len(x_list)) - 0.5)
     print('x_list = ',x_list)
     print('y_list = ',y_list)
     # Range of fluxes from 100 to 15000
-    flux_list = 100. * np.exp(5. * np.random.rand(len(x_list)))
+    flux_list = 100. * np.exp(5. * np_rng.rand(len(x_list)))
     print('fluxes range from ',np.min(flux_list),np.max(flux_list))
 
     # Draw a Moffat PSF at each location on the image.
@@ -802,7 +800,6 @@ def test_des_image():
         nstars = 25
         scale = 0.2
         size = 21
-    np.random.seed(1234)
     stamp_size = 51
 
     # The configuration dict with the right input fields for the file we're using.

--- a/tests/test_poly.py
+++ b/tests/test_poly.py
@@ -53,7 +53,8 @@ def test_poly_indexing():
     assert interp.nvariables[0]==10
 
     # check the packing then unpacking a
-    packed = np.random.uniform(size=interp.nvariables[0])
+    np_rng = np.random.RandomState(1234)
+    packed = np_rng.uniform(size=interp.nvariables[0])
     unpacked = interp._unpack_coefficients(0,packed)
     packed_test = interp._pack_coefficients(0,unpacked)
 
@@ -92,13 +93,14 @@ def test_poly_mean():
     nstars = 100
 
     # Choose some random values of star parameters
-    vectors = [ np.random.random(size=nparam) for i in range(nstars) ]
+    np_rng = np.random.RandomState(1234)
+    vectors = [ np_rng.random_sample(size=nparam) for i in range(nstars) ]
 
     # take the mean of them. Our curve fit should be able to reproduce this.
     mean = np.mean(vectors, axis=0)
 
     # Choose some random positions in the field.
-    data = [ piff.Star.makeTarget(u=np.random.random()*10, v=np.random.random()*10).data
+    data = [ piff.Star.makeTarget(u=np_rng.random_sample()*10, v=np_rng.random_sample()*10).data
              for i in range(nstars) ]
     fit = [ piff.StarFit(v) for v in vectors ]
     stars = [ piff.Star(d, f) for d,f in zip(data, fit) ]
@@ -117,7 +119,7 @@ def test_poly_mean():
     # We also expect that if we interpolate to any point we just
     # get the mean as well
     for i in range(30):
-        target = piff.Star.makeTarget(u=np.random.random()*10, v=np.random.random()*10)
+        target = piff.Star.makeTarget(u=np_rng.random_sample()*10, v=np_rng.random_sample()*10)
         target = interp.interpolate(target)
         np.testing.assert_almost_equal(target.fit.params, mean)
 
@@ -143,7 +145,7 @@ def sub_poly_linear(type1):
     # Now lets do something more interesting - test a linear model.
     # with no noise this should fit really well, though again not
     # numerically perfectly.
-    np.random.seed(12834)
+    np_rng = np.random.RandomState(1234)
     nparam = 3
     N = 1
     nstars=50
@@ -152,14 +154,14 @@ def sub_poly_linear(type1):
     X = 10.0 # size of the field
     Y = 10.0
 
-    pos = [ (np.random.random()*X, np.random.random()*Y)
+    pos = [ (np_rng.random_sample()*X, np_rng.random_sample()*Y)
             for i in range(nstars) ]
 
     # Let's make a function that is linear just as a function of one parameter
     # These are the linear fit parameters for each parameter in turn
-    m1 = np.random.uniform(size=nparam)
-    m2 = np.random.uniform(size=nparam)
-    c = np.random.uniform(size=nparam)
+    m1 = np_rng.uniform(size=nparam)
+    m2 = np_rng.uniform(size=nparam)
+    c = np_rng.uniform(size=nparam)
     def linear_func(pos):
         u = pos[0]
         v = pos[1]
@@ -177,7 +179,7 @@ def sub_poly_linear(type1):
 
     # Check that the interpolation recovers the desired function
     for i in range(30):
-        p=(np.random.random()*X, np.random.random()*Y)
+        p=(np_rng.random_sample()*X, np_rng.random_sample()*Y)
         target = piff.Star.makeTarget(u=p[0], v=p[1])
         target = interp.interpolate(target)
         np.testing.assert_almost_equal(linear_func(p), target.fit.params)
@@ -202,7 +204,7 @@ def test_poly_linear():
 def sub_poly_quadratic(type1):
     # This is basically the same as linear but with
     # quadratic variation
-    np.random.seed(1234)
+    np_rng = np.random.RandomState(1234)
     nparam = 3
     N = 2
     nstars=50
@@ -211,16 +213,16 @@ def sub_poly_quadratic(type1):
     X = 10.0 # size of the field
     Y = 10.0
 
-    pos = [ (np.random.random()*X, np.random.random()*Y)
+    pos = [ (np_rng.random_sample()*X, np_rng.random_sample()*Y)
             for i in range(nstars) ]
 
 
     # Let's make a function that is linear just as a function of one parameter
     # These are the linear fit parameters for each parameter in turn
-    m1 = np.random.uniform(size=nparam)
-    m2 = np.random.uniform(size=nparam)
-    q1 = np.random.uniform(size=nparam)
-    c = np.random.uniform(size=nparam)
+    m1 = np_rng.uniform(size=nparam)
+    m2 = np_rng.uniform(size=nparam)
+    q1 = np_rng.uniform(size=nparam)
+    c = np_rng.uniform(size=nparam)
     def quadratic_func(pos):
         u = pos[0]
         v = pos[1]
@@ -238,7 +240,7 @@ def sub_poly_quadratic(type1):
 
     # Check that the interpolation recovers the desired function
     for i in range(30):
-        p=(np.random.random()*X, np.random.random()*Y)
+        p=(np_rng.random_sample()*X, np_rng.random_sample()*Y)
         target = piff.Star.makeTarget(u=p[0], v=p[1])
         target = interp.interpolate(target)
         np.testing.assert_almost_equal(quadratic_func(p), target.fit.params)
@@ -264,19 +266,19 @@ def test_poly_quadratic():
 def test_poly_guess():
     # test that our initial guess gives us a flat function given
     # by the mean
-    np.random.seed(12434)
+    np_rng = np.random.RandomState(1234)
     N = 2
     X = 10.0
     Y = 10.0
     nstars=50
     nparam = 10
     interp = piff.Polynomial(N)
-    pos = [ (np.random.random()*X, np.random.random()*Y)
+    pos = [ (np_rng.random_sample()*X, np_rng.random_sample()*Y)
             for i in range(nstars) ]
 
     interp._setup_indices(nparam)
     for i in range(nparam):
-        param = np.random.random(size=nstars)
+        param = np_rng.random_sample(size=nstars)
         p0 = interp._initialGuess(pos, param, i)
         mu = param.mean()
         assert np.isclose(p0[0,0],mu)
@@ -291,7 +293,7 @@ def poly_load_save_sub(type1, type2, fname):
     # Test that we can serialize and deserialize a polynomial
     # interpolator correctly.  Copying all this stuff from above:
 
-    np.random.seed(12434)
+    np_rng = np.random.RandomState(1234)
     nparam = 3
     nstars=50
     # Use three different sizes to test everything
@@ -300,15 +302,15 @@ def poly_load_save_sub(type1, type2, fname):
     X = 10.0 # size of the field
     Y = 10.0
 
-    pos = [ (np.random.random()*X, np.random.random()*Y)
+    pos = [ (np_rng.random_sample()*X, np_rng.random_sample()*Y)
             for i in range(nstars) ]
 
     # Let's make a function that is linear just as a function of one parameter
     # These are the linear fit parameters for each parameter in turn
-    m1 = np.random.uniform(size=nparam)
-    m2 = np.random.uniform(size=nparam)
-    q1 = np.random.uniform(size=nparam)
-    c = np.random.uniform(size=nparam)
+    m1 = np_rng.uniform(size=nparam)
+    m2 = np_rng.uniform(size=nparam)
+    q1 = np_rng.uniform(size=nparam)
+    c = np_rng.uniform(size=nparam)
 
     def quadratic_func(pos):
         u = pos[0]
@@ -346,7 +348,7 @@ def poly_load_save_sub(type1, type2, fname):
     # Check that the old and new interpolators generate the same
     # value
     for i in range(30):
-        p=(np.random.random()*X, np.random.random()*Y)
+        p=(np_rng.random_sample()*X, np_rng.random_sample()*Y)
         target = piff.Star.makeTarget(u=p[0], v=p[1])
         target1 = interp.interpolate(target)
         target2 = interp.interpolate(target)
@@ -356,17 +358,17 @@ def test_poly_raise():
     # Test that we can serialize and deserialize a polynomial
     # interpolator correctly.  Copying all this stuff from above:
 
-    np.random.seed(12434)
+    np_rng = np.random.RandomState(1234)
     nparam = 3
     nstars = 50
 
     # Use three different sizes to test everything
     orders = [1,2,3]
     interp = piff.Polynomial(orders=orders)
-    pos = [ (np.random.random()*10, np.random.random()*10)
+    pos = [ (np_rng.random_sample()*10, np_rng.random_sample()*10)
             for i in range(nstars) ]
     #use the wrong number of parameters here so that we raise an error
-    vectors = [ np.random.random(size=nparam+1) for i in range(nstars) ]
+    vectors = [ np_rng.random_sample(size=nparam+1) for i in range(nstars) ]
     data = [ piff.Star.makeTarget(u=p[0], v=p[1]).data for p in pos ]
     fit = [ piff.StarFit(v) for v in vectors ]
     stars = [ piff.Star(d, f) for d,f in zip(data, fit) ]

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -88,16 +88,16 @@ def test_Mean():
     even qualifies as doing any kind of interpolating.  But it tests the basic glue software.
     """
     # Make a list of parameter vectors to "interpolate"
-    np.random.seed(123)
+    np_rng = np.random.RandomState(1234)
     nstars = 100
-    vectors = [ np.random.random(10) for i in range(nstars) ]
+    vectors = [ np_rng.random_sample(10) for i in range(nstars) ]
     mean = np.mean(vectors, axis=0)
     print('mean = ',mean)
 
     # Make some dummy StarData objects to use.  The only thing we really need is the properties,
     # although for the Mean interpolator, even this is ignored.
     target_data = [
-            piff.Star.makeTarget(x=np.random.random()*2048, y=np.random.random()*2048).data
+            piff.Star.makeTarget(x=np_rng.random_sample()*2048, y=np_rng.random_sample()*2048).data
             for i in range(nstars) ]
     fit = [ piff.StarFit(v) for v in vectors ]
     stars = [ piff.Star(d, f) for d,f in zip(target_data,fit) ]

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -235,21 +235,21 @@ def test_celestial():
 
 
 def test_io():
-    np.random.seed(1234)
+    np_rng = np.random.RandomState(1234)
     nstars = 100
-    x = np.random.random(nstars) * 2048.
-    y = np.random.random(nstars) * 2048.
-    flux = np.random.random(nstars) * 1000.
-    cenx = 2.*np.random.random(nstars) - 1.
-    ceny = 2.*np.random.random(nstars) - 1.
-    color_ri = np.random.random(nstars) * 1.4 - 0.8
-    color_iz = np.random.random(nstars) * 1.9 - 0.6
+    x = np_rng.random_sample(nstars) * 2048.
+    y = np_rng.random_sample(nstars) * 2048.
+    flux = np_rng.random_sample(nstars) * 1000.
+    cenx = 2.*np_rng.random_sample(nstars) - 1.
+    ceny = 2.*np_rng.random_sample(nstars) - 1.
+    color_ri = np_rng.random_sample(nstars) * 1.4 - 0.8
+    color_iz = np_rng.random_sample(nstars) * 1.9 - 0.6
     stars = [ piff.Star.makeTarget(x=x[i], y=y[i], scale=0.26, color_ri=color_ri[i],
                                    color_iz=color_iz[i]).withFlux(flux[i]) for i in range(nstars) ]
     for star in stars:
-        star.data.image.array[:] = np.random.random(star.data.image.array.shape)
+        star.data.image.array[:] = np_rng.random_sample(star.data.image.array.shape)
         star.data.weight = star.data.image.copy()
-        star.data.weight.array[:] = np.random.random(star.data.image.array.shape)
+        star.data.weight.array[:] = np_rng.random_sample(star.data.image.array.shape)
 
     file_name = os.path.join('output','star_io.fits')
     print('Writing stars to ',file_name)

--- a/tests/test_twodstats.py
+++ b/tests/test_twodstats.py
@@ -99,10 +99,10 @@ def psf_model(icens, jcens, icenter, jcenter):
 
 def generate_starlist(n_samples=500):
     # create n_samples images from the 63 ccds and pixel coordinates
-    np.random.seed(1234)
-    icens = np.random.randint(100, 2048, n_samples)
-    jcens = np.random.randint(100, 4096, n_samples)
-    ccdnums = np.random.randint(1, 63, n_samples)
+    np_rng = np.random.RandomState(1234)
+    icens = np_rng.randint(100, 2048, n_samples)
+    jcens = np_rng.randint(100, 4096, n_samples)
+    ccdnums = np_rng.randint(1, 63, n_samples)
     icenter = 1000
     jcenter = 2000
 


### PR DESCRIPTION
I was having trouble getting the unit tests to run on a machine that couldn't access the X server.  I kept getting:
```
 : cannot connect to X server localhost:11.0
```
which bombed out like a seg fault, not just raising a python Exception.  After messing with different iterations of the `plt.use('Agg')` function for a while, I eventually realized that we shouldn't be changing the user's pyplot state.  This is actually pretty bad form for a library.  Much better etiquette to use the object oriented API of matplotlib instead.

Anyway, when I made the switch to never importing `matplotlib.pyplot`, the errors finally stopped, so I think this is the way to go.  For now, there is a bit of extra boiler plate, since you have to build up the subplots manually, but once matplotlib 2.0 comes out, the API will be almost equivalent to the current `pyplot`-based API.

Also, while I was at it, I switched up our unit tests to not use the `numpy.random` global state either.  It's not as important, since we only do that in the tests, but it might lead to issues when running nosetests in multiprocessing mode.  So I switched to using `numpy.random.RandomState` instead.