### PR TITLE
Some input handling updates to deal with LSST image data formats

### DIFF
--- a/piff/input.py
+++ b/piff/input.py
@@ -379,8 +379,11 @@ class InputFiles(Input):
             if nimages < 1:
                 raise ValueError('input.nimages must be >= 1')
 
+        # Deal with dir here, since sometimes we need to have it already atteched for glob
+        # to work.
         if 'dir' in config:
             dir = galsim.config.ParseValue(config, 'dir', base, str)[0]
+            del config['dir']
 
         if 'image_file_name' not in config:
             raise AttributeError('Attribute image_file_name is required')
@@ -388,14 +391,13 @@ class InputFiles(Input):
             image_list = config['image_file_name']
             if len(image_list) == 0:
                 raise ValueError("image_file_name may not be an empty list")
+            if dir is not None:
+                image_list = [os.path.join(dir, n) for n in image_list]
         elif isinstance(config['image_file_name'], basestring):
             image_file_name = config['image_file_name']
             if dir is not None:
                 image_file_name = os.path.join(dir, image_file_name)
             image_list = sorted(glob.glob(image_file_name))
-            if dir is not None:
-                k = len(dir) if dir[-1] == '/' else len(dir)+1
-                image_list = [ f[k:] for f in image_list ]
             if len(image_list) == 0:
                 raise ValueError("No files found corresponding to "+config['image_file_name'])
         elif not isinstance(config['image_file_name'], dict):
@@ -419,14 +421,13 @@ class InputFiles(Input):
             cat_list = config['cat_file_name']
             if len(cat_list) == 0:
                 raise ValueError("cat_file_name may not be an empty list")
+            if dir is not None:
+                cat_list = [os.path.join(dir, n) for n in cat_list]
         elif isinstance(config['cat_file_name'], basestring):
             cat_file_name = config['cat_file_name']
             if dir is not None:
                 cat_file_name = os.path.join(dir, cat_file_name)
             cat_list = sorted(glob.glob(cat_file_name))
-            if dir is not None:
-                k = len(dir) if dir[-1] == '/' else len(dir)+1
-                cat_list = [ f[k:] for f in cat_list ]
             if len(cat_list) == 0:
                 raise ValueError("No files found corresponding to "+config['cat_file_name'])
         elif not isinstance(config['cat_file_name'], dict):
@@ -474,8 +475,6 @@ class InputFiles(Input):
 
             # Read the image
             image_file_name = params['image_file_name']
-            if 'dir' in params:
-                image_file_name = os.path.join(params['dir'], image_file_name)
             image_hdu = params.get('image_hdu', None)
             weight_hdu = params.get('weight_hdu', None)
             badpix_hdu = params.get('badpix_hdu', None)
@@ -498,8 +497,6 @@ class InputFiles(Input):
 
             # Read the catalog
             cat_file_name = params['cat_file_name']
-            if 'dir' in params:
-                cat_file_name = os.path.join(params['dir'], cat_file_name)
             cat_hdu = params.get('cat_hdu', None)
             x_col = params.get('x_col', 'x')
             y_col = params.get('y_col', 'y')

--- a/piff/input.py
+++ b/piff/input.py
@@ -517,6 +517,8 @@ class InputFiles(Input):
                     ra_col, dec_col, ra_units, dec_units, image.wcs,
                     flag_col, use_col, sky_col, gain_col,
                     sky, gain, nstars, image_file_name, logger)
+            # Check for objects off the edge.  We won't use them.
+            image_pos = [ pos for pos in image_pos if image.bounds.includes(pos) ]
 
             self.cat_file_name.append(cat_file_name)
             self.image_pos.append(image_pos)

--- a/piff/input.py
+++ b/piff/input.py
@@ -658,7 +658,7 @@ class InputFiles(Input):
         else:
             # Then treat this as an array of bools rather than a bitmask
             mask = np.zeros(col.shape[0], dtype=bool)
