### PR TITLE
Piff 103 calculate snr

### DIFF
--- a/piff/input.py
+++ b/piff/input.py
@@ -24,7 +24,7 @@ import glob
 import os
 import galsim
 
-from .util import hsm, run_multi
+from .util import hsm, run_multi, calculateSNR
 from .star import Star, StarData
 
 class Input(object):
@@ -111,49 +111,6 @@ class Input(object):
                        "s" if self.nimages > 1 else "")
 
         return stars
-
-    @staticmethod
-    def calculateSNR(image, weight):
-        """Calculate the signal-to-noise of a given image.
-
-        :param image:       The stamp image for a star
-        :param weight:      The weight image for a star
-        :param logger:      A logger object for logging debug info. [default: None]
-
-        :returns: the SNR value.
-        """
-        # The S/N value that we use will be the weighted total flux where the weight function
-        # is the star's profile itself.  This is the maximum S/N value that any flux measurement
-        # can possibly produce, which will be closer to an in-practice S/N than using all the
-        # pixels equally.
-        #
-        # F = Sum_i w_i I_i^2
-        # var(F) = Sum_i w_i^2 I_i^2 var(I_i)
-        #        = Sum_i w_i I_i^2             <--- Assumes var(I_i) = 1/w_i
-        #
-        # S/N = F / sqrt(var(F))
-        #
-        # Note that if the image is pure noise, this will produce a "signal" of
-        #
-        # F_noise = Sum_i w_i 1/w_i = Npix
-        #
-        # So for a more accurate estimate of the S/N of the actual star itself, one should
-        # subtract off Npix from the measured F.
-        #
-        # The final formula then is:
-        #
-        # F = Sum_i w_i I_i^2
-        # S/N = (F-Npix) / sqrt(F)
-
-        I = image.array
-        w = weight.array
-        mask = np.isfinite(I) & np.isfinite(w)
-        F = (w[mask]*I[mask]**2).sum(dtype=float)
-        Npix = np.sum(mask)
-        if F < Npix:
-            return 0.
-        else:
-            return (F - Npix) / np.sqrt(F)
 
     def getWCS(self, logger=None):
         """Get the WCS solutions for all the chips in the field of view.
@@ -646,7 +603,7 @@ class InputFiles(Input):
                 props['sky'] = sky[k]
 
             # Check the snr and limit it if appropriate
-            snr = InputFiles.calculateSNR(stamp, wt_stamp)
+            snr = calculateSNR(stamp, wt_stamp)
             logger.debug("SNR = %f",snr)
             if min_snr is not None and snr < min_snr:
                 logger.info("Skipping star at position %f,%f with snr=%f."%(x,y,snr))

--- a/piff/util.py
+++ b/piff/util.py
@@ -322,3 +322,46 @@ def run_multi(func, nproc, args, logger, kwargs=None):
 
     return output_list
 
+
+def calculateSNR(image, weight):
+    """Calculate the signal-to-noise of a given image.
+
+    :param image:       The stamp image for a star
+    :param weight:      The weight image for a star
+    :param logger:      A logger object for logging debug info. [default: None]
+
+    :returns: the SNR value.
+    """
+    # The S/N value that we use will be the weighted total flux where the weight function
+    # is the star's profile itself.  This is the maximum S/N value that any flux measurement
+    # can possibly produce, which will be closer to an in-practice S/N than using all the
+    # pixels equally.
+    #
+    # F = Sum_i w_i I_i^2
+    # var(F) = Sum_i w_i^2 I_i^2 var(I_i)
+    #        = Sum_i w_i I_i^2             <--- Assumes var(I_i) = 1/w_i
+    #
+    # S/N = F / sqrt(var(F))
+    #
+    # Note that if the image is pure noise, this will produce a "signal" of
+    #
+    # F_noise = Sum_i w_i 1/w_i = Npix
+    #
+    # So for a more accurate estimate of the S/N of the actual star itself, one should
+    # subtract off Npix from the measured F.
+    #
+    # The final formula then is:
+    #
+    # F = Sum_i w_i I_i^2
+    # S/N = (F-Npix) / sqrt(F)
+
+    I = image.array
+    w = weight.array
+    mask = np.isfinite(I) & np.isfinite(w)
+    F = (w[mask]*I[mask]**2).sum(dtype=float)
+    Npix = np.sum(mask)
+    if F < Npix:
+        return 0.
+    else:
+        return (F - Npix) / np.sqrt(F)
+

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -759,7 +759,7 @@ def test_stars():
     chipnum_list = [ star['chipnum'] for star in stars ]
     gain_list = [ star['gain'] for star in stars ]
     snr_list = [ star['snr'] for star in stars ]
-    snr_list2 = [ input.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
+    snr_list2 = [ piff.util.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
     print('snr = ', np.min(snr_list), np.max(snr_list))
     np.testing.assert_array_equal(chipnum_list, 0)
     np.testing.assert_array_equal(gain_list, gain_list[0])
@@ -778,7 +778,7 @@ def test_stars():
     print('snr = ', np.min(snr_list), np.max(snr_list))
     assert np.min(snr_list) < 20.
     assert np.max(snr_list) == 120.
-    snr_list2 = [ input.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
+    snr_list2 = [ piff.util.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
     snr_list = np.array(snr_list)
     snr_list2 = np.array(snr_list2)
     lo = np.where(snr_list < 120)
@@ -798,7 +798,7 @@ def test_stars():
     print('snr = ', np.min(snr_list), np.max(snr_list))
     assert np.min(snr_list) < 20.
     assert np.max(snr_list) == 100.
-    snr_list2 = [ input.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
+    snr_list2 = [ piff.util.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
     snr_list = np.array(snr_list)
     snr_list2 = np.array(snr_list2)
     lo = np.where(snr_list < 100)
@@ -818,7 +818,7 @@ def test_stars():
     print('snr = ', np.min(snr_list), np.max(snr_list))
     assert np.min(snr_list) >= 50.
     assert np.max(snr_list) == 100.
-    snr_list2 = [ input.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
+    snr_list2 = [ piff.util.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
     snr_list = np.array(snr_list)
     snr_list2 = np.array(snr_list2)
     lo = np.where(snr_list < 100)
@@ -902,7 +902,7 @@ def test_stars():
     # (which would be weird of course), then it could get to negative flux = wI^2.
     star0 = stars[0]
     star0.data.orig_weight *= -1.
-    snr0 = input.calculateSNR(star0.data.image, star0.data.orig_weight)
+    snr0 = piff.util.calculateSNR(star0.data.image, star0.data.orig_weight)
     assert snr0 == 0.
 
 


### PR DESCRIPTION
This PR moves the calculateSNR function for input.py to util.py, as it is used in a few places.