### PR TITLE
Remove dependency on lmfit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pyyaml
 treecorr>=4.0
 fitsio>=0.9.12
 scikit-learn>=0.18
-lmfit
 matplotlib>=1.5.0
 LSSTDESC.Coord>=1.0.5
 galsim>=2.0

--- a/setup.py
+++ b/setup.py
@@ -286,7 +286,7 @@ ext=Extension("piff._piff",
               depends=headers,
               undef_macros = undef_macros)
 
-dependencies = ['galsim', 'numpy', 'scipy', 'pyyaml', 'treecorr', 'fitsio', 'scikit-learn', 'lmfit', 'matplotlib', 'LSSTDESC.Coord']
+dependencies = ['galsim', 'numpy', 'scipy', 'pyyaml', 'treecorr', 'fitsio', 'scikit-learn', 'matplotlib', 'LSSTDESC.Coord']
 
 with open('README.rst') as file:
     long_description = file.read()

--- a/tests/test_gsobject_model.py
+++ b/tests/test_gsobject_model.py
@@ -212,7 +212,7 @@ def test_center():
             star = mod.reflux(star)
             print('Flux, ctr, chisq after fit {:d}:'.format(i),
                   star.fit.flux, star.fit.center, star.fit.chisq)
-            np.testing.assert_almost_equal(star.fit.flux/influx, 1.0, decimal=14)
+            np.testing.assert_almost_equal(star.fit.flux/influx, 1.0, decimal=8)
 
         # Residual image when done should be dominated by structure off the edge of the fitted
         # region.
@@ -223,7 +223,7 @@ def test_center():
         print('max image abs value = ',np.max(np.abs(s.image.array)))
         peak = np.max(np.abs(s.image.array[mask]))
         np.testing.assert_almost_equal(star2.image.array[mask]/peak, s.image.array[mask]/peak,
-                                       decimal=14)
+                                       decimal=8)
 
         # test copy_image
         star_copy = mod.draw(star, copy_image=True)


### PR DESCRIPTION
I think some of the issues I'm having with Ares's pull request stem from some API changes that lmfit made between 0.8 and 0.9.  I suspect Chris or Ares originally wrote the code to the old API specification and the changes broke various aspects of the code.

Rather than update the code to use the new API (especially since I'm not really familiar with either the old or the new one -- I don't ever use lmfit myself), I'd like to switch everything over to scipy.optimize.

So to get that conversation started, and also to help myself understand what the differences are between the two, I first decided to switch over the other uses of lmfit that we have in Piff.

The only changes to the unit tests required were some checks to only 8 decimal places of accuracy rather than 14.  The latter seems rather overkill, and I guess must stem from some more precise defaults in the lmfit package than scipy's default ftol=1.e-8.

Does anyone have any objections to this?  If not, I'm happy to do the work to switch the new optatmo stuff to use scipy instead of lmfit.