-            for bit in range(col.shape[1]):
+            for bit in range(col.shape[1]):  # pragma: no branch
                 if flag % 2 == 1:
                     mask |= col[:,bit]
                 flag = flag // 2
@@ -743,7 +743,7 @@ class InputFiles(Input):
             def safe_to_image(wcs, ra, dec):
                 try:
                     return wcs.toImage(galsim.CelestialCoord(ra*ra_units, dec*dec_units))
-                except galsim.GalSimError:
+                except galsim.GalSimError:  # pragma: no cover
                     # If the ra,dec is way off the image, this might fail to converge.
                     # In this case return something clearly not on an image so it gets
                     # excluded during the bounds check.

--- a/piff/input.py
+++ b/piff/input.py
@@ -184,9 +184,12 @@ class Input(object):
         # S/N = F / sqrt(var(F))
         I = image.array
         w = weight.array
-        flux = (w*I*I).sum(dtype=float)
-        snr = flux**0.5
-        return snr
+        mask = np.isfinite(I) & np.isfinite(w)
+        flux = (w[mask]*I[mask]**2).sum(dtype=float)
+        if flux <= 0.:
+            return 0.
+        else:
+            return flux**0.5
 
     def getWCS(self, logger=None):
         """Get the WCS solutions for all the chips in the field of view.

--- a/piff/input.py
+++ b/piff/input.py
@@ -526,8 +526,9 @@ class InputFiles(Input):
                     ra_col, dec_col, ra_units, dec_units, image.wcs,
                     flag_col, skip_flag, use_flag, sky_col, gain_col,
                     sky, gain, nstars, image_file_name, logger)
-            # Check for objects off the edge.  We won't use them.
-            image_pos = [ pos for pos in image_pos if image.bounds.includes(pos) ]
+            # Check for objects well off the edge.  We won't use them.
+            big_bounds = image.bounds.expand(self.stamp_size)
+            image_pos = [ pos for pos in image_pos if big_bounds.includes(pos) ]
 
             if config.get('remove_signal_from_weight', False):
                 # Subtract off the mean sky, since this isn't part of the "signal" we want to

--- a/piff/input.py
+++ b/piff/input.py
@@ -442,7 +442,7 @@ class InputFiles(Input):
             logger.debug('cat_list = %s',cat_list)
             if nimages is not None and nimages != len(cat_list):
                 raise ValueError("nimages = %s doesn't match length of cat_file_name list (%d)"%(
-                        config['nimages'], len(cat_list)))
+                        nimages, len(cat_list)))
             nimages = len(cat_list)
             logger.debug('nimages = %d',nimages)
             config['cat_file_name'] = {
@@ -657,7 +657,7 @@ class InputFiles(Input):
                 raise ValueError("flag_col = %s is not a column in %s"%(flag_col,cat_file_name))
             col = cat[flag_col]
             if len(col.shape) == 2:
-                logger.warning("Flag col (%s) is multidimensional.  Treatin as an array of bool",
+                logger.warning("Flag col (%s) is multidimensional.  Treating as an array of bool",
                                flag_col)
             if use_flag is not None:
                 # Remove any objects with flag & use_flag == 0

--- a/piff/input.py
+++ b/piff/input.py
@@ -338,6 +338,7 @@ class InputFiles(Input):
                 'weight_hdu' : int,
                 'badpix_hdu' : int,
                 'cat_hdu' : int,
+                'invert_weight' : bool,
                 'stamp_size' : int,
                 'gain' : str,
                 'min_snr' : float,
@@ -474,6 +475,9 @@ class InputFiles(Input):
 
             image, weight = self.readImage(
                     image_file_name, image_hdu, weight_hdu, badpix_hdu, noise, logger)
+
+            if config.get('invert_weight', False):
+                weight.invertSelf()
 
             # Update the wcs if necessary
             if 'wcs' in config:

--- a/piff/input.py
+++ b/piff/input.py
@@ -385,7 +385,7 @@ class InputFiles(Input):
                 image_file_name = os.path.join(dir, image_file_name)
             image_list = sorted(glob.glob(image_file_name))
             if dir is not None:
-                k = len(dir) + 1
+                k = len(dir) if dir[-1] == '/' else len(dir)+1
                 image_list = [ f[k:] for f in image_list ]
             if len(image_list) == 0:
                 raise ValueError("No files found corresponding to "+config['image_file_name'])
@@ -416,7 +416,7 @@ class InputFiles(Input):
                 cat_file_name = os.path.join(dir, cat_file_name)
             cat_list = sorted(glob.glob(cat_file_name))
             if dir is not None:
-                k = len(dir) + 1
+                k = len(dir) if dir[-1] == '/' else len(dir)+1
                 cat_list = [ f[k:] for f in cat_list ]
             if len(cat_list) == 0:
                 raise ValueError("No files found corresponding to "+config['cat_file_name'])

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -165,7 +165,7 @@ class SimplePSF(PSF):
                     raise
                 except ModelFitError as e:
                     logger.warning("Failed fitting star at %s.  Excluding it.", s.image_pos)
-                    logger.warning("  -- Caught exceptiond %s", e)
+                    logger.warning("  -- Caught exception: %s", e)
                     nremoved += 1
                 else:
                     new_stars.append(new_star)
@@ -190,7 +190,7 @@ class SimplePSF(PSF):
                     except Exception as e:  # pragma: no cover
                         logger.warning("Failed trying to reflux star at %s.  Excluding it.",
                                        s.image_pos)
-                        logger.warning("  -- Caught exceptiond %s", e)
+                        logger.warning("  -- Caught exception: %s", e)
                         nremoved += 1
                     else:
                         new_stars.append(new_star)

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -163,7 +163,7 @@ class SimplePSF(PSF):
                     new_star = fit_fn(s, logger=logger)
                 except (KeyboardInterrupt, SystemExit):
                     raise
-                except ModelFitError as e:
+                except ModelFitError as e:  # pragma: no cover
                     logger.warning("Failed fitting star at %s.  Excluding it.", s.image_pos)
                     logger.warning("  -- Caught exception: %s", e)
                     nremoved += 1

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -99,18 +99,21 @@ class SingleChipPSF(PSF):
         # update stars from psf outlier rejection
         self.stars = [ star for chipnum in wcs for star in self.psf_by_chip[chipnum].stars ]
 
-    def drawStar(self, star):
+    def drawStar(self, star, copy_image=True):
         """Generate PSF image for a given star.
 
         :param star:        Star instance holding information needed for interpolation as
                             well as an image/WCS into which PSF will be rendered.
