### PR TITLE
Add reserve_frac option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     - export MATPLOTLIBRC=$HOME/.matplotlib
 
     # Install dependencies
-    - pip install -r requirements.txt
+    - pip install -U -r requirements.txt
 
     # Install Pixmappy (not a requirement, but used in tests)  Also, not on pip.  :(
     - git clone https://github.com/gbernstein/pixmappy.git

--- a/piff/gsobject_model.py
+++ b/piff/gsobject_model.py
@@ -272,7 +272,9 @@ class GSObjectModel(Model):
         prof.shift(center).drawImage(model_image, method=self._method,
                                      offset=(star.image_pos - model_image.true_center))
         chisq = np.sum(star.weight.array * (star.image.array - model_image.array)**2)
-        dof = np.count_nonzero(star.weight.array) - self._nparams
+        # number of parameters is always 6 for dof, even though we ignore 1 or 3 of them
+        # for the PSF model.
+        dof = np.count_nonzero(star.weight.array) - 6
         fit = StarFit(params, params_var=params_var, flux=flux, center=center, chisq=chisq, dof=dof)
         return Star(star.data, fit)
 
@@ -342,12 +344,13 @@ class GSObjectModel(Model):
 
         # new_chisq ignores centroid shift, but close enough.
         new_chisq = np.sum(weight * (image - flux_ratio*model)**2)
+        new_dof = np.count_nonzero(weight) - 6
 
         return Star(star.data, StarFit(star.fit.params,
                                        flux = star.fit.flux * flux_ratio,
                                        center = new_center,
                                        chisq = new_chisq,
-                                       dof = np.count_nonzero(weight) - 1,
+                                       dof = new_dof,
                                        params_var = star.fit.params_var))
 
 

--- a/piff/input.py
+++ b/piff/input.py
@@ -120,12 +120,8 @@ class Input(object):
                 logger.info("Reserve %s of %s (reserve_frac=%s) input stars",
                             nreserve, len(stars), self.reserve_frac)
                 reserve_list = self.rng.choice(len(stars), nreserve, replace=False)
-                # Set them all to False, then update the reserve fraction to True.
-                # This makes sure they all have this value in the properties dict.
-                for star in stars:
-                    star.data.properties['is_reserve'] = False
-                for i in reserve_list:
-                    stars[i].data.properties['is_reserve'] = True
+                for i, star in enumerate(stars):
+                    star.data.properties['is_reserve'] = i in reserve_list
 
         # Concatenate the star lists into a single list
         stars = [s for slist in all_stars if slist is not None for s in slist if slist]
@@ -275,9 +271,8 @@ class InputFiles(Input):
                             multiple files at once. [default: 1]
             :reserve_frac:  Reserve a fraction of the stars from the PSF calculations, so they
                             can serve as fair points for diagnostic testing.  These stars will
-                            have outlier rejection performed along with the regular stars, but
-                            will not be used to constrain the PSF model.  The output files
-                            will contain the reserve stars, flagged as such.  Generally 0.2 is a
+                            not be used to constrain the PSF model, but the output files will
+                            contain the reserve stars, flagged as such.  Generally 0.2 is a
                             good choice if you are going to use this. [default: 0.]
             :seed:          A seed to use for numpy.random.default_rng, if desired. [default: None]
 

--- a/piff/input.py
+++ b/piff/input.py
@@ -454,7 +454,7 @@ class InputFiles(Input):
         self.reserve_frac = config.get('reserve_frac', 0.)
         try:
             self.rng = np.random.default_rng(config.get('seed', None))
-        except AttributError:  # pragma: no cover
+        except AttributeError:  # pragma: no cover
             # numpy <= 1.16 doesn't have this yet.  But RandomState is fine.
             self.rng = np.random.RandomState(config.get('seed', None))
 

--- a/piff/input.py
+++ b/piff/input.py
@@ -452,7 +452,11 @@ class InputFiles(Input):
         self.remove_signal_from_weight = config.get('remove_signal_from_weight', False)
         self.invert_weight = config.get('invert_weight', False)
         self.reserve_frac = config.get('reserve_frac', 0.)
