### PR TITLE
Fix for Issue #68

### DIFF
--- a/piff/gsobject_model.py
+++ b/piff/gsobject_model.py
@@ -106,16 +106,22 @@ class GSObjectModel(Model):
             du, dv, scale, g1, g2 = params
         return self.gsobj.dilate(scale).shear(g1=g1, g2=g2).shift(du, dv)
 
-    def draw(self, star):
+    def draw(self, star, copy_image=True):
         """Draw the model on the given image.
 
         :param star:    A Star instance with the fitted parameters to use for drawing and a
                         data field that acts as a template image for the drawn model.
+        :param copy_image:          If False, will use the same image object.
+                                    If True, will copy the image and then overwrite it.
+                                    [default: True]
 
         :returns: a new Star instance with the data field having an image of the drawn model.
         """
         prof = self.getProfile(star.fit.params).shift(star.fit.center) * star.fit.flux
-        image = star.image.copy()
+        if copy_image:
+            image = star.image.copy()
+        else:
+            image = star.image
         prof.drawImage(image, method=self._method, offset=(star.image_pos-image.true_center))
         data = StarData(image, star.image_pos, star.weight, star.data.pointing)
         return Star(data, star.fit)

--- a/piff/model.py
+++ b/piff/model.py
@@ -106,12 +106,15 @@ class Model(object):
         """
         raise NotImplementedError("Derived classes must define the fit function")
 
-    def draw(self, star):
+    def draw(self, star, copy_image=True):
         """Create new Star instance that has star.data filled with a rendering
         of the PSF specified by the current StarFit parameters, flux, and center.
         Coordinate mapping of the current StarData is assumed.
 
         :param star:   A Star instance
+        :param copy_image:          If False, will use the same image object.
+                                    If True, will copy the image and then overwrite it.
+                                    [default: True]
 
         :returns:      New Star instance with rendered PSF in StarData
         """

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -217,11 +217,14 @@ class Optical(Model):
 
         return prof
 
-    def draw(self, star):
+    def draw(self, star, copy_image=True):
         """Draw the model on the given image.
 
         :param star:    A Star instance with the fitted parameters to use for drawing and a
                         data field that acts as a template image for the drawn model.
+        :param copy_image:          If False, will use the same image object.
+                                    If True, will copy the image and then overwrite it.
+                                    [default: True]
 
         :returns: a new Star instance with the data field having an image of the drawn model.
         """
@@ -229,6 +232,10 @@ class Optical(Model):
         prof = self.getProfile(star.fit.params)
         center = galsim.PositionD(*star.fit.center)
         offset = star.data.image_pos + center - star.data.image.true_center
-        image = prof.drawImage(star.data.image.copy(), method='no_pixel', offset=offset)
+        if copy_image:
+            image = star.image.copy()
+        else:
+            image = star.image
+        prof.drawImage(image, method='no_pixel', offset=offset)
         data = StarData(image, star.data.image_pos, star.data.weight)
         return Star(data, star.fit)

--- a/piff/pixelgrid.py
+++ b/piff/pixelgrid.py
@@ -542,12 +542,15 @@ class PixelGrid(Model):
 
         return Star(star.data, outfit)
 
-    def draw(self, star):
+    def draw(self, star, copy_image=True):
         """Create new Star instance that has StarData filled with a rendering
         of the PSF specified by the current StarFit parameters, flux, and center.
         Coordinate mapping of the current StarData is assumed.
 
         :param star:   A Star instance
+        :param copy_image:          If False, will use the same image object.
+                                    If True, will copy the image and then overwrite it.
+                                    [default: True]
 
         :returns:      New Star instance with rendered PSF in StarData
         """
@@ -572,7 +575,7 @@ class PixelGrid(Model):
             # Change data from surface brightness into flux
             model *= star.data.pixel_area
 
-        return Star(star.data.setData(model,include_zero_weight=True), star.fit)
+        return Star(star.data.setData(model,include_zero_weight=True, copy_image=copy_image), star.fit)
 
     def reflux(self, star, fit_center=True, logger=None):
         """Fit the Model to the star's data, varying only the flux (and

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -171,21 +171,28 @@ class PSF(object):
         center = star.offset_to_center(offset)
         star = star.withFlux(flux, center)
 
+        # if a user specifies an image, then we want to preserve that image, so
+        # copy_image = False. If a user doesn't specify an image, then it
+        # doesn't matter if we overwrite it, so use copy_image=False
+        copy_image = False
         # Draw the star and return the image
