### PR TITLE
Use open symbols for negative rho values

### DIFF
--- a/piff/stats.py
+++ b/piff/stats.py
@@ -460,7 +460,8 @@ class RhoStats(Stats):
         ax.plot(meanr, xip, color=color)
         ax.plot(meanr, -xip, color=color, ls=':')
         ax.errorbar(meanr[xip>0], xip[xip>0], yerr=sig[xip>0], color=color, ls='', marker=marker)
-        ax.errorbar(meanr[xip<0], -xip[xip<0], yerr=sig[xip<0], color=color, ls='', marker=marker)
+        ax.errorbar(meanr[xip<0], -xip[xip<0], yerr=sig[xip<0], color=color, ls='', marker=marker,
+                    fillstyle='none', mfc='white')
         return ax.errorbar(-meanr, xip, yerr=sig, color=color, marker=marker)
 
     def plot(self, logger=None, **kwargs):


### PR DESCRIPTION
Addresses #76 .

Note, I only verified this works by copy-pasting the `_plot_single` code into a Jupyter notebook and testing there; the Piff test-suite itself doesn't seem to actually produce a plot with negative rho values.
