### PR TITLE
Improve meanify

### DIFF
--- a/piff/config.py
+++ b/piff/config.py
@@ -229,6 +229,15 @@ def meanify(config, logger=None):
     else:
         bin_spacing = 120. #default bin_spacing: 120 arcsec
 
+    if 'statistic' in config['hyper']:
+        if config['hyper']['statistic'] not in ['mean', 'median']:
+            raise ValueError("%s is not a suported statistic (only mean and median are currently suported)"
+                             %config['hyper']['statistic'])
+        else:
+            stat_used = config['hyper']['statistic']
+    else:
+        stat_used = 'mean' #default statistics: arithmetic mean over each bin
+
     if isinstance(config['output']['file_name'], list):
         psf_list = config['output']['file_name']
         if len(psf_list) == 0:
@@ -280,9 +289,9 @@ def meanify(config, logger=None):
     binning = [np.linspace(lu_min, lu_max, nbin_u), np.linspace(lv_min, lv_max, nbin_v)]
     nbinning = (len(binning[0]) - 1) * (len(binning[1]) - 1)
     params0 = np.zeros((nbinning, len(params[0])))
-    print('I am doing the new version')
+
     for i in range(len(params[0])):
-        average, u0, v0, bin_target = binned_statistic_2d(coords[:,0], coords[:,1], params[:,i], bins=binning, statistic='mean')
+        average, u0, v0, bin_target = binned_statistic_2d(coords[:,0], coords[:,1], params[:,i], bins=binning, statistic=stat_used)
         average = average.T
         average = average.reshape(-1)
         average[~np.isfinite(average)] = 0.

--- a/piff/config.py
+++ b/piff/config.py
@@ -300,6 +300,7 @@ def meanify(config, logger=None):
     binning = [np.linspace(lu_min, lu_max, nbin_u), np.linspace(lv_min, lv_max, nbin_v)]
     nbinning = (len(binning[0]) - 1) * (len(binning[1]) - 1)
     params0 = np.zeros((nbinning, len(params[0])))
+    Filter = np.array([True]*nbinning)
 
     for i in range(len(params[0])):
         if i in params_fitted:
@@ -308,7 +309,7 @@ def meanify(config, logger=None):
                                                               statistic=stat_used)
             average = average.T
             average = average.reshape(-1)
-            Filter = np.isfinite(average).reshape(-1)
+            Filter &= np.isfinite(average).reshape(-1)
             params0[:,i] = average
 
     # get center of each bin 
@@ -318,7 +319,8 @@ def meanify(config, logger=None):
 
     coords0 = np.array([u0.reshape(-1), v0.reshape(-1)]).T
 
-    # remove any entries with counts == 0
+    # remove any entries with nan (counts == 0 and non finite value in
+    # the 2D statistic computation) 
     coords0 = coords0[Filter]
     params0 = params0[Filter]
 

--- a/piff/config.py
+++ b/piff/config.py
@@ -294,7 +294,7 @@ def meanify(config, logger=None):
         average, u0, v0, bin_target = binned_statistic_2d(coords[:,0], coords[:,1], params[:,i], bins=binning, statistic=stat_used)
         average = average.T
         average = average.reshape(-1)
-        average[~np.isfinite(average)] = 0.
+        Filter = np.isfinite(average).reshape(-1)
         params0[:,i] = average
 
     # get center of each bin 
@@ -303,6 +303,10 @@ def meanify(config, logger=None):
     u0, v0 = np.meshgrid(u0, v0)
 
     coords0 = np.array([u0.reshape(-1), v0.reshape(-1)]).T
+
+    # remove any entries with counts == 0
+    coords0 = coords0[Filter]
+    params0 = params0[Filter]
 
     dtypes = [('COORDS0', coords0.dtype, coords0.shape),
               ('PARAMS0', params0.dtype, params0.shape),

--- a/tests/test_meanify.py
+++ b/tests/test_meanify.py
@@ -206,7 +206,7 @@ def test_meanify():
 
     if __name__ == '__main__':
         rtol = 1.e-1
-        atol = 1.e-2
+        atol = 2.e-2
         bin_spacing = 30  # arcsec
     else:
         rtol = 1.e-1
@@ -234,7 +234,7 @@ def test_meanify():
         'hyper' : {
             'file_name' : average_file,
             'dir': 'output',
-            'bin_spacing' : 30.#bin_spacing,
+            'bin_spacing' : bin_spacing,
         }}
 
     for config in [config0, config1]:
