### PR TITLE
Von-Karman kernel equal to 1 when distance equal to 0

### DIFF
--- a/piff/kernel.py
+++ b/piff/kernel.py
@@ -258,7 +258,7 @@ class VonKarman(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
 
             dists = cdist(X, Y, metric='euclidean')
             K = ((dists/length_scale)**(5./6.)) * special.kv(5./6.,2*np.pi*dists/length_scale)
-            Filter = np.isfinite(K)
+            Filter = (dists != 0.)
             lim0 = special.gamma(5./6.) / (2 * (np.pi**(5./6.)))
             if np.sum(Filter) != len(K[0])*len(K[:,0]):
                 K[~Filter] = lim0

--- a/piff/kernel.py
+++ b/piff/kernel.py
@@ -245,22 +245,24 @@ class VonKarman(StationaryKernelMixin, NormalizedKernelMixin, Kernel):
         length_scale = _check_length_scale(X, self.length_scale)
         if Y is None:
             dists = pdist(X, metric='euclidean')
-            K = (dists**(5./6.)) * special.kv(5./6.,2*np.pi*dists/length_scale)
+            K = ((dists/length_scale)**(5./6.)) * special.kv(5./6.,2*np.pi*dists/length_scale)
             K = squareform(K)
 
-            lim0 = special.gamma(5./6.) /(2 * ((np.pi / length_scale)**(5./6.)) )
+            lim0 = special.gamma(5./6.) / (2 * (np.pi**(5./6.)))
             np.fill_diagonal(K, lim0)
+            K /= lim0 
         else:
             if eval_gradient:
                 raise ValueError(
                     "Gradient can only be evaluated when Y is None.")
 
             dists = cdist(X, Y, metric='euclidean')
-            K = (dists**(5./6.)) * special.kv(5./6.,2*np.pi*dists/length_scale)
+            K = ((dists/length_scale)**(5./6.)) * special.kv(5./6.,2*np.pi*dists/length_scale)
             Filter = np.isfinite(K)
+            lim0 = special.gamma(5./6.) / (2 * (np.pi**(5./6.)))
             if np.sum(Filter) != len(K[0])*len(K[:,0]):
-                lim0 = special.gamma(5./6.) /(2 * ((np.pi / length_scale)**(5./6.)) )
                 K[~Filter] = lim0
+            K /= lim0
 
         if eval_gradient:
             if self.hyperparameter_length_scale.fixed:

--- a/tests/test_gp_interp.py
+++ b/tests/test_gp_interp.py
@@ -294,7 +294,7 @@ def make_vonkarman_and_rbf_psf_params(ntrain, nvalidate, nvisualize, scale_lengt
     cov_pos = 0.1**2 * np.exp(-0.5*dists**2/scale_length**2)
 
     # Next, generate input data by drawing from a single Gaussian Random Field.
-    kernel = 0.05**2 * piff.VonKarman(length_scale = scale_length)
+    kernel = 0.1**2 * piff.VonKarman(length_scale = scale_length)
     cov = kernel.__call__(np.array([us, vs]).T)    
 
     params['u'] = us
@@ -854,7 +854,7 @@ def test_gp_with_kernels():
         check_config = True
         rtol = 0.02
     else:
-        ntrain = 100
+        ntrain = 500
         npcas = [0]
         optimizes = [False]
         check_config = False
@@ -865,11 +865,11 @@ def test_gp_with_kernels():
     training_data, validation_data, visualization_data = make_vonkarman_and_rbf_psf_params(
             ntrain, nvalidate, nvisualize)
     
-    kernel = ["1*RBF(0.3, (1e-1, 1e1))",
-              "1*RBF(0.3, (1e-1, 1e1))",
-              "0.5*VonKarman(0.3, (1e-1, 1e1))",
-              "0.5*VonKarman(0.3, (1e-1, 1e1))",
-              "0.5*VonKarman(0.3, (1e-1, 1e1))"]
+    kernel = ["0.01*RBF(0.7, (1e-1, 1e1))",
+              "0.01*RBF(0.7, (1e-1, 1e1))",
+              "0.01*VonKarman(0.7, (1e-1, 1e1))",
+              "0.01*VonKarman(0.7, (1e-1, 1e1))",
+              "0.01*VonKarman(0.7, (1e-1, 1e1))"]
 
     for npca in npcas:
         for optimize in optimizes:

--- a/tests/test_gp_interp.py
+++ b/tests/test_gp_interp.py
@@ -211,7 +211,7 @@ def make_grf_psf_params(ntrain, nvalidate, nvisualize, scale_length=0.3):
 
     return training_data, validate_data, vis_data
 
-def make_vonkarman_psf_params(ntrain, nvalidate, nvisualize, scale_length=3.):
+def make_vonkarman_psf_params(ntrain, nvalidate, nvisualize, scale_length=2.):
     """ Make training/testing data for PSF with params drawn from isotropic Von Karman
     gaussian random field.
     """
@@ -819,7 +819,7 @@ def test_vonkarman_psf():
         npcas = [0]
         optimizes = [True, False]
         check_config = True
-        rtol = 0.02
+        rtol = 0.05
     else:
         ntrain = 100
         npcas = [0]
@@ -832,7 +832,7 @@ def test_vonkarman_psf():
     training_data, validation_data, visualization_data = make_vonkarman_psf_params(
             ntrain, nvalidate, nvisualize)
 
-    kernel = "0.01*VonKarman(3., (1e-1, 1e1))"
+    kernel = "0.01*VonKarman(2., (1e-1, 1e1))"
 
     for npca in npcas:
         for optimize in optimizes:
@@ -929,15 +929,19 @@ def test_vonkarman_kernel():
         A = (x[:,0]-x[:,0][:,None])
         B = (x[:,1]-x[:,1][:,None])
         distance = np.sqrt(A*A + B*B)
-        K = param[0]**2 * (distance**(5./6.)) * special.kv(-5./6.,2*np.pi*distance/param[1])
+        K = param[0]**2 * ((distance/param[1])**(5./6.)) * special.kv(-5./6.,2*np.pi*distance/param[1])
         Filtre = np.isfinite(K)
         dist = np.linspace(1e-4,1.,100)
-        div = 5./6. 
-        K[~Filtre] = param[0]**2 * special.gamma(div) /(2 * ((np.pi / param[1])**div) )
+        div = 5./6.
+        lim0 = special.gamma(div) /(2 * (np.pi**div) )
+        K[~Filtre] = param[0]**2 * lim0
+        K /= lim0
         return K
         
     def _vonkarman_corr_function(param, distance):
-        return param[0]**2 * (distance**(5./6.)) * special.kv(-5./6.,2*np.pi*distance/param[1])
+        div = 5./6.
+        lim0 = (2 * (np.pi**div) ) / special.gamma(div) 
+        return param[0]**2 * lim0 * ((distance/param[1])**(5./6.)) * special.kv(-5./6.,2*np.pi*distance/param[1])
     
     for corr in corr_lenght:
         for amp in kernel_amp:


### PR DESCRIPTION
Hi everyone, 

I made a little change on the Von-Karman kernel. Before this modification the value of this kernel for a distance equal to zeros was equal to:

special.gamma(5./6.) /(2 * ((np.pi / length_scale)**(5./6.)) )

The problem with that is just if you change the correlation length, it does change the value of the correlation function for a distance equal to zeros. This is a problem when you are multiplying the Von-Karman kernel by a constant Kernel, because basically you will not have the same constant with different correlation length, even if the true standard deviation of your data (like PSF size) does not change. 

To fixed that, I modified a bit the definition of the Von-Karman kernel in order to get a value of the kernel equal to one for a distance equal to zeros and for any correlation length. 

I guess this is better like that if we want to get a physical interpretation of the constant kernel (the variance of the data) when it is multiply by the Von-Karman kernel. 

If you have any question do not hesitates.
Cheers,
Pierre-François