### PR TITLE
speed up meanify by ~100x

### DIFF
--- a/piff/config.py
+++ b/piff/config.py
@@ -255,9 +255,6 @@ def meanify(config, logger=None):
     if 'dir' in config['hyper']:
         file_name_out = os.path.join(config['hyper']['dir'], file_name_out)
 
-    def _getcoord(star):
-        return np.array([star.data[key] for key in ['u', 'v']])
-
     coords = []
     params = []
 

--- a/piff/config.py
+++ b/piff/config.py
@@ -264,7 +264,7 @@ def meanify(config, logger=None):
     for fi, f in enumerate(file_name_in):
         logger.debug('Loading file {0} of {1}'.format(fi, len(file_name_in)))
         fits = fitsio.FITS(f)
-        coord, param = piff.Star.read_coords_params(fits, 'psf_stars')
+        coord, param = Star.read_coords_params(fits, 'psf_stars')
         fits.close()
 
         coords.append(coord)

--- a/piff/config.py
+++ b/piff/config.py
@@ -261,15 +261,18 @@ def meanify(config, logger=None):
     coords = []
     params = []
 
-    for f in file_name_in:
-        hdu = fitsio.FITS(f) 
-        stars = Star.read(hdu, 'psf_stars')
-        for s in stars:
-            coords.append(_getcoord(s))
-            params.append(s.fit.params)
+    for fi, f in enumerate(file_name_in):
+        logger.debug('Loading file {0} of {1}'.format(fi, len(file_name_in)))
+        star_arr = fitsio.read(f, 'psf_stars')
+        coord = np.array([star_arr['u'], star_arr['v']])
+        param = star_arr['params']
 
-    coords = np.array(coords)
-    params = np.array(params)
+        coords.append(coord)
+        params.append(param)
+
+    params = np.concatenate(params, axis=0)
+    coords = np.concatenate(coords, axis=1).T
+    logger.info('Computing average for {0} params with {1} stars'.format(len(params[0]), len(coords)))
 
     lu_min, lu_max = np.min(coords[:,0]), np.max(coords[:,0])
     lv_min, lv_max = np.min(coords[:,1]), np.max(coords[:,1])

--- a/piff/config.py
+++ b/piff/config.py
@@ -263,15 +263,15 @@ def meanify(config, logger=None):
 
     for fi, f in enumerate(file_name_in):
         logger.debug('Loading file {0} of {1}'.format(fi, len(file_name_in)))
-        star_arr = fitsio.read(f, 'psf_stars')
-        coord = np.array([star_arr['u'], star_arr['v']])
-        param = star_arr['params']
+        fits = fitsio.FITS(f)
+        coord, param = piff.Star.read_coords_params(fits, 'psf_stars')
+        fits.close()
 
         coords.append(coord)
         params.append(param)
 
     params = np.concatenate(params, axis=0)
-    coords = np.concatenate(coords, axis=1).T
+    coords = np.concatenate(coords, axis=0)
     logger.info('Computing average for {0} params with {1} stars'.format(len(params[0]), len(coords)))
 
     lu_min, lu_max = np.min(coords[:,0]), np.max(coords[:,0])

--- a/piff/gsobject_model.py
+++ b/piff/gsobject_model.py
@@ -245,7 +245,9 @@ class GSObjectModel(Model):
 
         try:
             params_var = np.diag(results.covar)
-        except ValueError, AttributeError:
+        except (ValueError, AttributeError) as e:
+            logger.warning("Failed to get params_var")
+            logger.warning("  -- Caught exception: %s",e)
             # results.covar is either None or does not exist
             params_var = np.zeros(6)
 

--- a/piff/gsobject_model.py
+++ b/piff/gsobject_model.py
@@ -243,10 +243,11 @@ class GSObjectModel(Model):
         if not results.success:
             raise RuntimeError("Error fitting with lmfit.")
 
-        if results.covar is None:
-            params_var = np.zeros(6)
-        else:
+        try:
             params_var = np.diag(results.covar)
+        except ValueError, AttributeError:
+            # results.covar is either None or does not exist
+            params_var = np.zeros(6)
 
         return flux, du, dv, scale, g1, g2, params_var
 

--- a/piff/gsobject_model.py
+++ b/piff/gsobject_model.py
@@ -235,6 +235,7 @@ class GSObjectModel(Model):
         :returns: (flux, dx, dy, scale, g1, g2, flag)
         """
         import lmfit
+        logger = galsim.config.LoggerWrapper(logger)
         params = self._lmfit_params(star)
         results = self._lmfit_minimize(params, star, logger=logger)
         if logger:

--- a/piff/star.py
+++ b/piff/star.py
@@ -329,12 +329,12 @@ class Star(object):
         :returns: the arrays coords and params
         """
         import galsim
