### PR TITLE
Add L0 option to Optical class

### DIFF
--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -195,6 +195,7 @@ class Optical(Model):
         if self.sigma is not None:
             gaussian = galsim.Gaussian(sigma=self.sigma)
             prof.append(gaussian)
+
         # atmosphere
         if len(self.atm_kwargs) > 0:
             if 'L0' in self.atm_kwargs and self.atm_kwargs['L0'] is not None:
@@ -205,13 +206,14 @@ class Optical(Model):
 
         # optics
         if params is None or len(params) == 0:
-            # no optics here
-            pass
+            # no aberrations.  Just the basic opt_kwargs
+            optics = galsim.OpticalPSF(**self.opt_kwargs)
         else:
             aberrations = [0,0,0,0] + list(params)
             optics = galsim.OpticalPSF(aberrations=aberrations, **self.opt_kwargs)
-            prof.append(optics)
-            # convolve together
+
+        # convolve together
+        prof.append(optics)
 
         if len(prof) == 1:
             prof = prof[0]

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -116,13 +116,12 @@ class Optical(Model):
         self.kwargs.update(kwargs)
 
         # Some of these aren't documented above, but allow them anyway.
-        optical_psf_keys = ('lam', 'diam', 'lam_over_diam', 'scale_unit',
-                            'circular_pupil', 'obscuration', 'interpolant',
-                            'oversampling', 'pad_factor', 'suppress_warning',
-                            'nstruts', 'strut_thick', 'strut_angle',
-                            'pupil_angle', 'pupil_plane_scale', 'pupil_plane_size')
-        self.optical_psf_kwargs = { key : self.kwargs[key] for key in self.kwargs
-                                                           if key in optical_psf_keys }
+        opt_keys = ('lam', 'diam', 'lam_over_diam', 'scale_unit',
+                    'circular_pupil', 'obscuration', 'interpolant',
+                    'oversampling', 'pad_factor', 'suppress_warning',
+                    'nstruts', 'strut_thick', 'strut_angle',
+                    'pupil_angle', 'pupil_plane_scale', 'pupil_plane_size')
+        self.opt_kwargs = { key : self.kwargs[key] for key in self.kwargs if key in opt_keys }
 
         # Deal with the pupil plane image now so it only needs to be loaded from disk once.
         if 'pupil_plane_im' in kwargs:
@@ -130,7 +129,7 @@ class Optical(Model):
             if isinstance(pupil_plane_im, str):
                 logger.debug('Loading pupil_plane_im from {0}'.format(pupil_plane_im))
                 pupil_plane_im = galsim.fits.read(pupil_plane_im)
-            self.optical_psf_kwargs['pupil_plane_im'] = pupil_plane_im
+            self.opt_kwargs['pupil_plane_im'] = pupil_plane_im
 
         atm_keys = ('lam', 'r0', 'lam_over_r0', 'scale_unit',
                     'fwhm', 'half_light_radius', 'r0_500', 'L0')
@@ -148,14 +147,14 @@ class Optical(Model):
         self.g2 = kwargs.pop('g2',None)
 
         # Check that no unexpected parameters were passed in:
-        extra_kwargs = [k for k in kwargs if k not in optical_psf_keys and k not in atm_keys]
+        extra_kwargs = [k for k in kwargs if k not in opt_keys and k not in atm_keys]
         if len(extra_kwargs) > 0:
             raise TypeError('__init__() got an unexpected keyword argument %r'%extra_kwargs[0])
 
         # Check for some required parameters.
-        if 'diam' not in self.optical_psf_kwargs:
+        if 'diam' not in self.opt_kwargs:
             raise TypeError("Required keyword argument 'diam' not found")
-        if 'lam' not in self.optical_psf_kwargs:
+        if 'lam' not in self.opt_kwargs:
             raise TypeError("Required keyword argument 'lam' not found")
 
         # pupil_angle and strut_angle won't serialize properly, so repr them now in self.kwargs.
