### PR TITLE
Let input errors be raised properly

### DIFF
--- a/piff/input.py
+++ b/piff/input.py
@@ -102,8 +102,8 @@ class Input(object):
                       remove_signal_from_weight=self.remove_signal_from_weight,
                       hsm_size_reject=self.hsm_size_reject)
 
-        stars = run_multi(call_makeStarsFromImage, self.nproc, args,
-                          raise_except=True, logger=logger, kwargs=kwargs)
+        stars = run_multi(call_makeStarsFromImage, self.nproc, raise_except=True,
+                          args=args, logger=logger, kwargs=kwargs)
 
         # Concatenate the star lists into a single list
         stars = [s for slist in stars if slist is not None for s in slist if slist]

--- a/piff/input.py
+++ b/piff/input.py
@@ -102,7 +102,7 @@ class Input(object):
                       remove_signal_from_weight=self.remove_signal_from_weight,
                       hsm_size_reject=self.hsm_size_reject)
 
-        stars = run_multi(call_makeStarsFromImage, self.nproc, args, logger, kwargs)
+        stars = run_multi(call_makeStarsFromImage, self.nproc, args, True, logger, kwargs)
 
         # Concatenate the star lists into a single list
         stars = [s for slist in stars if slist is not None for s in slist if slist]

--- a/piff/input.py
+++ b/piff/input.py
@@ -102,7 +102,8 @@ class Input(object):
                       remove_signal_from_weight=self.remove_signal_from_weight,
                       hsm_size_reject=self.hsm_size_reject)
 
-        stars = run_multi(call_makeStarsFromImage, self.nproc, args, True, logger, kwargs)
+        stars = run_multi(call_makeStarsFromImage, self.nproc, args,
+                          raise_except=True, logger=logger, kwargs=kwargs)
 
         # Concatenate the star lists into a single list
         stars = [s for slist in stars if slist is not None for s in slist if slist]

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -107,7 +107,7 @@ class SingleChipPSF(PSF):
         chipnums = list(wcs.keys())
         args = [(chipnum, self.single_psf, stars, wcs, pointing) for chipnum in chipnums]
 
-        output = run_multi(single_chip_run, self.nproc, args, False, logger)
+        output = run_multi(single_chip_run, self.nproc, args, raise_except=False, logger=logger)
 
         for chipnum, psf in zip(chipnums, output):
             self.psf_by_chip[chipnum] = psf

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -107,7 +107,7 @@ class SingleChipPSF(PSF):
         chipnums = list(wcs.keys())
         args = [(chipnum, self.single_psf, stars, wcs, pointing) for chipnum in chipnums]
 
-        output = run_multi(single_chip_run, self.nproc, args, logger)
+        output = run_multi(single_chip_run, self.nproc, args, False, logger)
 
         for chipnum, psf in zip(chipnums, output):
             self.psf_by_chip[chipnum] = psf

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -107,7 +107,8 @@ class SingleChipPSF(PSF):
         chipnums = list(wcs.keys())
         args = [(chipnum, self.single_psf, stars, wcs, pointing) for chipnum in chipnums]
 
-        output = run_multi(single_chip_run, self.nproc, args, raise_except=False, logger=logger)
+        output = run_multi(single_chip_run, self.nproc, raise_except=False,
+                           args=args, logger=logger)
 
         for chipnum, psf in zip(chipnums, output):
             self.psf_by_chip[chipnum] = psf

--- a/piff/util.py
+++ b/piff/util.py
@@ -231,6 +231,7 @@ def _run_multi_helper(func, i, args, kwargs, log_level):
         from io import StringIO
 
     import logging
+    import traceback
 
     # In multiprocessing, we cannot pass in the logger, so log to a string and then
     # return that back at the end to be logged by the parent process.
@@ -245,6 +246,9 @@ def _run_multi_helper(func, i, args, kwargs, log_level):
     except Exception as e:
         # Exceptions don't propagate through multiprocessing.  So best alternative
         # is to catch it and return it.  We can deal with it somehow on the other end.