-        star = self.drawStar(star)
+        star = self.drawStar(star, copy_image=copy_image)
         return star.data.image
 
-    def drawStarList(self, stars):
+    def drawStarList(self, stars, copy_image=True):
         """Generate PSF images for given stars.
 
         :param stars:       List of Star instances holding information needed
                             for interpolation as well as an image/WCS into
                             which PSF will be rendered.
+        :param copy_image:          If False, will use the same image object.
+                                    If True, will copy the image and then overwrite it.
+                                    [default: True]
 
         :returns:           List of Star instances with its image filled with
                             rendered PSF
         """
-        return [self.drawStar(star) for star in stars]
+        return [self.drawStar(star, copy_image=copy_image) for star in stars]
 
     def write(self, file_name, logger=None):
         """Write a PSF object to a file.

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -218,33 +218,39 @@ class SimplePSF(PSF):
 
         logger.warning("PSF fit did not converge.  Max iterations = %d reached.",max_iterations)
 
-    def drawStarList(self, stars):
+    def drawStarList(self, stars, copy_image=True):
         """Generate PSF images for given stars. Takes advantage of
         interpolateList for significant speedup with some interpolators.
 
         :param stars:       List of Star instances holding information needed
                             for interpolation as well as an image/WCS into
                             which PSF will be rendered.
+        :param copy_image:          If False, will use the same image object.
+                                    If True, will copy the image and then overwrite it.
+                                    [default: True]
 
         :returns:           List of Star instances with its image filled with
                             rendered PSF
         """
         stars_interpolated = self.interp.interpolateList(stars)
-        stars_drawn = [self.model.draw(star) for star in stars_interpolated]
+        stars_drawn = [self.model.draw(star, copy_image=copy_image) for star in stars_interpolated]
         return stars_drawn
 
-    def drawStar(self, star):
+    def drawStar(self, star, copy_image=True):
         """Generate PSF image for a given star.
 
         :param star:        Star instance holding information needed for interpolation as
                             well as an image/WCS into which PSF will be rendered.
+        :param copy_image:          If False, will use the same image object.
+                                    If True, will copy the image and then overwrite it.
+                                    [default: True]
 
         :returns:           Star instance with its image filled with rendered PSF
         """
         # Interpolate parameters to this position/properties:
         star = self.interp.interpolate(star)
         # Render the image
-        return self.model.draw(star)
+        return self.model.draw(star, copy_image=copy_image)
 
     def _finish_write(self, fits, extname, logger):
         """Finish the writing process with any class-specific steps.

--- a/piff/star.py
+++ b/piff/star.py
@@ -739,7 +739,7 @@ class StarData(object):
             mask = wt != 0.
             return pix[mask], wt[mask], u[mask], v[mask]
 
-    def setData(self, data, include_zero_weight=False):
+    def setData(self, data, include_zero_weight=False, copy_image=True):
         """Return new StarData with data values replaced by elements of provided 1d array.
         The array should match the ordering of the one that is produced by getDataVector().
 
@@ -747,13 +747,19 @@ class StarData(object):
         :param include_zero_weight: If True, the data array includes all pixels.
                                     If False, it only includes the pixels with weight > 0.
                                     [default: False]
+        :param copy_image:          If False, will use the same image object.
+                                    If True, will copy the image and then overwrite it.
+                                    [default: True]
 
         :returns:    New StarData structure
         """
         # ??? Do we need a way to fill in pixels that have zero weight and
         # don't get passed out by getDataVector()???
 
-        newimage = self.image.copy()
+        if copy_image:
+            newimage = self.image.copy()
+        else:
+            newimage = self.image
         if include_zero_weight:
             newimage.array[:,:] = data.reshape(newimage.array.shape)
         else:

--- a/tests/test_gsobject_model.py
+++ b/tests/test_gsobject_model.py
@@ -225,6 +225,13 @@ def test_center():
         np.testing.assert_almost_equal(star2.image.array[mask]/peak, s.image.array[mask]/peak,
                                        decimal=14)
 
+        # test copy_image
+        star_copy = mod.draw(star, copy_image=True)
+        star_nocopy = mod.draw(star, copy_image=False)
+        star.image.array[0,0] = 132435
+        assert star_nocopy.image.array[0,0] == star.image.array[0,0]
+        assert star_copy.image.array[0,0] != star.image.array[0,0]
+        assert star_copy.image.array[1,1] == star.image.array[1,1]
 
 @timer
 def test_interp():

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -45,6 +45,13 @@ def test_optical(model=None):
     np.testing.assert_almost_equal(star_fitted.fit.flux, star.fit.flux)
     np.testing.assert_almost_equal(star_fitted.fit.params, star.fit.params)
 
