### PR TITLE
Slight tweaks to GPInterp API

### DIFF
--- a/piff/gp_interp.py
+++ b/piff/gp_interp.py
@@ -27,7 +27,28 @@ from .star import Star, StarFit
 
 class GPInterp(Interp):
     """
-    An interpolator that uses Gaussian process from treegp to interpolate multiple surfaces.
+    An interpolator that models the underlying field as a Gaussian process.
+
+    Gaussian process regression, also known as “Kriging,” assumes that the parameters
+    are drawn from a multi-dimensional Gaussian random field across the (u, v) space.
+    It requires an estimate of the spatial covariance function of p, commonly referred to
+    as the kernel.
+
+    The interpolation estimate at an arbitrary location (u, v) is the minimum variance
+    unbiased estimate from the Gaussian distribution at that location conditioned on the
+    values of the parameters measured at all the PSF stars.
+
+    The implemention of this class use the treegp module. (https://github.com/PFLeget/treegp)
+    It can use any of the kernels defined in scikit-learn (https://scikit-learn.org/)
+    to define the covariance matrix as well as a custom VonKarman kernel defined in treegp.
+    The default kernel is the so-called "squared exponential" or "radial basis function" kernel,
+    known as RBF in scikit-learn.
+
+    The default behavior involves measuring the radial two-point correlation function with
+    TreeCorr (https://github.com/rmjarvis/TreeCorr) and then fitting the hyper-parameters of
+    the kernel that best fits this measurement.  This can be done either isotropically
+    or anisotropically.  There are also options to use the traditional maximum likelihood
+    optimization or no optimization if preferred.  See the ``optimizer`` parameter below.
 
     :param keys:         A list of keys for properties that will be interpolated.  Must be 2
                          properties, which can be used to calculate a 2-point correlation
@@ -37,41 +58,41 @@ class GPInterp(Interp):
                          of Kernels objects (one per PSF param).  The reprs of sklear Kernels
                          will work, as well as the repr of a custom treegp VonKarman object.
                          [default: 'RBF(1)']
-    :param optimizer:    Indicates which techniques to use for optimizing the kernel. Three options
+    :param optimizer:    Indicates which techniques to use for optimizing the kernel. Four options
                          are available:
 
-                            * "isotropic" = optimize the kernel using an isotropic radial
-                              2-point correlation function estimated by TreeCorr.
-                            * "anisotropic" = optimize the kernel using the two-dimentional
-                              2-point correlation function estimated by TreeCorr.
-                            * "likelihood" = use the classical gaussian process maximum
-                              likelihood to optimize the kernel.
+                            * "isotropic" = use an isotropic radial 2-point correlation function
+                              estimated by TreeCorr.
+                            * "anisotropic" = use an anisotropic two-dimensional 2-point
+                              correlation function estimated by TreeCorr.
+                            * "likelihood" = use the classical Gaussian process maximum
+                              likelihood method.
                             * "none" = don't do any kernal optimization.
 
                          [default: "isotropic"]
-    :param rows:         A list of integer which indicates on which rows of Star.fit.param
+    :param rows:         A list of integer which indicates which rows of Star.fit.param
                          need to be interpolated using GPs. [default: None, which means all rows]
-    :param l0:           Initial guess for correlation length when optimzer is "anisotropic".
-                         [default: 3000.]
     :param normalize:    Whether to normalize the interpolation parameters to have a mean of 0.
                          Normally, the parameters being interpolated are not mean 0, so you would
                          want this to be True, but if your parameters have an a priori mean of 0,
                          then subtracting off the realized mean would be invalid.  [default: True]
     :param white_noise:  A float value that indicate the ammount of white noise that you want to
                          use during the gp interpolation. This is an additional uncorrelated noise
-                         added to the error of the PSF parameters. [default: 0.]
-    :param nbins:        Number of bins (if 1D correlation function) of the square root of the
-                         number of bins (if 2D correlation function) used in TreeCorr to compute the
-                         2-point correlation function. Used only if optimizer is "isotropic"
-                         or "anisotropic". [default: 20]
+                         added in quadrature to the measured uncertainties of the PSF parameters.
+                         This should be given as a "sigma" value, not a variance. [default: 0.]
+    :param nbins:        Number of bins (in each direction using a 2D correlation function)
+                         used in TreeCorr to compute the 2-point correlation function. Used only if
+                         optimizer is "isotropic" or "anisotropic". [default: 20]
     :param min_sep:      Minimum separation between pairs when computing 2-point correlation
-                         function. In the same units as the keys. Compute automaticaly if it
-                         is not given. Used only if optimizer is "isotropic" or "anisotropic".
-                         [default: None]
+                         function in arcsec (or more generally the same units as the keys).
+                         Compute automaticaly if it is not given. Used only if optimizer is
+                         "isotropic" or "anisotropic".  [default: None]
     :param max_sep:      Maximum separation between pairs when computing 2-point correlation
-                         function. In the same units as the keys. Compute automaticaly if it
-                         is not given. Used only if optimizer is "isotropic" or "anisotropic".
-                         [default: None]
+                         function in arcsec (or more generally the same units as the keys).
+                         Compute automaticaly if it is not given. Used only if optimizer is
+                         "isotropic" or "anisotropic".  [default: None]
+    :param l0:           Initial guess for correlation length when optimzer is "anisotropic" in
+                         arcsec (or more generally the same units as the keys). [default: 3000.]
     :param average_fits: A fits file that have the spatial average functions of PSF parameters
                          build in it. Build using meanify and piff output across different
                          exposures. See meanify documentation for details. [default: None]

--- a/tests/test_gp_interp.py
+++ b/tests/test_gp_interp.py
@@ -201,7 +201,8 @@ def check_gp(stars_training, stars_validation, kernel, optimizer,
 
     if optimizer is not 'none':
         truth_hyperparameters = np.exp(interp._init_theta)
-        fitted_hyperparameters = np.exp(np.array([gp._optimizer._kernel.theta for gp in interp.gps]))
+        fitted_hyperparameters = np.exp(
+                np.array([gp._optimizer._kernel.theta for gp in interp.gps]))
         np.testing.assert_allclose(np.mean(fitted_hyperparameters, axis=0),
                                    np.mean(truth_hyperparameters, axis=0),
                                    rtol=rtol)
@@ -212,25 +213,30 @@ def check_gp(stars_training, stars_validation, kernel, optimizer,
         for j in range(3):
             plt.figure()
             plt.title('%s validation'%(title[j]), fontsize=18)
-            plt.scatter(xtest[:,0], xtest[:,1], c=y_validation[:,j], vmin=-4e-2, vmax=4e-2, cmap=plt.cm.seismic)
+            plt.scatter(xtest[:,0], xtest[:,1], c=y_validation[:,j], vmin=-4e-2, vmax=4e-2,
+                        cmap=plt.cm.seismic)
             plt.colorbar()
             plt.figure()
             plt.title('%s test (gp interp)'%(title[j]), fontsize=18)
-            plt.scatter(xtest[:,0], xtest[:,1], c=y_test[:,j], vmin=-4e-2, vmax=4e-2, cmap=plt.cm.seismic)
+            plt.scatter(xtest[:,0], xtest[:,1], c=y_test[:,j], vmin=-4e-2, vmax=4e-2,
+                        cmap=plt.cm.seismic)
             plt.colorbar()
 
-        if optimizer in ['two-pcf', 'anisotropic']:
-            if optimizer == 'two-pcf':
+        if optimizer in ['isotropic', 'anisotropic']:
+            if optimizer == 'isotropic':
                 for gp in interp.gps:
                     plt.figure()
                     plt.scatter(gp._optimizer._2pcf_dist, gp._optimizer._2pcf)
                     plt.plot(gp._optimizer._2pcf_dist, gp._optimizer._2pcf_fit)
-                    plt.plot(gp._optimizer._2pcf_dist, np.ones_like(gp._optimizer._2pcf_dist)*4e-4,'b--')
+                    plt.plot(gp._optimizer._2pcf_dist,
+                             np.ones_like(gp._optimizer._2pcf_dist)*4e-4,'b--')
                     plt.ylim(0,7e-4)
             else:
                 for gp in interp.gps:
-                    EXT = [np.min(gp._optimizer._2pcf_dist[:,0]), np.max(gp._optimizer._2pcf_dist[:,0]),
-                           np.min(gp._optimizer._2pcf_dist[:,1]), np.max(gp._optimizer._2pcf_dist[:,1])]
+                    EXT = [np.min(gp._optimizer._2pcf_dist[:,0]),
+                                  np.max(gp._optimizer._2pcf_dist[:,0]),
+                           np.min(gp._optimizer._2pcf_dist[:,1]),
+                                  np.max(gp._optimizer._2pcf_dist[:,1])]
                     CM = plt.cm.seismic
                     MAX = np.max(gp._optimizer._2pcf)
                     N = int(np.sqrt(len(gp._optimizer._2pcf)))
@@ -239,7 +245,8 @@ def check_gp(stars_training, stars_validation, kernel, optimizer,
                     plt.subplots_adjust(wspace=0.5,left=0.07,right=0.95, bottom=0.15,top=0.85)
 
                     plt.subplot(1,2,1)
-                    plt.imshow(gp._optimizer._2pcf.reshape(N,N), extent=EXT, interpolation='nearest', origin='lower',
+                    plt.imshow(gp._optimizer._2pcf.reshape(N,N), extent=EXT,
+                               interpolation='nearest', origin='lower',
                                vmin=-MAX, vmax=MAX, cmap=CM)
                     cbar = plt.colorbar()
                     cbar.formatter.set_powerlimits((0, 0))
@@ -250,7 +257,8 @@ def check_gp(stars_training, stars_validation, kernel, optimizer,
                     plt.title('Measured 2-PCF',fontsize=16)
 
                     plt.subplot(1,2,2)
-                    plt.imshow(gp._optimizer._2pcf_fit.reshape(N,N), extent=EXT, interpolation='nearest',
+                    plt.imshow(gp._optimizer._2pcf_fit.reshape(N,N), extent=EXT,
+                               interpolation='nearest',
                                origin='lower',vmin=-MAX,vmax=MAX, cmap=CM)
                     cbar = plt.colorbar()
                     cbar.formatter.set_powerlimits((0, 0))
@@ -282,9 +290,9 @@ def test_gp_interp_isotropic():
                "4e-4 * VonKarman(20.)"]
 
     optimizer = ['none',
-                 'log-likelihood',
-                 'two-pcf',
-                 'two-pcf']
+                 'likelihood',
+                 'isotropic',
+                 'isotropic']
 
     rows = [[0,1,2], None, None, None]
 
@@ -337,9 +345,10 @@ def test_gp_interp_anisotropic():
 
     for i in range(len(kernels)):
 
-        stars_training, stars_validation = make_gaussian_random_fields(kernels[i], nstars[i], xlim=-20, ylim=20,
-                                                                       seed=30352010, vmax=4e-2,
-                                                                       noise_level=noise_level)
+        stars_training, stars_validation = make_gaussian_random_fields(
+                kernels[i], nstars[i], xlim=-20, ylim=20,
+                seed=30352010, vmax=4e-2,
+                noise_level=noise_level)
         check_gp(stars_training, stars_validation, kernels[i],
                  optimizer[i], min_sep=0., max_sep=5., nbins=11,
                  l0=20., atol=atol, rtol=rtol, plotting=False)

--- a/tests/test_meanify.py
+++ b/tests/test_meanify.py
@@ -276,7 +276,7 @@ def test_meanify():
     stars_training = stars[:900]
     stars_validation = stars[900:]
 
-    fit_hyp = ['none', 'two-pcf']
+    fit_hyp = ['none', 'isotropic']
 
     for fit in fit_hyp:
         gp = piff.GPInterp(kernel="0.009 * RBF(300.*0.26)",


### PR DESCRIPTION
I was updating the Piff paper with the latest updates to the GPInterp class (#97), and I think I'd like to propose a slight change in the names for the `optimizer` option.  Specifically `log_likelihood` -> `likelihood` and `two-pcf` -> `isotropic`.

I think this more clearly sets up the default `isotropic` and common alternative `anisotropic` as being very similar, but with the latter allowing for the anisotropy.

And the `log_` part seemed unnecessary as merely an implementation detail about how the maximum likelihood optimization is done.  I think `likelihood` is probably sufficient here.

So here is the text in the paper about the optimizers parameter now:

The TreeGP module has several methods for how to optimize the kernel's
hyper-parameters, which are available in piff via the optimizer parameter:

1. `likelihood` is the traditional maximum likelihood optimization.
    It finds the hyper-parameters that maximize the likelihood of the Gaussian
    process solution.  This is similar to the optimization done by the
    `GaussianProcessRegressor` in scikit-learn although technically 
    TreeGP has a custom implementation, which uses `scipy.optimize` for its back end.
2. `isotropic` uses a direct measurement of the two-point correlation function of the 
    $\hat p_{ik}$ values using TreeCorr. This is the default `optimizer` 
    and usually gives significantly improved results over the maximum likelihood method.
3. `anisotropic` is similar to `isotropic` except that it uses the `TwoD` binning option in 
    TreeCorr, which measures the correlation function is two spatial directions, 
    rather than just radially.  This is particularly useful if the PSF pattern is
    significantly anisotropic (e.g. due to a predominant wind direction).  In this
    case, the resulting kernel is anisotropic as well.
4. `none` does no optimization of the hyper-parameters.  This is probably
    only useful for tests where you may know the true kernel and don't want any
    optimization to be performed.

I also put some of the paper text about GPInterp into the GPInterp doc string as explanation.  And fixed some typos and grammar errors I noticed.

@PFLeget Let me know if this seems ok with you.  I'm close to finalizing the paper, so I'd like to get this merged pretty soon if possible.  Thanks!