+        # Also add more details here with verbose>=2 to help with debugging.
+        tr = traceback.format_exc()
+        logger.info("Caught exception:\n%s",tr)
         out = e
 
     handler.flush()
@@ -279,7 +283,7 @@ def run_multi(func, nproc, args, logger, kwargs=None):
         i, out, log = result
         logger.info(log)
         if isinstance(out, Exception):
-            logger.warning("Caught exception: %r",out)
+            logger.warning("Caught exception in multiprocessing job: %r",out)
         else:
             output_list[i] = out
 

--- a/piff/util.py
+++ b/piff/util.py
@@ -256,7 +256,7 @@ def _run_multi_helper(func, i, args, kwargs, log_level):
     return i, out, buf.getvalue()
 
 
-def run_multi(func, nproc, args, raise_except, logger, kwargs=None):
+def run_multi(func, nproc, raise_except, args, logger, kwargs=None):
     """Run a function possibly in multiprocessing mode.
 
     This is basically just doing a Pool.map, but it handles the logger properly (which cannot
@@ -266,8 +266,8 @@ def run_multi(func, nproc, args, raise_except, logger, kwargs=None):
                             func(*args, logger=logger, **kwargs)
     :param nproc:       How many processes to run.  If nproc=1, no multiprocessing is done.
                         nproc <= 0 means use all the cores.
-    :param args:        a list of args for func for each job to run.
     :param raise_except: Whether to raise any exceptions that happen in individual jobs.
+    :param args:        a list of args for func for each job to run.
     :param logger:      The logger you would pass to func in single-processor mode.
     :param kwargs:      a list of kwargs for func for each job to run.  May also be a single dict
                         to use for all jobs. [default: None]

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -440,7 +440,7 @@ def test_single():
     # Check that errors in the multiprocessing input get properly reported.
     config['input']['ra_col'] = 'invalid'
     with CaptureLog(level=2) as cl:
-        with np.testing.assert_raises(RuntimeError):
+        with np.testing.assert_raises(ValueError):
             psf = piff.process(config, cl.logger)
     assert "ra_col = invalid is not a column" in cl.output
 
@@ -449,6 +449,15 @@ def test_single():
     config['verbose'] = 0
     with np.testing.assert_raises(ValueError):
         psf = piff.process(config)
+
+    # But just the input error.  Not the one in fitting.
+    config['psf']['nproc'] = 1
+    config['input']['ra_col'] = 'ra'
+    config['verbose'] = 1
+    with CaptureLog(level=1) as cl:
+        psf = piff.process(config, logger=cl.logger)
+    assert "No stars.  Cannot find PSF model." in cl.output
+    assert "Ignoring this failure and continuing on." in cl.output
 
 
 @timer

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -444,6 +444,12 @@ def test_single():
             psf = piff.process(config, cl.logger)
     assert "ra_col = invalid is not a column" in cl.output
 
+    # With nproc=1, the error is raised directly.
+    config['input']['nproc'] = 1
+    config['verbose'] = 0
+    with np.testing.assert_raises(ValueError):
+        psf = piff.process(config)
+
 
 @timer
 def test_pickle():


### PR DESCRIPTION
@eacharles pointed out that the multiprocessing helper currently swallows errors that happen in the input processing.  This was intentional for the fitting multiprocessing, since we want to allow some chips to fail and continue on with other chips.  But it makes debugging e.g. typos in the input section of the config file annoying.

So this PR fixes that by having the input call to multi_helper use `raise_except = True` and the single_chip one use `raise_except=False`.  And the utility function will raise or not appropriately. 

This is slightly tricky when you are multiprocessing, since you don't want to raise the exception until all the processes are done.  So we let them all finish first and then if there were any exceptions, one of them gets raised.  When nproc=1, it just raises the exception immediately.

It also adds some traceback when the exception was in multiprocessing to give more help when debugging.