+    # test copy_image
+    star_copy = model.draw(star, copy_image=True)
+    star_nocopy = model.draw(star, copy_image=False)
+    star.image.array[0,0] = 132435
+    assert star_nocopy.image.array[0,0] == star.image.array[0,0]
+    assert star_copy.image.array[0,0] != star.image.array[0,0]
+    assert star_copy.image.array[1,1] == star.image.array[1,1]
 
 @timer
 def test_pupil_im(pupil_plane_file='input/DECam_pupil_128.fits'):

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -218,7 +218,18 @@ def test_single_image():
     print('mean = ',interp.mean)
 
     # Check that the interpolation is what it should be
-    target = piff.Star.makeTarget(x=1024, y=123) # Any position would work here.
+    # Any position would work here.
+    chipnum = 0
+    x = 1024
+    y = 123
+    orig_wcs = input.getWCS()[chipnum]
+    orig_pointing = input.getPointing()
+    image_pos = galsim.PositionD(x,y)
+    world_pos = piff.StarData.calculateFieldPos(image_pos, orig_wcs, orig_pointing)
+    u,v = world_pos.x, world_pos.y
+    stamp_size = config['stamp_size']
+
+    target = piff.Star.makeTarget(x=x, y=y, u=u, v=v, wcs=orig_wcs, stamp_size=stamp_size, pointing=orig_pointing)
     true_params = [ sigma, g1, g2 ]
     test_star = interp.interpolate(target)
     np.testing.assert_almost_equal(test_star.fit.params, true_params, decimal=4)
@@ -231,7 +242,7 @@ def test_single_image():
             'cat_file_name' : cat_file,
             'flag_col' : 'flag',
             'use_col' : 'use',
-            'stamp_size' : 48
+            'stamp_size' : stamp_size
         },
         'psf' : {
             'model' : { 'type' : 'Gaussian',
@@ -255,6 +266,31 @@ def test_single_image():
     test_star_list = psf.drawStarList([target])[0]
     np.testing.assert_equal(test_star.fit.params, test_star_list.fit.params)
     np.testing.assert_equal(test_star.image.array, test_star_list.image.array)
+
+    # test copy_image property of drawStar and draw
+    for draw in [psf.drawStar, psf.model.draw]:
+        target_star_copy = psf.interp.interpolate(piff.Star(target.data.copy(), target.fit.copy()))  # interp is so that when we do psf.model.draw we have fit.params to work with
+
+        test_star_copy = draw(target_star_copy, copy_image=True)
+        test_star_nocopy = draw(target_star_copy, copy_image=False)
+        # if we modify target_star_copy, then test_star_nocopy should be modified, but not test_star_copy
+        target_star_copy.image.array[0,0] = 23456
+        assert test_star_nocopy.image.array[0,0] == target_star_copy.image.array[0,0]
+        assert test_star_copy.image.array[0,0] != target_star_copy.image.array[0,0]
+        # however the other pixels SHOULD still be all the same value
+        assert test_star_nocopy.image.array[1,1] == target_star_copy.image.array[1,1]
+        assert test_star_copy.image.array[1,1] == target_star_copy.image.array[1,1]
+
+    # test that draw works
+    test_image = psf.draw(x=target['x'], y=target['y'], stamp_size=config['input']['stamp_size'], flux=target.fit.flux, offset=target.fit.center)
+    # this image should be the same values as test_star
+    assert test_image == test_star.image
+    # test that draw does not copy the image
+    image_ref = psf.draw(x=target['x'], y=target['y'], stamp_size=config['input']['stamp_size'], flux=target.fit.flux, offset=target.fit.center, image=test_image)
+    image_ref.array[0,0] = 123456789
+    assert test_image.array[0,0] == image_ref.array[0,0]
+    assert test_star.image.array[0,0] != test_image.array[0,0]
+    assert test_star.image.array[1,1] == test_image.array[1,1]
 
     # Round trip to a file
     psf.write(psf_file, logger)


### PR DESCRIPTION
Fixes Issue #68 by adding a copy_image parameter to calls for draw, drawStar, drawStarList, and setData. I went with this route because we have treated drawStar as returning a different image object throughout the code; always writing onto the same image ends up breaking a bunch of code.

So, if the user wants drawStar to use the same image, they can specify it, but otherwise it returns a copy like we have in the past. psf.draw, in contrast, will draw onto a provided image. I also added a few lines in the unit tests to confirm whether an image is copied or not.