-        assert extname in fits
+        if extname not in fits: raise RuntimeError('{0} not found in FITS object'.format(extname))
         colnames = fits[extname].get_colnames()
 
         columns = ['u', 'v', 'params']
         for key in columns:
-            assert key in colnames
+            if key not in colnames: raise RuntimeError('{0} not found in table'.format(key))
 
         data = fits[extname].read(columns=columns)
         coords = np.array([data['u'], data['v']]).T

--- a/piff/star.py
+++ b/piff/star.py
@@ -320,6 +320,28 @@ class Star(object):
         fits.write_table(data, extname=extname)
 
     @classmethod
+    def read_coords_params(cls, fits, extname):
+        """Read only star fit parameters and coordinates from a FITS file.
+
+        :param fits:        An open fitsio.FITS object
+        :param extname:     The name of the extension to read from
+
+        :returns: the arrays coords and params
+        """
+        import galsim
+        assert extname in fits
+        colnames = fits[extname].get_colnames()
+
+        columns = ['u', 'v', 'params']
+        for key in columns:
+            assert key in colnames
+
+        data = fits[extname].read(columns=columns)
+        coords = np.array([data['u'], data['v']]).T
+        params = data['params']
+        return coords, params
+
+    @classmethod
     def read(cls, fits, extname):
         """Read stars from a FITS file.
 

--- a/piff/star.py
+++ b/piff/star.py
@@ -389,7 +389,7 @@ class Star(object):
         wcs_list = [ w.withOrigin(p, wp) for w,p,wp in zip(wcs_list, pos_list, wpos_list) ]
         bounds_list = [ galsim.BoundsI(*b) for b in zip(xmin,xmax,ymin,ymax) ]
         image_list = [ galsim.Image(bounds=b, wcs=w) for b,w in zip(bounds_list, wcs_list) ]
-        weight_list = [ galsim.Image(bounds=b, wcs=w) for b,w in zip(bounds_list, wcs_list) ]
+        weight_list = [ galsim.Image(init_value=1.0, bounds=b, wcs=w) for b,w in zip(bounds_list, wcs_list) ]
         data_list = [ StarData(im, pos, weight=w, properties=prop, pointing=point)
                       for im,pos,w,prop,point in zip(image_list, pos_list, weight_list,
                                                      prop_list, pointing_list) ]

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -329,13 +329,9 @@ def test_io():
             np.testing.assert_array_equal(s2params, s2params_manual)
         else:
             # reading read_coords_params should fail with an AssertionError if there is no params
-            try:
+            with np.testing.assert_raises(RuntimeError):
                 with fitsio.FITS(file_name, 'r') as fin:
                     s2coords, s2params = piff.Star.read_coords_params(fin, 'stars')
-            except AssertionError:
-                pass
-            else:
-                raise AssertionError
 
 if __name__ == '__main__':
     test_init()

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -328,7 +328,7 @@ def test_io():
             np.testing.assert_array_equal(s2coords, s2coords_manual)
             np.testing.assert_array_equal(s2params, s2params_manual)
         else:
-            # reading read_coords_params should fail with an AssertionError if there is no params
+            # reading read_coords_params should fail with a RuntimeError if there is no params
             with np.testing.assert_raises(RuntimeError):
                 with fitsio.FITS(file_name, 'r') as fin:
                     s2coords, s2params = piff.Star.read_coords_params(fin, 'stars')

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -314,6 +314,28 @@ def test_io():
             #np.testing.assert_almost_equal(s1.data.image.array,s2.data.image.array)
             #np.testing.assert_almost_equal(s1.data.weight.array,s2.data.weight.array)
 
+        # test read_coords_params
+        if do_params:
+            with fitsio.FITS(file_name, 'r') as fin:
+                s2coords, s2params = piff.Star.read_coords_params(fin, 'stars')
+            s2coords_manual = []
+            s2params_manual = []
+            for s in stars2:
+                s2coords_manual.append(np.array([s.data[key] for key in ['u', 'v']]))
+                s2params_manual.append(s.fit.params)
+            s2coords_manual = np.array(s2coords_manual)
+            s2params_manual = np.array(s2params_manual)
+            np.testing.assert_array_equal(s2coords, s2coords_manual)
+            np.testing.assert_array_equal(s2params, s2params_manual)
+        else:
+            # reading read_coords_params should fail with an AssertionError if there is no params
+            try:
+                with fitsio.FITS(file_name, 'r') as fin:
+                    s2coords, s2params = piff.Star.read_coords_params(fin, 'stars')
+            except AssertionError:
+                pass
+            else:
+                raise AssertionError
 
 if __name__ == '__main__':
     test_init()


### PR DESCRIPTION
a very simple change that speeds up meanify considerably: instead of creating star objects, just load the arrays directly. This resulted in about a factor of 100 speedup for me (2-3 sec per PSF to 0.02 sec per PSF for y3 psfs).

I'm PRing this in case there's a good reason to create star objects for this case. Otherwise I'll merge in a day or so.