+        :param copy_image:          If False, will use the same image object.
+                                    If True, will copy the image and then overwrite it.
+                                    [default: True]
 
         :returns:           Star instance with its image filled with rendered PSF
         """
         if 'chipnum' not in star.data.properties:
             raise ValueError("SingleChip drawStar requires the star to have a chipnum property")
         chipnum = star['chipnum']
-        return self.psf_by_chip[chipnum].drawStar(star)
+        return self.psf_by_chip[chipnum].drawStar(star, copy_image=copy_image)
 
     def _finish_write(self, fits, extname, logger):
         """Finish the writing process with any class-specific steps.

--- a/piff/star.py
+++ b/piff/star.py
@@ -819,7 +819,8 @@ class StarData(object):
                         extracted.  If None, the data image is used.  All signals are
                         clipped from below at zero.
         :param gain:    The gain, in e per ADU, assumed in calculating new weights.  If None
-                        is given, then the 'gain' property is used, else defaults gain=1.
+                        is given, then the 'gain' property is used, else defaults to not
+                        adding any variance.
 
         :returns: a new StarData instance with updated weight array.
         """

--- a/piff/star.py
+++ b/piff/star.py
@@ -542,7 +542,8 @@ class Star(object):
                         extracted.  If None, the data image is used.  All signals are
                         clipped from below at zero.
         :param gain:    The gain, in e per ADU, assumed in calculating new weights.  If None
-                        is given, then the 'gain' property is used, else defaults gain=1.
+                        is given, then the 'gain' property is used, else defaults to not
+                        adding any variance.
 
         :returns: a new Star instance with updated weight array.
         """