@@ -209,7 +208,7 @@ class Optical(Model):
             pass
         else:
             aberrations = [0,0,0,0] + list(params)
-            optics = galsim.OpticalPSF(aberrations=aberrations, **self.optical_psf_kwargs)
+            optics = galsim.OpticalPSF(aberrations=aberrations, **self.opt_kwargs)
             prof.append(optics)
             # convolve together
 

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -213,9 +213,6 @@ class Optical(Model):
             prof.append(optics)
             # convolve together
 
-        if len(prof) == 0:
-            raise RuntimeError('No profile returned by model!')
-
         if len(prof) == 1:
             prof = prof[0]
         else:

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -135,7 +135,7 @@ class Optical(Model):
                     'fwhm', 'half_light_radius', 'r0_500', 'L0')
         self.atm_kwargs = { key : self.kwargs[key] for key in self.kwargs if key in atm_keys }
         # If lam is the only one, then remove it -- we don't have a Kolmogorov component then.
-        if self.atm_kwargs.keys() == ['lam']:
+        if list(self.atm_kwargs.keys()) == ['lam']:
             self.atm_kwargs = {}
         # Also, let r0=0 or None indicate that there is no atm component
         if 'r0' in self.atm_kwargs and not self.atm_kwargs['r0']:
@@ -202,6 +202,7 @@ class Optical(Model):
             else:
                 atm = galsim.Kolmogorov(**self.atm_kwargs)
             prof.append(atm)
+
         # optics
         if params is None or len(params) == 0:
             # no optics here

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -130,16 +130,16 @@ class Optical(Model):
                 pupil_plane_im = galsim.fits.read(pupil_plane_im)
             self.optical_psf_kwargs['pupil_plane_im'] = pupil_plane_im
 
