### PR TITLE
REF list galsim like all of the other dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -286,17 +286,7 @@ ext=Extension("piff._piff",
               depends=headers,
               undef_macros = undef_macros)
 
-dependencies = ['numpy', 'scipy', 'pyyaml', 'treecorr', 'fitsio', 'scikit-learn', 'lmfit', 'matplotlib', 'LSSTDESC.Coord']
-
-try:
-    print('Checking that GalSim can be imported')
-    import galsim
-except ImportError:
-    print('Piff requires that GalSim be installed on your system.')
-    print('Please install GalSim before proceeding:')
-    print('    https://github.com/GalSim-developers/GalSim')
-    raise
-print('GalSim is version ',galsim.__version__)
+dependencies = ['galsim', 'numpy', 'scipy', 'pyyaml', 'treecorr', 'fitsio', 'scikit-learn', 'lmfit', 'matplotlib', 'LSSTDESC.Coord']
 
 with open('README.rst') as file:
     long_description = file.read()


### PR DESCRIPTION
This PR makes sure galsim is properly listed as a runtime environment The current scheme is outside of the pypi standards and is breaking installations from requirements.txt files.