--- a/tests/input/make_input.yaml
+++ b/tests/input/make_input.yaml
@@ -59,8 +59,7 @@ output:
         columns:
             x: '$image_pos.x'
             y: '$image_pos.y'
-            flag: '$1 if obj_num % 5 == 0 else 0'
-            use: '$0 if obj_num % 7 == 0 else 1'
+            flag: '$(4 if obj_num % 5 == 0 else 0) | (1 if obj_num % 7 != 0 else 0)'
             sky: 
                 # Since sky_level won't have been parsed yet, this is a trick to tell it that
                 # we are expected it to be a float, so it knows how to parse it.

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -40,7 +40,7 @@ def setup():
     }
     gs_config['output']['truth']['columns']['ra'] = '$wcs.toWorld(image_pos).ra / galsim.hours'
     gs_config['output']['truth']['columns']['dec'] = '$wcs.toWorld(image_pos).dec / galsim.degrees'
-    galsim.config.BuildFiles(1, galsim.config.CopyConfig(gs_config), file_num=1)
+    galsim.config.BuildFiles(1, galsim.config.CopyConfig(gs_config), file_num=2)
 
     cat_file_name = os.path.join('input', 'test_input_cat_00.fits')
     data = fitsio.read(cat_file_name)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -248,9 +248,11 @@ def test_cols():
                 'image_file_name' : 'test_input_image_00.fits',
                 'cat_file_name' : 'test_input_cat_00.fits',
                 'flag_col' : 'flag',
+                'skip_flag' : 4
              }
     input = piff.InputFiles(config, logger=logger)
     assert len(input.image_pos) == 1
+    print('len = ',len(input.image_pos[0]))
     assert len(input.image_pos[0]) == 80
 
     # Similarly the use columns will skip anything with use == 0 (every 7th item here)
@@ -258,10 +260,12 @@ def test_cols():
                 'dir' : 'input',
                 'image_file_name' : 'test_input_image_00.fits',
                 'cat_file_name' : 'test_input_cat_00.fits',
-                'use_col' : 'use',
+                'flag_col' : 'flag',
+                'use_flag' : 1
              }
     input = piff.InputFiles(config, logger=logger)
     assert len(input.image_pos) == 1
+    print('len = ',len(input.image_pos[0]))
     assert len(input.image_pos[0]) == 85
 
     # Can do both
@@ -269,12 +273,26 @@ def test_cols():
                 'dir' : 'input',
                 'image_file_name' : 'test_input_image_00.fits',
                 'cat_file_name' : 'test_input_cat_00.fits',
-                'use_col' : 'use',
+                'flag_col' : 'flag',
+                'skip_flag' : '4',
+                'use_flag' : '1',
+             }
+    input = piff.InputFiles(config, logger=logger)
+    assert len(input.image_pos) == 1
+    print('len = ',len(input.image_pos[0]))
+    assert len(input.image_pos[0]) == 68
+
+    # If no skip_flag it specified, it skips all != 0.
+    config = {
+                'dir' : 'input',
+                'image_file_name' : 'test_input_image_00.fits',
+                'cat_file_name' : 'test_input_cat_00.fits',
                 'flag_col' : 'flag',
              }
     input = piff.InputFiles(config, logger=logger)
     assert len(input.image_pos) == 1