@@ -244,7 +244,6 @@ def test_meanify():
         params0 = make_average(coord=average['COORDS0'][0] / 0.26, gp=False)
         keys = ['hlr', 'g1', 'g2']
         for i,key in enumerate(keys):
-            print(key)
             np.testing.assert_allclose(params0[key], average['PARAMS0'][0][:,i],
                                        rtol=rtol, atol=atol)
         

--- a/tests/test_meanify.py
+++ b/tests/test_meanify.py
@@ -234,7 +234,7 @@ def test_meanify():
         'hyper' : {
             'file_name' : average_file,
             'dir': 'output',
-            'bin_spacing' : bin_spacing,
+            'bin_spacing' : 30.#bin_spacing,
         }}
 
     for config in [config0, config1]:
@@ -244,9 +244,10 @@ def test_meanify():
         params0 = make_average(coord=average['COORDS0'][0] / 0.26, gp=False)
         keys = ['hlr', 'g1', 'g2']
         for i,key in enumerate(keys):
+            print(key)
             np.testing.assert_allclose(params0[key], average['PARAMS0'][0][:,i],
                                        rtol=rtol, atol=atol)
-
+        
     ## gaussian process testing of meanify 
     np.random.seed(68)
     x = np.random.uniform(0, 2048, size=1000)
@@ -272,5 +273,5 @@ def test_meanify():
         np.testing.assert_allclose(params_interp, params_validation, rtol=rtol, atol=atol)
 
 if __name__ == '__main__':
-    setup()
+    #setup()
     test_meanify()

--- a/tests/test_meanify.py
+++ b/tests/test_meanify.py
@@ -235,6 +235,7 @@ def test_meanify():
             'file_name' : average_file,
             'dir': 'output',
             'bin_spacing' : bin_spacing,
+            'statistic' : 'median',
         }}
 
     for config in [config0, config1]:
@@ -272,5 +273,5 @@ def test_meanify():
         np.testing.assert_allclose(params_interp, params_validation, rtol=rtol, atol=atol)
 
 if __name__ == '__main__':
-    #setup()
+    setup()
     test_meanify()

--- a/tests/test_meanify.py
+++ b/tests/test_meanify.py
@@ -235,19 +235,36 @@ def test_meanify():
             'file_name' : average_file,
             'dir': 'output',
             'bin_spacing' : bin_spacing,
+            'statistic' : 'mean',
+            'params_fitted': [0, 2]
+        }}
+
+    config2 = {
+        'output' : {
+            'file_name' : psf_file,
+            'dir': 'output',
+        },
+        'hyper' : {
+            'file_name' : average_file,
+            'dir': 'output',
+            'bin_spacing' : bin_spacing,
             'statistic' : 'median',
         }}
 
-    for config in [config0, config1]:
+    for config in [config0, config1, config2]:
         piff.meanify(config)
         ## test if found initial average
         average = fitsio.read(os.path.join('output',average_file))
         params0 = make_average(coord=average['COORDS0'][0] / 0.26, gp=False)
         keys = ['hlr', 'g1', 'g2']
         for i,key in enumerate(keys):
-            np.testing.assert_allclose(params0[key], average['PARAMS0'][0][:,i],
-                                       rtol=rtol, atol=atol)
-        
+            if config == config1 and i == 1:
+                np.testing.assert_allclose(np.zeros(len(average['PARAMS0'][0][:,i])),
+                                           average['PARAMS0'][0][:,i], rtol=0, atol=0)
+            else:
+                np.testing.assert_allclose(params0[key], average['PARAMS0'][0][:,i],
+                                           rtol=rtol, atol=atol)
+
     ## gaussian process testing of meanify 
     np.random.seed(68)
     x = np.random.uniform(0, 2048, size=1000)


### PR DESCRIPTION
Hi everyone, 

I added new options into meanify. Now you have the option of using the median. Basically, I added two options in the config of meanify within the `'hyper'` key. You can choose your desired statistics now (`'mean'` or `'median'` and `'mean'` is default). The other option is a list of integer `'params_fitted'` which indicates on which parameters you want to compute the `'mean'`/`'median'`. I added this last option because computing the median is really slow in comparaison of the mean, and I don’t need to compute the mean for all PSF’s parameters in the case of the OptAtmo model (only for atmosphere). 

It seems that the median improves a little bit the Rowe statistics on what I saw. I can show you some results on that at the next Piff meeting. 


If you have any questions do not hesitate.
Cheers,
Pierre-Francois