-        kolmogorov_keys = ('lam', 'r0', 'lam_over_r0', 'scale_unit',
+        atm_keys = ('lam', 'r0', 'lam_over_r0', 'scale_unit',
                            'fwhm', 'half_light_radius', 'r0_500')
-        self.kolmogorov_kwargs = { key : self.kwargs[key] for key in self.kwargs
-                                                          if key in kolmogorov_keys }
+        self.atm_kwargs = { key : self.kwargs[key] for key in self.kwargs
+                                                          if key in atm_keys }
         # If lam is the only one, then remove it -- we don't have a Kolmogorov component then.
-        if self.kolmogorov_kwargs.keys() == ['lam']:
-            self.kolmogorov_kwargs = {}
-        # Also, let r0=0 or None indicate that there is no kolmogorov component
-        if 'r0' in self.kolmogorov_kwargs and not self.kolmogorov_kwargs['r0']:
-            self.kolmogorov_kwargs = {}
+        if self.atm_kwargs.keys() == ['lam']:
+            self.atm_kwargs = {}
+        # Also, let r0=0 or None indicate that there is no atm component
+        if 'r0' in self.atm_kwargs and not self.atm_kwargs['r0']:
+            self.atm_kwargs = {}
 
         # Store the Gaussian and shear parts
         self.sigma = kwargs.pop('sigma',None)
@@ -147,7 +147,7 @@ class Optical(Model):
         self.g2 = kwargs.pop('g2',None)
 
         # Check that no unexpected parameters were passed in:
-        extra_kwargs = [k for k in kwargs if k not in optical_psf_keys and k not in kolmogorov_keys]
+        extra_kwargs = [k for k in kwargs if k not in optical_psf_keys and k not in atm_keys]
         if len(extra_kwargs) > 0:
             raise TypeError('__init__() got an unexpected keyword argument %r'%extra_kwargs[0])
 
@@ -196,8 +196,8 @@ class Optical(Model):
             gaussian = galsim.Gaussian(sigma=self.sigma)
             prof.append(gaussian)
         # atmosphere
-        if len(self.kolmogorov_kwargs) > 0:
-            atm = galsim.Kolmogorov(**self.kolmogorov_kwargs)
+        if len(self.atm_kwargs) > 0:
+            atm = galsim.Kolmogorov(**self.atm_kwargs)
             prof.append(atm)
         # optics
         if params is None or len(params) == 0:

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -142,13 +142,14 @@ def test_gaussian():
     print('test gaussian')
     star = make_empty_star()
     # test gaussian alone
-    sigma = 1
+    sigma = 1.7
     g1 = -0.1
     g2 = 0.05
     model = piff.Optical(r0=0, sigma=sigma, template='des')
     star = model.draw(star)
     # insert assert statement about sigma
-    np.testing.assert_almost_equal(gaussian.fit(star).fit.params[0], sigma, 5)
+    # We don't expect sigma to match.  But it should be the biggest component, so close-ish
+    np.testing.assert_allclose(gaussian.fit(star).fit.params[0], sigma, rtol=1.e-2)
 
     # omitting atm params is equivalent
     kwargs = piff.optical_model.optical_templates['des'].copy()
@@ -161,9 +162,10 @@ def test_gaussian():
     model = piff.Optical(r0=0, sigma=sigma, g1=g1, g2=g2, template='des')
     star = model.draw(star)
     params = gaussian.fit(star).fit.params
-    np.testing.assert_almost_equal(params[0], sigma, 5)
-    np.testing.assert_almost_equal(params[1], g1, 5)
-    np.testing.assert_almost_equal(params[2], g2, 5)
+    np.testing.assert_allclose(gaussian.fit(star).fit.params[0], sigma, rtol=1.e-2)
+    # Shears are much closer, since the optical part is round.
+    np.testing.assert_allclose(params[1], g1, rtol=1.e-4)
+    np.testing.assert_allclose(params[2], g2, rtol=1.e-4)
 
     # now gaussian, shear, aberration, r0
     star = make_empty_star(params=[0.5, 0.8, -0.7, 0.5, -0.2, 0.9, -1, 2.0])

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -53,6 +53,15 @@ def test_optical(model=None):
     assert star_copy.image.array[0,0] != star.image.array[0,0]
     assert star_copy.image.array[1,1] == star.image.array[1,1]
 
+    with np.testing.assert_raises(TypeError):
+        piff.Optical(template='des', invalid=True)
+    with np.testing.assert_raises(TypeError):
+        piff.Optical(lam=700)  # missing diam
+    with np.testing.assert_raises(TypeError):
+        piff.Optical(diam=4)  # missing lam
+    with np.testing.assert_raises(ValueError):
+        piff.Optical(template='invalid')
+
 @timer
 def test_pupil_im(pupil_plane_file='input/DECam_pupil_128.fits'):
     import galsim

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -160,9 +160,9 @@ def test_disk():
     for key in model.optical_psf_kwargs:
         assert key in model2.optical_psf_kwargs, 'key %r missing from model2 optical_psf_kwargs'%key
         assert model.optical_psf_kwargs[key] == model2.optical_psf_kwargs[key], 'key %r mismatch'%key
-    for key in model.kolmogorov_kwargs:
-        assert key in model2.kolmogorov_kwargs, 'key %r missing from model2 kolmogorov_kwargs'%key
-        assert model.kolmogorov_kwargs[key] == model2.kolmogorov_kwargs[key], 'key %r mismatch'%key
+    for key in model.atm_kwargs:
+        assert key in model2.atm_kwargs, 'key %r missing from model2 atm_kwargs'%key
+        assert model.atm_kwargs[key] == model2.atm_kwargs[key], 'key %r mismatch'%key
     assert model.sigma == model2.sigma,'sigma mismatch'
     assert model.g1 == model2.g1,'g1 mismatch'
     assert model.g2 == model2.g2,'g2 mismatch'

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -98,6 +98,21 @@ def test_kolmogorov():
 
 
 @timer
+def test_vonkarman():
+    # Like above, but using L0.
+    star = make_empty_star()
+
+    model = piff.Optical(r0=0.1, L0=20, template='des')
+    star = model.draw(star)
+
+    model2 = piff.Optical(r0=0.1, L0=40, template='des')
+    star2 = model2.draw(star)
+
+    chi2 = np.std((star.image - star2.image).array)
+    assert chi2 != 0,'chi2 is zero!?'
+
+
+@timer
 def test_shearing():
     print('test shearing')
     # make sure if we put in common mode ellipticities that things change
@@ -211,6 +226,7 @@ if __name__ == '__main__':
     test_pupil_im(pupil_plane_file='input/DECam_pupil_128.fits')
     test_pupil_im(pupil_plane_file='input/DECam_pupil_512.fits')
     test_kolmogorov()
+    test_vonkarman()
     test_shearing()
     test_gaussian()
     test_disk()

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -141,6 +141,13 @@ def test_gaussian():
     # insert assert statement about sigma
     np.testing.assert_almost_equal(gaussian.fit(star).fit.params[0], sigma, 5)
 
+    # omitting atm params is equivalent
+    kwargs = piff.optical_model.optical_templates['des'].copy()
+    del kwargs['r0']
+    model2 = piff.Optical(sigma=sigma, **kwargs)
+    star2 = model2.draw(star)
+    assert star.image == star2.image
+
     # gaussian and shear
     model = piff.Optical(r0=0, sigma=sigma, g1=g1, g2=g2, template='des')
     star = model.draw(star)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -71,13 +71,13 @@ def test_pupil_im(pupil_plane_file='input/DECam_pupil_128.fits'):
         pupil_plane_im.scale = ref_psf._psf.aper.pupil_plane_scale
         pupil_plane_im.write(pupil_plane_file)
 
-    model_pupil_plane_im = model.optical_psf_kwargs['pupil_plane_im']
+    model_pupil_plane_im = model.opt_kwargs['pupil_plane_im']
     np.testing.assert_array_equal(pupil_plane_im.array, model_pupil_plane_im.array)
 
     # test passing a different optical template that includes diam
     piff.optical_model.optical_templates['test'] = {'diam': 2, 'lam':500, 'r0':0.1}
     model = piff.Optical(pupil_plane_im=pupil_plane_im, template='test')
-    model_pupil_plane_im = model.optical_psf_kwargs['pupil_plane_im']
+    model_pupil_plane_im = model.opt_kwargs['pupil_plane_im']
     np.testing.assert_array_equal(pupil_plane_im.array, model_pupil_plane_im.array)
 
 
@@ -172,9 +172,9 @@ def test_disk():
     for key in model.kwargs:
         assert key in model2.kwargs, 'key %r missing from model2 kwargs'%key
         assert model.kwargs[key] == model2.kwargs[key], 'key %r mismatch'%key
-    for key in model.optical_psf_kwargs:
-        assert key in model2.optical_psf_kwargs, 'key %r missing from model2 optical_psf_kwargs'%key
-        assert model.optical_psf_kwargs[key] == model2.optical_psf_kwargs[key], 'key %r mismatch'%key
+    for key in model.opt_kwargs:
+        assert key in model2.opt_kwargs, 'key %r missing from model2 opt_kwargs'%key
+        assert model.opt_kwargs[key] == model2.opt_kwargs[key], 'key %r mismatch'%key
     for key in model.atm_kwargs:
         assert key in model2.atm_kwargs, 'key %r missing from model2 atm_kwargs'%key
         assert model.atm_kwargs[key] == model2.atm_kwargs[key], 'key %r mismatch'%key


### PR DESCRIPTION
In the optatmo branch @areshernandez uses a VonKarman profile for the atmospheric component.  This adds this option to the regular `Optical` class simply by specifying L0 as one of the atmospheric parameters.