-    assert len(input.image_pos[0]) == 68
+    print('len = ',len(input.image_pos[0]))
+    assert len(input.image_pos[0]) == 12
 
     # Check invalid column names
     base_config = {
@@ -286,7 +304,10 @@ def test_cols():
     np.testing.assert_raises(ValueError, piff.InputFiles, dict(sky_col='xx', **base_config))
     np.testing.assert_raises(ValueError, piff.InputFiles, dict(gain_col='xx', **base_config))
     np.testing.assert_raises(ValueError, piff.InputFiles, dict(flag_col='xx', **base_config))
-    np.testing.assert_raises(ValueError, piff.InputFiles, dict(use_col='xx', **base_config))
+    np.testing.assert_raises(ValueError, piff.InputFiles,
+                             dict(flag_col='flag', skip_flag='xx', **base_config))
+    np.testing.assert_raises(ValueError, piff.InputFiles,
+                             dict(flag_col='flag', use_flag='xx', **base_config))
 
     # Can't give duplicate sky, gain
     np.testing.assert_raises(ValueError, piff.InputFiles, dict(sky_col='sky', sky=3, **base_config))

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -103,7 +103,10 @@ def test_oversample():
     # Pixelized model with Lanczos 3 interp, coarser pix scale
     interp = 'Lanczos(3)'  # eval the string
     mod = piff.PixelGrid(2*du, nside//2, interp, start_sigma=1.5, force_model_center=False)
-    star = mod.initialize(s).withFlux(flux=np.sum(s.image.array))
+    # mask=False isn't required here. It's an option that we don't really test anywhere, but
+    # doing it here at least gets that branch covered.
+    # TODO: Either remove this option, which apparently isn't very useful, or add a real test.
+    star = mod.initialize(s, mask=False).withFlux(flux=np.sum(s.image.array))
 
     for i in range(2):
         star = mod.fit(star)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -143,15 +143,14 @@ def test_single_image():
     # Where to put the stars.  Include some flagged and not used locations.
     x_list = [ 123.12, 345.98, 567.25, 1094.94, 924.15, 1532.74, 1743.11, 888.39, 1033.29, 1409.31 ]
     y_list = [ 345.43, 567.45, 1094.32, 924.29, 1532.92, 1743.83, 888.83, 1033.19, 1409.20, 123.11 ]
-    flag_list = [ 0, 0, 12, 0, 0, 1, 0, 0, 0, 0 ]
-    use_list = [ 1, 1, 1, 1, 1, 0, 1, 1, 0, 1 ]
+    flag_list = [ 1, 1, 13, 1, 1, 5, 1, 1, 1, 1 ]
 
     # Draw a Gaussian PSF at each location on the image.
     sigma = 1.3
     g1 = 0.23
     g2 = -0.17
     psf = galsim.Gaussian(sigma=sigma).shear(g1=g1, g2=g2)
-    for x,y,flag,use in zip(x_list, y_list, flag_list, use_list):
+    for x,y,flag in zip(x_list, y_list, flag_list):
         bounds = galsim.BoundsI(int(x-31), int(x+32), int(y-31), int(y+32))
         offset = galsim.PositionD( x-int(x)-0.5 , y-int(y)-0.5 )
         psf.drawImage(image=image[bounds], method='no_pixel', offset=offset)
@@ -168,12 +167,11 @@ def test_single_image():
     image.write(image_file)
 
     # Write out the catalog to a file
-    dtype = [ ('x','f8'), ('y','f8'), ('flag','i2'), ('use','i2') ]
+    dtype = [ ('x','f8'), ('y','f8'), ('flag','i2') ]
     data = np.empty(len(x_list), dtype=dtype)
     data['x'] = x_list
     data['y'] = y_list
     data['flag'] = flag_list
-    data['use'] = use_list
     cat_file = os.path.join('output','simple_cat.fits')
     fitsio.write(cat_file, data, clobber=True)
 
@@ -193,11 +191,12 @@ def test_single_image():
     np.testing.assert_equal([pos.x for pos in input.image_pos[0]], x_list)
     np.testing.assert_equal([pos.y for pos in input.image_pos[0]], y_list)
 
-    # Repeat, using flag and use columns this time.
+    # Repeat, using flag columns this time.
     config = { 'image_file_name' : image_file,
                'cat_file_name': cat_file,
                'flag_col': 'flag',
-               'use_col': 'use',
+               'use_flag': '1',
+               'skip_flag': '4',
                'stamp_size': 48 }
     input = piff.InputFiles(config, logger=logger)
     print('pos = ',input.image_pos)
@@ -241,7 +240,8 @@ def test_single_image():
             'image_file_name' : image_file,
             'cat_file_name' : cat_file,
             'flag_col' : 'flag',
-            'use_col' : 'use',
+            'use_flag' : 1,
+            'skip_flag' : 4,
             'stamp_size' : stamp_size
         },
         'psf' : {

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -143,7 +143,7 @@ def test_single_image():
     # Where to put the stars.  Include some flagged and not used locations.
     x_list = [ 123.12, 345.98, 567.25, 1094.94, 924.15, 1532.74, 1743.11, 888.39, 1033.29, 1409.31 ]
     y_list = [ 345.43, 567.45, 1094.32, 924.29, 1532.92, 1743.83, 888.83, 1033.19, 1409.20, 123.11 ]
-    flag_list = [ 1, 1, 13, 1, 1, 5, 1, 1, 1, 1 ]
+    flag_list = [ 1, 1, 13, 1, 1, 4, 1, 1, 0, 1 ]
 
     # Draw a Gaussian PSF at each location on the image.
     sigma = 1.3
@@ -155,7 +155,7 @@ def test_single_image():
         offset = galsim.PositionD( x-int(x)-0.5 , y-int(y)-0.5 )
         psf.drawImage(image=image[bounds], method='no_pixel', offset=offset)
         # corrupt the ones that are marked as flagged
-        if flag:
+        if flag & 4:
             print('corrupting star at ',x,y)
             ar = image[bounds].array
             im_max = np.max(ar) * 0.2


### PR DESCRIPTION
In running Piff on DC2 (1.2i) data, I ran into some issues with the LSST calexp and catalog data, which required some changes to the Piff input handling.

1. There are no "weight" images.  Instead, the calexp has a `var` image, which is the inverse of what one would normally call a weight image.
    * To deal with this, I added an `invert_weight` option to do `weight = 1/var`.
2. The `var` image includes the variance from the signal, not just the variance from the sky, read noise, etc., which is what you normally want to use for model fitting.
    * To get to what we want, we need to subtract off the image / gain from the variance.  I added a `remove_signal_from_weight` option that does this.
    * If the gain is provided, then this is straightforward.  
    * If not, then we can fit for the gain doing a linear regression of the variance values for each pixel and the image values, which give us the gain as the (inverse of the) slope.
3. The `flags` column in the catalog file is not a bitmask.  Rather it is a 2-dimensionall array of booleans.  So each object has an array of boolean flags for all the different things that DM flags about each object.  One of these is the "good psf star" flag, which I wanted to use to get the input star selection to Piff.
    * My solution here was for Piff to just recognize when a `flag` column was 2-dimensional and automatically treat the flag values as an array of booleans.  Hopefully there isn't some other use case where a 2-d array would have a different meaning....

Some other changes I made along the way:
* I now do a better estimate of the initial flux of the star in the PixelGrid model.  When I wasn't subtracting off the signal from the variance, the old way of getting the initial flux was wildly inaccurate and took a while to converge.  This probably isn't too important anymore now that I'm fixing the weights, but it doesn't hurt.
* The signal-to-noise estimate borked when the flux was negative or NaN, so no I'm more careful about both.  (I didn't actually check which was happening for one star here, but both adjustments are probably a good idea.)
* Piff had been assuming that a nonzero flag should either mean don't use the object (if given as a `flag_col`) or do use it (if given as a `use_col`).  This wasn't sufficiently flexible, so I switched it to there being a single flag column, but you can specify bits that mean either "use" (`use_flag`) or "don't use" (`skip_flag`).
* The way the `dir` field was used was buggy given the way I wanted to use it here.  I fixed it.
* I had tried to use the true star list as an input list.  It ended up no working very well, although I never really figured out what the problem was.  But to get that to work, I needed Piff to automatically notice when input stars are not on the image and exclude them.