-        self.rng = np.random.default_rng(config.get('seed', None))
+        try:
+            self.rng = np.random.default_rng(config.get('seed', None))
+        except AttributError:  # pragma: no cover
+            # numpy <= 1.16 doesn't have this yet.  But RandomState is fine.
+            self.rng = np.random.RandomState(config.get('seed', None))
 
         logger.info("Reading in %d images",nimages)
         for image_num in range(nimages):

--- a/piff/pixelgrid.py
+++ b/piff/pixelgrid.py
@@ -179,7 +179,7 @@ class PixelGrid(Model):
         #
         #    A dp = b
         #
-        # Even if the solutionis degenerate, gelsy works fine using QRP decomposition.
+        # Even if the solution is degenerate, gelsy works fine using QRP decomposition.
         # And it's much faster than SVD.
         dparam = scipy.linalg.lstsq(star1.fit.A, star1.fit.b,
                                     check_finite=False, cond=1.e-6,

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -159,6 +159,9 @@ class SimplePSF(PSF):
                 raise RuntimeError("No stars.  Cannot find PSF model.")
 
             logger.warning("Iteration %d: Fitting %d stars", iteration+1, len(use_stars))
+            if len(use_stars) != len(self.stars):
+                logger.warning("             (%d stars are reserved)",
+                               len(self.stars)-len(use_stars))
 
             # Perform the fit or compute design matrix as appropriate using just non-reserve stars
             fit_fn = self.model.chisq if quadratic_chisq else self.model.fit

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -118,7 +118,7 @@ class SimplePSF(PSF):
 
         logger.debug("Initializing models")
         # model.initialize may fail
-        nremoved = 0
+        self.nremoved = 0
         new_stars = []
         for s in self.stars:
             try:
@@ -126,13 +126,13 @@ class SimplePSF(PSF):
             except Exception as e:  # pragma: no cover
                 logger.warning("Failed initializing star at %s. Excluding it.", s.image_pos)
                 logger.warning("  -- Caught exception: %s",e)
-                nremoved += 1
+                self.nremoved += 1
             else:
                 new_stars.append(new_star)
-        if nremoved == 0:
+        if self.nremoved == 0:
             logger.debug("No stars removed in initialize step")
         else:
-            logger.info("Removed %d stars in initialize", nremoved)
+            logger.info("Removed %d stars in initialize", self.nremoved)
         self.stars = new_stars
 
         logger.debug("Initializing interpolator")
@@ -166,7 +166,7 @@ class SimplePSF(PSF):
             # Perform the fit or compute design matrix as appropriate using just non-reserve stars
             fit_fn = self.model.chisq if quadratic_chisq else self.model.fit
 
-            nremoved = 0
+            nremoved = 0  # For this iteration
             new_use_stars = []
             for star in use_stars:
                 try:
@@ -227,7 +227,7 @@ class SimplePSF(PSF):
             self.chisq = chisq
             self.last_delta_chisq = oldchisq-chisq
             self.dof = dof
-            self.nremoved = nremoved
+            self.nremoved += nremoved  # Keep track of the total number removed in all iterations.
 
             # Very simple convergence test here:
             # Note, the lack of abs here means if chisq increases, we also stop.

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -580,10 +580,7 @@ class HSMCatalogStats(Stats):
         self.u = positions[mask, 0]
         self.v = positions[mask, 1]
         self.flux = shapes_truth[mask, 0]
-        self.reserve = np.zeros_like(self.u, dtype=bool)
-        for i,s in enumerate(stars):
-            if s.is_reserve:
-                self.reserve[i] = True
+        self.reserve = np.array([s.is_reserve for s in stars], dtype=bool)
         self.T_data = shapes_truth[mask, 3]
         self.g1_data = shapes_truth[mask, 4]
         self.g2_data = shapes_truth[mask, 5]

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -552,7 +552,7 @@ class HSMCatalogStats(Stats):
         :T_model:   The size of the PSF model at the same locations as the star.
         :g1_model:  The g1 component of the PSF model.
         :g2_model:  The g2 component of the PSF model.
-        :reserve:   Whether the star was a reserve star. (Placeholder -- always false now.)
+        :reserve:   Whether the star was a reserve star.
     """
     def __init__(self, file_name=None, logger=None):
         """
@@ -580,7 +580,10 @@ class HSMCatalogStats(Stats):
         self.u = positions[mask, 0]
         self.v = positions[mask, 1]
         self.flux = shapes_truth[mask, 0]
-        self.reserve = np.zeros_like(self.u, dtype=bool)  # For now, all reserve = False
+        self.reserve = np.zeros_like(self.u, dtype=bool)
+        for i,s in enumerate(stars):
+            if s.is_reserve:
+                self.reserve[i] = True
         self.T_data = shapes_truth[mask, 3]
         self.g1_data = shapes_truth[mask, 4]
         self.g2_data = shapes_truth[mask, 5]

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -1108,6 +1108,7 @@ def test_des_image():
     # That's why the default is False.
     print('Repeat with include_reserve=True')
     config['psf']['outliers']['include_reserve'] = True
+    config['psf']['outliers']['max_remove'] = 0.01
     piff.piffify(config)
     psf = piff.read(psf_file)
     nreserve = len([s for s in psf.stars if s.is_reserve])

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -947,12 +947,14 @@ def test_des_image():
             'ra' : 'TELRA',
             'dec' : 'TELDEC',
             'gain' : 'GAINA',
+            'reserve_frac' : 0.2,
+            'seed' : 1234,
             # Test explicitly specifying the wcs (although it is the same here as what is in the
             # image anyway).
             'wcs' : {
                 'type': 'Fits',
                 'file_name': image_file
-            }
+            },
         },
         'output' : {
             'file_name' : psf_file,
@@ -972,7 +974,7 @@ def test_des_image():
                 'type' : 'Chisq',
                 'nsigma' : nsigma,
                 'max_remove' : 3
-            }
+            },
         },
     }
     if __name__ == '__main__':

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -576,7 +576,9 @@ def test_hsmcatalog():
         'input' : {
             'image_file_name' : image_file,
             'cat_file_name' : cat_file,
-            'stamp_size' : 48
+            'stamp_size' : 48,
+            'reserve_frac' : 0.2,
+            'seed' : 123
         },
         'psf' : {
             'model' : { 'type' : 'Gaussian',
@@ -608,7 +610,10 @@ def test_hsmcatalog():
     np.testing.assert_allclose(data['x'], true_data['x'])
     np.testing.assert_allclose(data['y'], true_data['y'])
     np.testing.assert_allclose(data['flux'], 123.45, atol=0.001)
-    np.testing.assert_array_equal(data['reserve'], False)
+    print('reserve = ',data['reserve'])
+    print('nreserve = ',np.sum(data['reserve']))
+    print('ntot = ',len(data['reserve']))
+    assert np.sum(data['reserve']) == int(0.2 * len(data['reserve']))
     np.testing.assert_allclose(data['T_model'], data['T_data'], rtol=1.e-4)
     np.testing.assert_allclose(data['g1_model'], data['g1_data'], rtol=1.e-4)
     np.testing.assert_allclose(data['g2_model'], data['g2_data'], rtol=1.e-4)


### PR DESCRIPTION
One last aspirational item that I put into the paper as a "current" feature that we hadn't implemented yet.  This PR adds `reserve_frac` as an optional input field.  This selects a fraction of the input stars as reserve stars and doesn't use them for the psf processing.

These reserve stars can optionally be included in the outlier rejection, but when I tried it out, they were very preferentially selected as outliers.  Maybe not surprising, but it indicates that this might not be a great idea in general.  It's an option, but not the default.  (By default only non-reserve stars are allowed to be rejected as outliers.)

It also implements the reserve nature of the star when outputting the HSMCatalog with shape measurements.  This had already had a placeholder where all stars were marked as not reserved.  This updates that to use the real reserve value.