### PR TITLE
Don't refit in draw operations if stars already have usable fit parameters

### DIFF
--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -239,9 +239,12 @@ class SimplePSF(PSF):
         :returns:           List of Star instances with its image filled with
                             rendered PSF
         """
-        stars_interpolated = self.interp.interpolateList(stars)
-        stars_drawn = [self.model.draw(star, copy_image=copy_image) for star in stars_interpolated]
-        return stars_drawn
+        if any(star.fit is None or star.fit.params is None for star in stars):
+            stars = self.interp.interpolateList(stars)
+            for star in stars:
+                self.model.normalize(star)
+        stars = [self.model.draw(star, copy_image=copy_image) for star in stars]
+        return stars
 
     def drawStar(self, star, copy_image=True):
         """Generate PSF image for a given star.
@@ -254,9 +257,10 @@ class SimplePSF(PSF):
 
         :returns:           Star instance with its image filled with rendered PSF
         """
-        # Interpolate parameters to this position/properties:
-        star = self.interp.interpolate(star)
-        self.model.normalize(star)
+        # Interpolate parameters to this position/properties (if not already done):
+        if star.fit is None or star.fit.params is None:
+            star = self.interp.interpolate(star)
+            self.model.normalize(star)
         # Render the image
         return self.model.draw(star, copy_image=copy_image)
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -39,6 +39,7 @@ def test_twodstats():
     stars, true_model = generate_starlist(100)
     psf = piff.SimplePSF(model, interp)
     psf.fit(stars, None, None)
+    stars = psf.stars  # These have the right fit parameters
 
     # check the coeffs of sigma and g2, which are actually linear fits
     # skip g1 since it is actually a 2d parabola


### PR DESCRIPTION
Change the behavior of the `psf.drawStar` and `psf.drawStarList` functions in the `SimplePSF` class to not redo the interpolation if the stars already have useable fit parameters.  This is a pretty minor efficiency gain most of the time, since our interpolations are usually pretty quick.  But it is important if the interpolation is GPInterp, since then the interpolation step is relatively expensive.  

In particular, if you compute multiple stats, this only has to do the interpolation once, rather than repeatedly for each statistic, doing the same calculation multiple times.

This is related to an optimization in the optatmo branch discussed on issue #100.  This doesn't directly address that issue -- rather the same adjustment should be made in the optatmo versions of these functions.