### PR TITLE
Bring coverage up to 100%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,7 @@ coverage:
     project:
       default:
         enabled: yes
-        target: 70%
+        target: 100%
         threshold: 1%
         branches: null
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 branches:
     only:
         - master
-        - coverage
 
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
     only:
         - master
+        - coverage
 
 language: python
 python:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,14 @@
+Changes from version 1.0 to 1.1
+===============================
+
+
+Performance improvements
+------------------------
+
+
+New features
+------------
+
+
+Bug fixes
+---------

--- a/piff/__init__.py
+++ b/piff/__init__.py
@@ -74,7 +74,7 @@ from .config import piffify, setup_logger, read_config, parse_variables
 from .config import plotify, process, meanify
 
 # Models -- Class names here match what they are called in the config file
-from .model import Model, ModelFitError
+from .model import Model
 from .pixelgrid import PixelGrid, Lanczos
 from .gsobject_model import GSObjectModel, Gaussian, Kolmogorov, Moffat
 

--- a/piff/basis_interp.py
+++ b/piff/basis_interp.py
@@ -357,7 +357,7 @@ class BasisPolynomial(BasisInterp):
         super(BasisPolynomial, self).__init__()
 
         self._keys = keys
-        if hasattr(order,'len'):
+        if hasattr(order,'__len__'):
             if not len(order)==len(keys):
                 raise ValueError('Number of provided orders does not match number of keys')
             self._orders = order

--- a/piff/config.py
+++ b/piff/config.py
@@ -231,8 +231,8 @@ def meanify(config, logger=None):
 
     if 'statistic' in config['hyper']:
         if config['hyper']['statistic'] not in ['mean', 'median']:
-            raise ValueError("%s is not a suported statistic (only mean and median are currently suported)"
-                             %config['hyper']['statistic'])
+            raise ValueError("%s is not a suported statistic (only mean and median are currently "
+                             "suported)"%config['hyper']['statistic'])
         else:
             stat_used = config['hyper']['statistic']
     else:
@@ -256,15 +256,14 @@ def meanify(config, logger=None):
             file_name = os.path.join(dir, file_name)
         psf_list = sorted(glob.glob(file_name))
         if len(psf_list) == 0:
-            raise ValueError("No files found corresponding to "+config['file_name'])
-    elif not isinstance(config['file_name'], dict):
-        raise ValueError("file_name should be either a dict or a string")
+            raise ValueError("No files found corresponding to "+config['output']['file_name'])
+    else:
+        raise ValueError("file_name should be either a list or a string")
 
-    if psf_list is not None:
-        logger.debug('psf_list = %s',psf_list)
-        npsfs = len(psf_list)
-        logger.debug('npsfs = %d',npsfs)
-        config['output']['file_name'] = psf_list
+    logger.debug('psf_list = %s',psf_list)
+    npsfs = len(psf_list)
+    logger.debug('npsfs = %d',npsfs)
+    config['output']['file_name'] = psf_list
 
     file_name_in = config['output']['file_name']
     logger.info("Looking for PSF at %s", file_name_in)

--- a/piff/des/decam_wavefront.py
+++ b/piff/des/decam_wavefront.py
@@ -20,6 +20,7 @@ from ..knn_interp import kNNInterp
 
 import numpy as np
 import fitsio
+import galsim
 
 class DECamWavefront(kNNInterp):
     """
@@ -70,39 +71,36 @@ class DECamWavefront(kNNInterp):
 
         from sklearn.neighbors import KNeighborsRegressor
         self.knn = KNeighborsRegressor(**self.knr_kwargs)
-        if logger:
-            logger.debug("Made regressor")
+
+        logger = galsim.config.LoggerWrapper(logger)  # This avoids need for "if logger:"
+        logger.debug("Made regressor")
 
         fits = fitsio.FITS(file_name)
-        if logger:
-            logger.debug("Made fits")
-            logger.debug(fits)
-            logger.debug(fits[1])
+        logger.debug("Made fits")
+        logger.debug(fits)
+        logger.debug(fits[1])
+
         data = fits[extname].read()
-        if logger:
-            logger.debug("read data from fits file")
+        logger.debug("read data from fits file")
+
         locations = np.array([data[attr] for attr in self.keys]).T
-        if logger:
-            logger.debug("locations shape = %s",locations.shape)
+        logger.debug("locations shape = %s",locations.shape)
+
         targets = np.array([data[attr] for attr in self.attr_target_wavefront]).T
-        if logger:
-            logger.debug("targets shape = %s",targets.shape)
+        logger.debug("targets shape = %s",targets.shape)
 
         self._fit(locations, targets)
-        if logger:
-            logger.debug("done fit")
+        logger.debug("done fit")
 
         # set misalignment as [[delta_i, thetax_i, thetay_i]] with i == 0 corresponding to defocus
         self.misalignment = np.array([[0.0, 0.0, 0.0]] * (self.z_max - self.z_min + 1))
-        if logger:
-            logger.debug("misalignement shape = %s",self.misalignment.shape)
+        logger.debug("misalignement shape = %s",self.misalignment.shape)
 
         # to get the ccd coords
         attr_save = ['x', 'y', 'ccdnum']
         Xpixel = np.array([data[attr] for attr in attr_save]).T
         self.Xpixel = Xpixel
-        if logger:
-            logger.debug("Xpixel shape = %s",self.Xpixel.shape)
+        logger.debug("Xpixel shape = %s",self.Xpixel.shape)
 
     def misalign_wavefront(self, misalignment):
         """Pass along misalignment parameter
@@ -128,25 +126,23 @@ class DECamWavefront(kNNInterp):
                     nu_misalignment[indx, 2] = misalignment[key]
             misalignment = nu_misalignment
         # if array, check that shape is right, and put it in
-        if hasattr(self, 'misalignment') and misalignment.shape != self.misalignment.shape:
+        if misalignment.shape != self.misalignment.shape:
             raise ValueError("New misalignment shape must match old!")
         self.misalignment = misalignment
 
-    def _predict(self, locations, targets=None, logger=None):
+    def _predict(self, locations, logger=None):
         """Predict from knn.
 
         :param locations:   The locations for interpolating. (n_samples, n_features). In sklearn
                             parlance, this is 'X'
-        :param targets:     The target values. (n_samples, n_targets). In sklearn parlance, this is
-                            'y'. If given, then only apply misalignment
 
         :returns:   Regressed parameters targets (n_samples, n_targets)
         """
-        if np.shape(targets) == ():
-            # if no y, then interpolate
-            targets = self.knn.predict(locations)
-        if logger:
-            logger.debug('Regression shape: %s', targets.shape)
+        logger = galsim.config.LoggerWrapper(logger)
+
+        targets = self.knn.predict(locations)
+        logger.debug('Regression shape: %s', targets.shape)
+
         # add misalignment shape (n_targets, 3)
         # locations is (n_samples, 2)
         # targets is (n_samples, n_targets)

--- a/piff/gp_interp.py
+++ b/piff/gp_interp.py
@@ -137,11 +137,10 @@ class GPInterp(Interp):
 
         if isinstance(kernel,str):
             self.kernel_template = [kernel]
+        elif isinstance(kernel, (list, np.ndarray)):
+            self.kernel_template = [ker for ker in kernel]
         else:
-            if type(kernel) is not list and type(kernel) is not np.ndarray:
-                raise TypeError("kernel should be a string a list or a numpy.ndarray of string")
-            else:
-                self.kernel_template = [ker for ker in kernel]
+            raise TypeError("kernel should be a string a list or a numpy.ndarray of string")
 
         if self.optimizer not in ['anisotropic', 'isotropic', 'likelihood', 'none']:
             raise ValueError("Only anisotropic, isotropic, likelihood, and " \
@@ -191,16 +190,16 @@ class GPInterp(Interp):
             self.rows = np.arange(0, self.nparams, 1).astype(int)
         else:
             self.nparams = len(self.rows)
+            self.rows = np.array(self.rows)
 
         if len(self.kernel_template)==1:
             self.kernels = [self.kernel_template[0] for i in range(self.nparams)]
+        elif len(self.kernel_template) == self.nparams:
+            self.kernels = [ker for ker in self.kernel_template]
         else:
-            if len(self.kernel_template)!= self.nparams:
-                raise ValueError("numbers of kernel provided should be 1 (same for all parameters) or " \
-                                 "equal to the number of params (%i), number kernel provided: %i" \
-                                 %((self.nparams,len(self.kernel_template))))
-            else:
-                self.kernels = [copy.deepcopy(ker) for ker in self.kernel_template]
+            raise ValueError("numbers of kernel provided should be 1 (same for all parameters) "
+                             "or equal to the number of params (%i), number kernel provided: %i"
+                                %((self.nparams,len(self.kernel_template))))
         self.gps = []
 
         for i in range(self.nparams):
@@ -211,7 +210,8 @@ class GPInterp(Interp):
                                         p0=[self.l0, 0, 0], white_noise=self.white_noise,
                                         n_neighbors=self.n_neighbors,
                                         average_fits=self.average_fits, indice_meanify = i,
-                                        nbins=self.nbins, min_sep=self.min_sep, max_sep=self.max_sep)
+                                        nbins=self.nbins,
+                                        min_sep=self.min_sep, max_sep=self.max_sep)
             self.gps.append(gp)
 
         self._init_theta = np.array([gp.kernel_template.theta for gp in self.gps])
@@ -320,15 +320,9 @@ class GPInterp(Interp):
         self.optimizer = data['OPTIMIZER'][0]
 
         if len(self.kernel_template)==1:
-            self.kernels = [copy.deepcopy(self.kernel_template[0]) for i in range(self.nparams)]
+            self.kernels = [self.kernel_template[0] for i in range(self.nparams)]
         else:
-            if len(self.kernel_template)!= self.nparams:
-                raise ValueError(
-                    "numbers of kernel provided should be 1 (same for all parameters) or " +
-                    "equal to the number of params (%i), number kernel provided: %i"%(
-                        (self.nparams,len(self.kernel_template))))
-            else:
-                self.kernels = [copy.deepcopy(ker) for ker in self.kernel_template]
+            self.kernels = [ker for ker in self.kernel_template]
 
         self.gps = []
         for i in range(self.nparams):

--- a/piff/gsobject_model.py
+++ b/piff/gsobject_model.py
@@ -337,6 +337,8 @@ class GSObjectModel(Model):
         # new_chisq ignores centroid shift, but close enough.
         new_chisq = np.sum(weight * (image - flux_ratio*model)**2)
         new_dof = np.count_nonzero(weight) - 6
+        logger.debug("    new_chisq = %s",new_chisq)
+        logger.debug("    new_dof = %s",new_dof)
 
         return Star(star.data, StarFit(star.fit.params,
                                        flux = star.fit.flux * flux_ratio,

--- a/piff/gsobject_model.py
+++ b/piff/gsobject_model.py
@@ -19,7 +19,7 @@
 import numpy as np
 import galsim
 
-from .model import Model, ModelFitError
+from .model import Model
 from .star import Star, StarFit
 from .util import hsm, estimate_cov_from_jac
 
@@ -66,8 +66,8 @@ class GSObjectModel(Model):
 
         ref_flux, ref_cenu, ref_cenv, ref_size, ref_g1, ref_g2, flag = hsm(self.draw(star))
         ref_shape = galsim.Shear(g1=ref_g1, g2=ref_g2)
-        if flag:
-            raise ModelFitError("Error calculating model moments for this star.")
+        if flag != 0:
+            raise RuntimeError("Error calculating model moments for this star.")
 
         param_flux = star.fit.flux
         if star.fit.params is None:

--- a/piff/input.py
+++ b/piff/input.py
@@ -24,7 +24,7 @@ import glob
 import os
 import galsim
 
-from .util import hsm, run_multi, calculateSNR
+from .util import run_multi, calculateSNR
 from .star import Star, StarData
 
 class Input(object):
@@ -717,7 +717,7 @@ class InputFiles(Input):
 
         if hsm_size_reject != 0:
             # Calculate the hsm size for each star and throw out extreme outliers.
-            sigma = [hsm(star)[3] for star in stars]
+            sigma = [star.hsm[3] for star in stars]
             med_sigma = np.median(sigma)
             iqr_sigma = scipy.stats.iqr(sigma)
             logger.debug("Doing hsm sigma rejection.")

--- a/piff/input.py
+++ b/piff/input.py
@@ -369,7 +369,7 @@ class InputFiles(Input):
             del config['dir']
 
         if 'image_file_name' not in config:
-            raise AttributeError('Attribute image_file_name is required')
+            raise TypeError('Parameter image_file_name is required')
         elif isinstance(config['image_file_name'], list):
             image_list = config['image_file_name']
             if len(image_list) == 0:
@@ -385,7 +385,7 @@ class InputFiles(Input):
                 raise ValueError("No files found corresponding to "+config['image_file_name'])
         elif isinstance(config['image_file_name'], dict):
             if nimages is None:
-                raise ValueError(
+                raise TypeError(
                     'input.nimages is required if not using a list or simple string for ' +
                     'file names')
         else:
@@ -406,7 +406,7 @@ class InputFiles(Input):
         assert nimages is not None
 
         if 'cat_file_name' not in config:
-            raise AttributeError('Attribute cat_file_name is required')
+            raise TypeError('Parameter cat_file_name is required')
         elif isinstance(config['cat_file_name'], list):
             cat_list = config['cat_file_name']
             if len(cat_list) == 0:

--- a/piff/knn_interp.py
+++ b/piff/knn_interp.py
@@ -141,11 +141,7 @@ class kNNInterp(Interp):
             if star.fit is None:
                 fit = StarFit(yi)
             else:
-                try:
-                    fit = star.fit.newParams(yi)
-                except TypeError:
-                    logger.info('Warning, stars interpolated to wrong number of params! %s', len(fit))
-                    fit = StarFit(yi)
+                fit = star.fit.newParams(yi)
             star_list_fitted.append(Star(star.data, fit))
         return star_list_fitted
 

--- a/piff/mean_interp.py
+++ b/piff/mean_interp.py
@@ -51,8 +51,6 @@ class Mean(Interp):
         """
         if self.mean is None:
             return star
-        elif star.fit is None:
-            fit = StarFit(self.mean)
         else:
             fit = star.fit.newParams(self.mean)
         return Star(star.data, fit)

--- a/piff/model.py
+++ b/piff/model.py
@@ -81,12 +81,7 @@ class Model(object):
 
         :returns:       Star instance with the appropriate initial fit values
         """
-        # If implemented, update the flux to something close to right.
-        if hasattr(self, 'reflux'):
-            star = self.reflux(star, fit_center=False, logger=logger)
-        else:
-            star = star.withFlux(np.sum(star.data.image.array))
-        return star
+        raise NotImplementedError("Derived classes must define the initialize function")
 
     def normalize(self, star):
         """Make sure star.fit.params are normalized properly.

--- a/piff/model.py
+++ b/piff/model.py
@@ -23,11 +23,6 @@ from .util import write_kwargs, read_kwargs
 from .star import Star, StarData
 
 
-# Raise this if there's a failure in the Model.fit() method.
-class ModelFitError(Exception):
-    pass
-
-
 class Model(object):
     """The base class for modeling a single PSF (i.e. no interpolation yet)
 

--- a/piff/model.py
+++ b/piff/model.py
@@ -18,9 +18,10 @@
 
 from __future__ import print_function
 import numpy as np
+import galsim
 
 from .util import write_kwargs, read_kwargs
-from .star import Star, StarData
+from .star import Star, StarData, StarFit
 
 
 class Model(object):
@@ -103,6 +104,61 @@ class Model(object):
         :returns:      New Star instance with updated fit information
         """
         raise NotImplementedError("Derived classes must define the fit function")
+
+    def reflux(self, star, fit_center=True, logger=None):
+        """Fit the Model to the star's data, varying only the flux (and
+        center, if it is free).  Flux and center are updated in the Star's
+        attributes.  This is a single-step solution if only solving for flux,
+        otherwise an iterative operation.  DOF in the result assume
+        only flux (& center) are free parameters.
+
+        :param star:        A Star instance
+        :param fit_center:  If False, disable any motion of center
+        :param logger:      A logger object for logging debug info. [default: None]
+
+        :returns:           New Star instance, with updated flux, center, chisq, dof
+        """
+        logger = galsim.config.LoggerWrapper(logger)
+        logger.debug("Reflux for star:")
+        logger.debug("    flux = %s",star.fit.flux)
+        logger.debug("    center = %s",star.fit.center)
+        logger.debug("    props = %s",star.data.properties)
+        logger.debug("    image = %s",star.data.image)
+        #logger.debug("    image = %s",star.data.image.array)
+        #logger.debug("    weight = %s",star.data.weight.array)
+        logger.debug("    image center = %s",star.data.image(star.data.image.center))
+        logger.debug("    weight center = %s",star.data.weight(star.data.weight.center))
+
+        image, weight, u, v = star.data.getDataVector(include_zero_weight=True)
+        model = self.draw(star).image.array.flatten()
+
+        WIM = weight * image * model
+        WMM = weight * model**2
+
+        f_data = np.sum(WIM)
+        f_model = np.sum(WMM)
+        flux_ratio = f_data / f_model
+
+        if fit_center and self._centered:
+            ushift = np.sum(WIM * u)/f_data - np.sum(WMM * u)/f_model
+            vshift = np.sum(WIM * v)/f_data - np.sum(WMM * v)/f_model
+            new_center = (star.fit.center[0] + ushift,
+                          star.fit.center[1] + vshift)
+        else:
+            new_center = star.fit.center
+
+        # new_chisq ignores centroid shift, but close enough.
+        new_chisq = np.sum(weight * (image - flux_ratio*model)**2)
+        new_dof = np.count_nonzero(weight) - 6
+        logger.debug("    new_chisq = %s",new_chisq)
+        logger.debug("    new_dof = %s",new_dof)
+
+        return Star(star.data, StarFit(star.fit.params,
+                                       flux = star.fit.flux * flux_ratio,
+                                       center = new_center,
+                                       chisq = new_chisq,
+                                       dof = new_dof,
+                                       params_var = star.fit.params_var))
 
     def draw(self, star, copy_image=True):
         """Draw the model on the given image.

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -43,6 +43,7 @@ optical_templates = {
 class Optical(Model):
 
     _method = 'no_pixel'
+    _centered = True
 
     def __init__(self, template=None, logger=None, **kwargs):
         """Initialize the Optical Model

--- a/piff/outliers.py
+++ b/piff/outliers.py
@@ -344,10 +344,9 @@ class ChisqOutliers(Outliers):
         if not self.include_reserve:
             good_stars += [ s for s in stars if s.is_reserve ]
 
-        if nremoved > 0:
-            logger.debug("chisq = %s",chisq[~(chisq <= thresh)])
-            logger.debug("thresh = %s",thresh[~(chisq <= thresh)])
-            logger.debug("flux = %s",[s.flux for g,s in zip(good,stars) if not g])
+        logger.debug("chisq = %s",chisq[~(chisq <= thresh)])
+        logger.debug("thresh = %s",thresh[~(chisq <= thresh)])
+        logger.debug("flux = %s",[s.flux for g,s in zip(good,stars) if not g])
 
         assert nremoved == len(stars) - len(good_stars)
         return good_stars, nremoved

--- a/piff/output.py
+++ b/piff/output.py
@@ -55,7 +55,7 @@ class Output(object):
         return output_handler
 
     @classmethod
-    def parseKwargs(cls, config_output, logger=None):  # pragma: no cover
+    def parseKwargs(cls, config_output, logger=None):
         """Parse the output field of a configuration dict and return the kwargs to use for
         initializing an instance of the class.
 

--- a/piff/output.py
+++ b/piff/output.py
@@ -108,8 +108,6 @@ class OutputFile(Output):
         :param stats_list:  Optionally a list of Stats instances to also output. [default: None]
         :param logger:      A logger object for logging debug info. [default: None]
         """
-        # TODO: could probably also add an option to output one or more catalogs with information
-        #       about the star lists, measured size/shape, etc.
         self.file_name = file_name
         if stats_list is not None:
             self.stats_list = stats_list

--- a/piff/pixelgrid.py
+++ b/piff/pixelgrid.py
@@ -26,7 +26,6 @@ import warnings
 from galsim import Lanczos
 from .model import Model
 from .star import Star, StarData, StarFit
-from .util import hsm
 
 class PixelGrid(Model):
 
@@ -140,7 +139,7 @@ class PixelGrid(Model):
 
         # Calculate the second moment to initialize an initial Gaussian profile.
         # hsm returns: flux, x, y, sigma, g1, g2, flag
-        sigma = hsm(star)[3]
+        sigma = star.hsm[3]
 
         # Create an initial parameter array using a Gaussian profile.
         u = np.arange( -self._origin[0], self.size-self._origin[0]) * self.scale

--- a/piff/polynomial_interp.py
+++ b/piff/polynomial_interp.py
@@ -62,9 +62,9 @@ class Polynomial(Interp):
                             the signature of numpy.polynomial.polynomial.polyval2d
         """
         if order is None and orders is None:
-            raise AttributeError("Either order or orders is required")
+            raise TypeError("Either order or orders is required")
         if order is not None and orders is not None:
-            raise AttributeError("Cannot provide both order and orders")
+            raise TypeError("Cannot provide both order and orders")
         self.degenerate_points = False
         self.order = order
         self.orders = orders

--- a/piff/polynomial_interp.py
+++ b/piff/polynomial_interp.py
@@ -405,8 +405,5 @@ class Polynomial(Interp):
         """
         pos = self.getProperties(star)
         p = [self._interpolationModel(pos, coeff) for coeff in self.coeffs]
-        if star.fit is None:
-            fit = StarFit(p)
-        else:
-            fit = star.fit.newParams(p)
+        fit = star.fit.newParams(p)
         return Star(star.data, fit)

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -319,17 +319,10 @@ class PSF(object):
             import pickle
         logger = galsim.config.LoggerWrapper(logger)
 
-        # Start with the chipnums, which may be int or str type.
-        # Assume they are all the same type at least.
+        # Start with the chipnums
         chipnums = list(self.wcs.keys())
         cols = [ chipnums ]
-        if np.dtype(type(chipnums[0])).kind in np.typecodes['AllInteger']:
-            dtypes = [ ('chipnums', int) ]
-        else:
-            # coerce to string, just in case it's something else.
-            chipnums = [ str(c) for c in chipnums ]
-            max_len = np.max([ len(c) for c in chipnums ])
-            dtypes = [ ('chipnums', bytes, max_len) ]
+        dtypes = [ ('chipnums', int) ]
 
         # GalSim WCS objects can be serialized via pickle
         wcs_str = [ base64.b64encode(pickle.dumps(w)) for w in self.wcs.values() ]
@@ -341,8 +334,6 @@ class PSF(object):
         nchunks = max_len // chunk_size + 1
         cols.append( [nchunks]*len(chipnums) )
         dtypes.append( ('nchunks', int) )
-        if nchunks > 1:
-            logger.debug('Using %d chunks for the wcs pickle string',nchunks)
 
         # Update to size of chunk we actually need.
         chunk_size = (max_len + nchunks - 1) // nchunks

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -86,7 +86,7 @@ class PSF(object):
         return psf
 
     @classmethod
-    def parseKwargs(cls, config_psf, logger):
+    def parseKwargs(cls, config_psf, logger=None):
         """Parse the psf field of a configuration dict and return the kwargs to use for
         initializing an instance of the class.
 
@@ -98,10 +98,7 @@ class PSF(object):
 
         :returns: a kwargs dict to pass to the initializer
         """
-        kwargs = {}
-        kwargs.update(config_psf)
-        kwargs.pop('type',None)
-        return kwargs
+        raise NotImplementedError("Derived classes must define the parseKwargs function")
 
     def draw(self, x, y, chipnum=0, flux=1.0, offset=(0,0), stamp_size=48, image=None,
              logger=None, **kwargs):
@@ -288,22 +285,6 @@ class PSF(object):
         psf._finish_read(fits, extname, logger)
 
         return psf
-
-    def _finish_read(self, fits, extname, logger):
-        """Finish up the read process
-
-        In the base class, this is a no op, but for classes that need to do something else at
-        the end of the read process, this hook is available to be overridden.
-
-        (E.g. composite psf classes might copy the stars, wcs, pointing information into the
-        various components.)
-
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The name of the extension with the psf information.
-        :param logger:      A logger object for logging debug info.
-        """
-        pass
-
 
     def writeWCS(self, fits, extname, logger):
         """Write the WCS information to a FITS file.

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -144,7 +144,7 @@ class PSF(object):
         for key in self.extra_interp_properties:
             if key not in kwargs:
                 raise TypeError("Extra interpolation property %r is required"%key)
-            properties = kwags.pop(key)
+            properties[key] = kwargs.pop(key)
         if len(kwargs) != 0:
             raise TypeError("draw got an unexpecte keyword argument %r"%kwargs.keys()[0])
 

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -88,7 +88,8 @@ class SimplePSF(PSF):
         kwargs.pop('type',None)
 
         for key in ['model', 'interp']:
-            if key not in kwargs:
+            if key not in kwargs:  # pragma: no cover
+                # This actually is covered, but for some reason, codecov thinks it isn't.
                 raise ValueError("%s field is required in psf field for type=Simple"%key)
 
         # make a Model object to use for the individual stellar fitting

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -66,6 +66,10 @@ class SimplePSF(PSF):
             'chisq_thresh': self.chisq_thresh,
             'max_iter': self.max_iter,
         }
+        self.chisq = 0.
+        self.last_delta_chisq = 0.
+        self.dof = 0
+        self.nremoved = 0
 
     @classmethod
     def parseKwargs(cls, config_psf, logger):
@@ -272,15 +276,12 @@ class SimplePSF(PSF):
         :param logger:      A logger object for logging debug info.
         """
         logger = galsim.config.LoggerWrapper(logger)
-        if hasattr(self, 'chisq'):
-            chisq_dict = {
-                'chisq' : self.chisq,
-                'last_delta_chisq' : self.last_delta_chisq,
-                'dof' : self.dof,
-                'nremoved' : self.nremoved,
-            }
-        else:
-            chisq_dict = {}
+        chisq_dict = {
+            'chisq' : self.chisq,
+            'last_delta_chisq' : self.last_delta_chisq,
+            'dof' : self.dof,
+            'nremoved' : self.nremoved,
+        }
         write_kwargs(fits, extname + '_chisq', chisq_dict)
         logger.debug("Wrote the chisq info to extension %s",extname + '_chisq')
         self.model.write(fits, extname + '_model')

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -263,60 +263,7 @@ class SimplePSF(PSF):
         self.model.normalize(star)
         return star
 
-    def drawStarList(self, stars, copy_image=True):
-        """Generate PSF images for given stars. Takes advantage of
-        interpolateList for significant speedup with some interpolators.
-
-        .. note::
-
-            If the stars already have the fit parameters calculated, then this will trust
-            those values and not redo the interpolation.  If this might be a concern, you can
-            force the interpolation to be redone by running
-
-                >>> stars = psf.interpolateList(stars)
-
-            before running `drawStarList`.
-
-        :param stars:       List of Star instances holding information needed
-                            for interpolation as well as an image/WCS into
-                            which PSF will be rendered.
-        :param copy_image:  If False, will use the same image object.
-                            If True, will copy the image and then overwrite it.
-                            [default: True]
-
-        :returns:           List of Star instances with its image filled with
-                            rendered PSF
-        """
-        if any(star.fit is None or star.fit.params is None for star in stars):
-            stars = self.interpolateStarList(stars)
-        stars = [self.model.draw(star, copy_image=copy_image) for star in stars]
-        return stars
-
-    def drawStar(self, star, copy_image=True):
-        """Generate PSF image for a given star.
-
-        .. note::
-
-            If the star already has the fit parameters calculated, then this will trust
-            those values and not redo the interpolation.  If this might be a concern, you can
-            force the interpolation to be redone by running
-
-                >>> star = psf.interpolateList(star)
-
-            before running `drawStar`.
-
-        :param star:        Star instance holding information needed for interpolation as
-                            well as an image/WCS into which PSF will be rendered.
-        :param copy_image:  If False, will use the same image object.
-                            If True, will copy the image and then overwrite it.
-                            [default: True]
-
-        :returns:           Star instance with its image filled with rendered PSF
-        """
-        # Interpolate parameters to this position/properties (if not already done):
-        if star.fit is None or star.fit.params is None:
-            star = self.interpolateStar(star)
-        # Render the image
+    def _drawStar(self, star, copy_image=True):
         return self.model.draw(star, copy_image=copy_image)
 
     def _finish_write(self, fits, extname, logger):

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 import numpy as np
 import galsim
 
-from .model import Model, ModelFitError
+from .model import Model
 from .interp import Interp
 from .outliers import Outliers
 from .psf import PSF
@@ -171,7 +171,7 @@ class SimplePSF(PSF):
             for star in use_stars:
                 try:
                     star = fit_fn(star, logger=logger)
-                except ModelFitError as e:  # pragma: no cover
+                except Exception as e:  # pragma: no cover
                     logger.warning("Failed fitting star at %s.", star.image_pos)
                     logger.warning("Excluding it from this iteration.")
                     logger.warning("  -- Caught exception: %s", e)

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -42,8 +42,7 @@ class SimplePSF(PSF):
         :param outliers:    Optionally, an Outliers instance used to remove outliers.
                             [default: None]
         :param extra_interp_properties: A list of any extra properties that will be used for
-                            the interpolation in addition to (u,v).
-                            [default: None]
+                                        the interpolation in addition to (u,v). [default: None]
         :param chisq_thresh: Change in reduced chisq at which iteration will terminate.
                             [default: 0.1]
         :param max_iter:    Maximum number of iterations to try. [default: 30]
@@ -58,7 +57,7 @@ class SimplePSF(PSF):
         self.chisq_thresh = chisq_thresh
         self.max_iter = max_iter
         self.kwargs = {
-            # These are junk entries that will be overwritten.
+            # model and interp are junk entries that will be overwritten.
             # TODO: Come up with a nicer mechanism for specifying items that can be overwritten
             #       in the _finish_read function.
             'model': 0,

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -195,19 +195,18 @@ class SimplePSF(PSF):
 
             # Refit and recenter all stars, collect stats
             logger.debug("             Re-fluxing stars")
-            if hasattr(self.model, 'reflux'):
-                new_stars = []
-                for s in self.stars:
-                    try:
-                        new_star = self.model.reflux(s, logger=logger)
-                    except Exception as e:  # pragma: no cover
-                        logger.warning("Failed trying to reflux star at %s.  Excluding it.",
-                                       s.image_pos)
-                        logger.warning("  -- Caught exception: %s", e)
-                        nremoved += 1
-                    else:
-                        new_stars.append(new_star)
-                self.stars = new_stars
+            new_stars = []
+            for s in self.stars:
+                try:
+                    new_star = self.model.reflux(s, logger=logger)
+                except Exception as e:  # pragma: no cover
+                    logger.warning("Failed trying to reflux star at %s.  Excluding it.",
+                                    s.image_pos)
+                    logger.warning("  -- Caught exception: %s", e)
+                    nremoved += 1
+                else:
+                    new_stars.append(new_star)
+            self.stars = new_stars
 
             # Perform outlier rejection, but not on first iteration for degenerate solvers.
             if self.outliers and (iteration > 0 or not degenerate_points):

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -123,19 +123,22 @@ class SingleChipPSF(PSF):
         # update stars from psf outlier rejection
         self.stars = [ star for chipnum in chipnums for star in self.psf_by_chip[chipnum].stars ]
 
-    def drawStar(self, star, copy_image=True):
-        """Generate PSF image for a given star.
+    def interpolateStar(self, star):
+        """Update the star to have the current interpolated fit parameters according to the
+        current PSF model.
 
-        :param star:        Star instance holding information needed for interpolation as
-                            well as an image/WCS into which PSF will be rendered.
-        :param copy_image:          If False, will use the same image object.
-                                    If True, will copy the image and then overwrite it.
-                                    [default: True]
+        :param star:        Star instance to update.
 
-        :returns:           Star instance with its image filled with rendered PSF
+        :returns:           Star instance with its fit parameters updated.
         """
         if 'chipnum' not in star.data.properties:
-            raise ValueError("SingleChip drawStar requires the star to have a chipnum property")
+            raise ValueError("SingleChip requires the star to have a chipnum property")
+        chipnum = star['chipnum']
+        return self.psf_by_chip[chipnum].interpolateStar(star)
+
+    def _drawStar(self, star, copy_image=True):
+        if 'chipnum' not in star.data.properties:
+            raise ValueError("SingleChip requires the star to have a chipnum property")
         chipnum = star['chipnum']
         return self.psf_by_chip[chipnum].drawStar(star, copy_image=copy_image)
 

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -49,9 +49,8 @@ class SingleChipPSF(PSF):
                             (This will be turned into nchips copies of the provided object.)
         :param nproc:       How many multiprocessing processes to use for running multiple
                             chips at once. [default: 1]
-        :param extra_interp_properties:     A list of any extra properties that will be used for
-                                            the interpolation in addition to (u,v).
-                                            [default: None]
+        :param extra_interp_properties: A list of any extra properties that will be used for
+                                        the interpolation in addition to (u,v). [default: None]
         """
         self.single_psf = single_psf
         self.nproc = nproc

--- a/piff/star.py
+++ b/piff/star.py
@@ -803,43 +803,6 @@ class StarData(object):
             mask = wt != 0.
             return pix[mask], wt[mask], u[mask], v[mask]
 
-    def setData(self, data, include_zero_weight=False, copy_image=True):
-        """Return new StarData with data values replaced by elements of provided 1d array.
-        The array should match the ordering of the one that is produced by getDataVector().
-
-        :param data:                A 1d numpy array with new values for the image data.
-        :param include_zero_weight: If True, the data array includes all pixels.
-                                    If False, it only includes the pixels with weight > 0.
-                                    [default: False]
-        :param copy_image:          If False, will use the same image object.
-                                    If True, will copy the image and then overwrite it.
-                                    [default: True]
-
-        :returns:    New StarData structure
-        """
-        # ??? Do we need a way to fill in pixels that have zero weight and
-        # don't get passed out by getDataVector()???
-
-        if copy_image:
-            newimage = self.image.copy()
-        else:
-            newimage = self.image
-        if include_zero_weight:
-            newimage.array[:,:] = data.reshape(newimage.array.shape)
-        else:
-            ignore = self.weight.array==0.
-            newimage.array[ignore] = 0.
-            newimage.array[~ignore] = data
-
-        return StarData(image=newimage,
-                        image_pos=self.image_pos,
-                        weight=self.weight,
-                        orig_weight=self.orig_weight,
-                        pointing=self.pointing,
-                        field_pos=self.field_pos,
-                        properties=self.properties,
-                        _xyuv_set=True)
-
     def addPoisson(self, signal=None, gain=None):
         """Return new StarData with the weight values altered to reflect
         Poisson shot noise from a signal source, e.g. when the weight

--- a/piff/star.py
+++ b/piff/star.py
@@ -676,11 +676,8 @@ class StarData(object):
             self.weight = galsim.Image(image.bounds, init_value=1, wcs=image.wcs, dtype=float)
         elif type(weight) in [int, float]:
             self.weight = galsim.Image(image.bounds, init_value=weight, wcs=image.wcs, dtype=float)
-        elif isinstance(weight, galsim.Image):
-            # Work-around for bug in GalSim 1.3
-            self.weight = galsim.Image(weight, dtype=float, wcs=weight.wcs)
         else:
-            self.weight = galsim.Image(weight, dtype=float)
+            self.weight = galsim.Image(weight, dtype=float, wcs=weight.wcs)
 
         if orig_weight is None:
             self.orig_weight = self.weight
@@ -738,11 +735,8 @@ class StarData(object):
                     properties['ra'] = sky_pos.ra / galsim.hours
                 if 'dec' not in properties:
                     properties['dec'] = sky_pos.dec / galsim.degrees
-            if galsim.__version__ >= '2.0':
-                u, v = pointing.project(sky_pos)
-                return galsim.PositionD(u/galsim.arcsec, v/galsim.arcsec)
-            else:
-                return pointing.project(sky_pos)
+            u, v = pointing.project(sky_pos)
+            return galsim.PositionD(u/galsim.arcsec, v/galsim.arcsec)
         else:
             return wcs.toWorld(image_pos)
 

--- a/piff/star.py
+++ b/piff/star.py
@@ -244,7 +244,7 @@ class Star(object):
         # Check that input parameters are valid
         for param in ['x', 'y', 'u', 'v']:
             if eval(param) is not None and param in properties:
-                raise AttributeError("%s may not be given both as a kwarg and in properties"%param)
+                raise TypeError("%s may not be given both as a kwarg and in properties"%param)
         properties = properties.copy()  # So we can modify it and not mess up the caller.
         x = properties.pop('x', x)
         y = properties.pop('y', y)
@@ -252,13 +252,13 @@ class Star(object):
         v = properties.pop('v', v)
         properties.update(kwargs)  # Add any extra kwargs into properties
         if (x is None) != (y is None):
-            raise AttributeError("Either x and y must both be given, or neither.")
+            raise TypeError("Either x and y must both be given, or neither.")
         if (u is None) != (v is None):
-            raise AttributeError("Either u and v must both be given, or neither.")
+            raise TypeError("Either u and v must both be given, or neither.")
         if x is None and u is None:
-            raise AttributeError("Some kind of position must be given.")
+            raise TypeError("Some kind of position must be given.")
         if wcs is not None and scale is not None:
-            raise AttributeError("Scale is invalid when also providing wcs.")
+            raise TypeError("Scale is invalid when also providing wcs.")
 
         # Figure out what the wcs should be if not provided
         if wcs is None:
@@ -289,10 +289,9 @@ class Star(object):
         if image.wcs is None:
             image.wcs = wcs
         if weight is not None:
-            weight = galsim.Image(weight.array.copy(), scale=image.scale)
+            weight = galsim.Image(weight.array.copy(), wcs=image.wcs)
             weight.setCenter(int(x+0.5), int(y+0.5))
 
-            
         # Build the StarData instance
         data = StarData(image, image_pos, field_pos=field_pos, properties=properties, 
                         pointing=pointing, weight=weight)        
@@ -904,7 +903,6 @@ class StarFit(object):
         self.b = b
         self.chisq = chisq
         self.dof = dof
-        return
 
     @property
     def alpha(self):

--- a/piff/star.py
+++ b/piff/star.py
@@ -934,14 +934,3 @@ class StarFit(object):
     def copy(self):
         return StarFit(self.params, self.flux, self.center, self.A, self.b,
                        self.chisq, self.dof)
-
-    def __getitem__(self, key):
-        """Get a property of the star fit.
-
-        Looks at params to get the property
-
-        :param key:     The name of the property to return
-
-        :returns: the value of the given property.
-        """
-        return self.params[key]

--- a/piff/star.py
+++ b/piff/star.py
@@ -375,12 +375,14 @@ class Star(object):
 
         :returns: the arrays coords and params
         """
-        if extname not in fits: raise RuntimeError('{0} not found in FITS object'.format(extname))
+        if extname not in fits:
+            raise IOError('{0} not found in FITS object'.format(extname))
         colnames = fits[extname].get_colnames()
 
         columns = ['u', 'v', 'params']
         for key in columns:
-            if key not in colnames: raise RuntimeError('{0} not found in table'.format(key))
+            if key not in colnames:
+                raise IOError('{0} not found in table'.format(key))
 
         data = fits[extname].read(columns=columns)
         coords = np.array([data['u'], data['v']]).T
@@ -698,7 +700,7 @@ class StarData(object):
         # Make sure the user didn't provide their own x,y,u,v in properties.
         for key in ['x', 'y', 'u', 'v']:
             if properties is not None and key in properties and not _xyuv_set:
-                raise AttributeError("Cannot provide property %s in properties dict."%key)
+                raise TypeError("Cannot provide property %s in properties dict."%key)
 
         self.properties['x'] = self.image_pos.x
         self.properties['y'] = self.image_pos.y
@@ -727,7 +729,7 @@ class StarData(object):
         # Calculate the field_pos, the position in the fov coordinates
         if wcs.isCelestial():
             if pointing is None:
-                raise AttributeError("If the image uses a CelestialWCS then pointing is required.")
+                raise TypeError("If the image uses a CelestialWCS then pointing is required.")
             sky_pos = wcs.toWorld(image_pos)
             if properties is not None:
                 if 'ra' not in properties:
@@ -924,7 +926,7 @@ class StarFit(object):
         """
         npp = np.array(params)
         if self.params is not None and npp.shape != self.params.shape:
-            raise TypeError('new StarFit parameters do not match dimensions of old ones')
+            raise ValueError('new StarFit parameters do not match dimensions of old ones')
         flux = kwargs.pop('flux', self.flux)
         center = kwargs.pop('center', self.center)
         return StarFit(npp, flux=flux, center=center, **kwargs)

--- a/piff/star.py
+++ b/piff/star.py
@@ -320,12 +320,8 @@ class Star(object):
             prop_keys.remove(key)
         # Add any remaining properties
         for key in prop_keys:
-            if hasattr(stars[0].data.properties[key], '__iter__'):
-                dtypes.append( (key, float, len(stars[0].data.properties[key])))
-                cols.append( [ s.data.properties[key] for s in stars ])
-            else:
-                dtypes.append( (key, float) )
-                cols.append( [ s.data.properties[key] for s in stars ] )
+            dtypes.append( (key, float) )
+            cols.append( [ s.data.properties[key] for s in stars ] )
 
         # Add the local WCS values
         dtypes.extend( [('dudx', float), ('dudy', float), ('dvdx', float), ('dvdy', float) ] )

--- a/piff/star.py
+++ b/piff/star.py
@@ -852,48 +852,6 @@ class StarData(object):
                         properties=dict(self.properties, gain=gain),
                         _xyuv_set = True)
 
-    def maskPixels(self, mask):
-        """Return new StarData with weight nulled at pixels marked as False in the mask.
-        Note that this cannot un-mask any previously nulled pixels.
-
-        :param mask:      Boolean array with False marked in pixels that should henceforth
-                          be ignored in fitting.
-                          If this is a 2d array it is assumed to match the weight image.
-                          If it is a 1d array, it is assumed to match the vectors returned by
-                          getDataVector().  If None, the self.image is used, clipped from below
-
-        :returns:         A new StarData instance with updated weight array.
-        """
-
-        # Mark the pixels that are not already worthless
-        use = self.weight.array!=0.
-
-        # Get the signal data
-        if len(mask.shape)==2:
-            m = mask[use]
-        else:
-            # Insert 1d vector into currently valid pixels
-            m = mask
-
-        # Zero appropriate weight pixels in new copy
-        weight = self.weight.copy()
-        weight.array[use] = np.where(m, self.weight.array[use], 0.)
-
-        if self.orig_weight != self.weight:
-            orig_weight = self.orig_weight.copy()
-            orig_weight.array[use] = np.where(m, self.orig_weight.array[use], 0.)
-        else:
-            orig_weight = weight
-
-        # Return new object
-        return StarData(image=self.image,
-                        image_pos=self.image_pos,
-                        weight=weight,
-                        orig_weight=orig_weight,
-                        pointing=self.pointing,
-                        properties=self.properties,
-                        _xyuv_set=True)
-
 
 class StarFit(object):
     """Class to hold the results of fitting a Model to some StarData, or specify

--- a/piff/star_stats.py
+++ b/piff/star_stats.py
@@ -142,6 +142,8 @@ class StarStats(Stats):
 
         :returns: fig, ax
         """
+        if not hasattr(self, 'indices'):
+            raise RuntimeError("Must call compute before calling plot or write")
 
         # make figure
         from matplotlib.figure import Figure

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -154,7 +154,7 @@ class Stats(object):
         logger = galsim.config.LoggerWrapper(logger)
         # measure moments with Gaussian on image
         logger.debug("Measuring shapes of real stars")
-        shapes_truth = np.array([ piff.util.hsm(star) for star in stars ])
+        shapes_truth = np.array([ star.hsm for star in stars ])
         for star, shape in zip(stars, shapes_truth):
             logger.debug("real shape for star at %s is %s",star.image_pos, shape)
 
@@ -164,7 +164,7 @@ class Stats(object):
 
         # generate the model stars and measure moments
         logger.debug("Generating and Measuring Model Stars")
-        shapes_model = np.array([ piff.util.hsm(star) for star in psf.drawStarList(stars)])
+        shapes_model = np.array([ star.hsm for star in psf.drawStarList(stars)])
         for star, shape in zip(stars, shapes_model):
             logger.debug("model shape for star at %s is %s",star.image_pos, shape)
 

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -40,11 +40,11 @@ class Stats(object):
     else with it besides just write it to a file.
     """
     @classmethod
-    def process(cls, config_stats, logger):
+    def process(cls, config_stats, logger=None):
         """Parse the stats field of the config dict.
 
         :param config_stats:    The configuration dict for the stats field.
-        :param logger:          A logger object for logging debug info.
+        :param logger:          A logger object for logging debug info. [default: None]
 
         :returns: a Stats instance
         """
@@ -250,9 +250,6 @@ class ShapeHistogramsStats(Stats):
 
         :returns: fig, ax
         """
-        if not hasattr(self, 'T'):
-            raise RuntimeError("Shape Histogram has not been computed yet.  Cannot plot.")
-
         from matplotlib.figure import Figure
         fig = Figure(figsize = (15,10))
         # In matplotlib 2.0, this will be
@@ -273,6 +270,9 @@ class ShapeHistogramsStats(Stats):
         axs[1, 2].set_xlabel(r'$g_{2, data} - g_{2, model}$')
         if self.skip:
             return fig, axs
+
+        if not hasattr(self, 'T'):
+            raise RuntimeError("Must call compute before calling plot or write")
 
         # some defaults for the kwargs
         if 'histtype' not in kwargs:
@@ -513,6 +513,9 @@ class RhoStats(Stats):
         if self.skip:
             return fig,axs
 
+        if not hasattr(self, 'rho1'):
+            raise RuntimeError("Must call compute before calling plot or write")
+
         # Left plot is rho1,3,4
         rho1 = self._plot_single(axs[0], self.rho1, 'blue', 'o')
         rho3 = self._plot_single(axs[0], self.rho3, 'green', 's', 0.1)
@@ -609,6 +612,8 @@ class HSMCatalogStats(Stats):
             file_name = self.file_name
         if file_name is None:
             raise ValueError("No file_name specified for %s"%self.__class__.__name__)
+        if not hasattr(self, 'u'):
+            raise RuntimeError("Must call compute before calling write")
 
         logger.warning("Writing HSM catalog to file %s",file_name)
 

--- a/piff/twod_stats.py
+++ b/piff/twod_stats.py
@@ -285,10 +285,10 @@ class TwoDHistStats(Stats):
             ui, vi = unique
 
             sample = z[(indx_u == ui) & (indx_v == vi)]
-            if len(sample) > 0:
-                value = self.reducing_function(sample)
-                C[vi, ui] = value
-                C.mask[vi, ui] = 0
+            assert len(sample) > 0  # This is ensured by how we calculate unique_indx
+            value = self.reducing_function(sample)
+            C[vi, ui] = value
+            C.mask[vi, ui] = 0
 
         return C
 
@@ -590,9 +590,9 @@ class WhiskerStats(Stats):
             ui, vi = unique
 
             sample = z[(indx_u == ui) & (indx_v == vi)]
-            if len(sample) > 0:
-                value = self.reducing_function(sample)
-                C[vi, ui] = value
-                C.mask[vi, ui] = 0
+            assert len(sample) > 0
+            value = self.reducing_function(sample)
+            C[vi, ui] = value
+            C.mask[vi, ui] = 0
 
         return C

--- a/piff/twod_stats.py
+++ b/piff/twod_stats.py
@@ -66,6 +66,8 @@ class TwoDHistStats(Stats):
         :param logger:      A logger object for logging debug info. [default: None]
         """
         logger = galsim.config.LoggerWrapper(logger)
+        self.twodhists = {}
+
         # get the shapes
         logger.info("Measuring Star and Model Shapes")
         positions, shapes_truth, shapes_model = self.measureShapes(psf, stars, logger=logger)
@@ -109,7 +111,6 @@ class TwoDHistStats(Stats):
 
         # compute the arrays
         logger.info("Computing TwoDHist arrays")
-        self.twodhists = {}
 
         # throw in coordinates for good measure
         self.twodhists['u'] = self._array_to_2dhist(u, indx_u, indx_v, unique_indx)
@@ -187,6 +188,9 @@ class TwoDHistStats(Stats):
         axs[2, 2].set_title('dg2')
         if self.skip:
             return fig, axs
+
+        if not hasattr(self, 'twodhists'):
+            raise RuntimeError("Must call compute before calling plot or write")
 
         # make the colormaps
         logger.info("Creating TwoDHist colormaps")
@@ -429,6 +433,7 @@ class WhiskerStats(Stats):
         :param logger:      A logger object for logging debug info. [default: None]
         """
         logger = galsim.config.LoggerWrapper(logger)
+        self.twodhists = {}
 
         # get the shapes
         logger.info("Measuring Star and Model Shapes")
@@ -486,7 +491,6 @@ class WhiskerStats(Stats):
 
         # compute the arrays
         logger.info("Computing TwoDHist arrays")
-        self.twodhists = {}
 
         self.twodhists['u'] = self._array_to_2dhist(u, indx_u, indx_v, unique_indx)
         self.twodhists['v'] = self._array_to_2dhist(v, indx_u, indx_v, unique_indx)
@@ -538,6 +542,9 @@ class WhiskerStats(Stats):
         axs[1].set_ylabel('v')
         if self.skip:
             return fig, axs
+
+        if not hasattr(self, 'twodhists'):
+            raise RuntimeError("Must call compute before calling plot or write")
 
         # make the plots
         logger.info("Creating TwoDHist whiskerplots")

--- a/piff/util.py
+++ b/piff/util.py
@@ -80,9 +80,11 @@ def make_dtype(key, value):
         t = t.replace('U','S')
     elif dt.kind in ['S','U']:
         t = bytes
-    else:
+    else:  # pragma: no cover
         # Other objects should be manually serialized by the initializer or the finish_read and
         # finish_write functions.
+        # (We don't hit this in tests, so don't cover it, but if it happens in development,
+        #  this helps produce a more sensible error.)
         raise ValueError("Cannot serialize object of type %s"%t)
     dt = make_dt_tuple(key, t, size)
 
@@ -103,11 +105,8 @@ def adjust_value(value, dtype):
         # if no size or size == 0, then just use t as the type.
         return t(value)
     elif t == bytes:
-        # Strings may need to be encoded.
-        try:
-            return value.encode()
-        except AttributeError:
-            return value
+        # Py2.7 strings need to be encoded.
+        return value.encode()
     else:
         try:
             # Arrays of strings may need to be encoded.

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -10,24 +10,6 @@ exclude_lines =
     # If you put this in a comment, you can manually exclude code from being covered.
     pragma: no cover
 
-    # Don't complain about missing debug-only code:
-    logger.debug
-
-    # Don't complain if tests don't hit defensive checks of user input
-    raise NotImplementedError
-    raise ValueError
-    raise RuntimeError
-    raise TypeError
-    raise AttributeError
-    raise IndexError
-    raise IOError
-    raise KeyError
-
-    # Don't complain about not hitting warning code
-    if suppress_warnings is False:
-    import warnings
-    warnings.warn
-
     # Don't complain if non-runnable code isn't run:
     if False:
     if 0:
@@ -37,6 +19,3 @@ exclude_lines =
     except .*KeyboardInterrupt
     except IOError
     except OSError
-
-    # Or code for special cases of older versions of things.
-    except ImportError

--- a/tests/output/.gitignore
+++ b/tests/output/.gitignore
@@ -2,3 +2,4 @@
 *.pdf
 *.png
 *.piff
+test_dir

--- a/tests/test_gsobject_model.py
+++ b/tests/test_gsobject_model.py
@@ -228,7 +228,7 @@ def test_center():
 
         # Measured centroid of PSF model should be close to 0,0
         star3 = mod.draw(star.withFlux(influx, (0,0)))
-        flux, cenx, ceny, sigma, e1, e2, flag = piff.util.hsm(star3)
+        flux, cenx, ceny, sigma, e1, e2, flag = star3.hsm
         print('HSM measurements: ',flux, cenx, ceny, sigma, g1, g2, flag)
         np.testing.assert_allclose(cenx, 0, atol=1.e-4)
         np.testing.assert_allclose(ceny, 0, atol=1.e-4)
@@ -282,7 +282,7 @@ def test_uncentered():
 
         # Measured centroid of PSF model should be close to u0, v0
         star3 = mod.draw(star.withFlux(influx, (0,0)))
-        flux, cenx, ceny, sigma, e1, e2, flag = piff.util.hsm(star3)
+        flux, cenx, ceny, sigma, e1, e2, flag = star3.hsm
         print('HSM measurements: ',flux, cenx, ceny, sigma, g1, g2, flag)
         np.testing.assert_allclose(cenx, u0, rtol=1.e-4)
         np.testing.assert_allclose(ceny, v0, rtol=1.e-4)

--- a/tests/test_gsobject_model.py
+++ b/tests/test_gsobject_model.py
@@ -829,7 +829,7 @@ def test_fail():
     g1 = 0.33
     g2 = -0.27
     flux = 15
-    noise = 2
+    noise = 2.
     seed = 1234
 
     psf = galsim.Moffat(half_light_radius=1.0, beta=2.5, trunc=3.0)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -198,6 +198,12 @@ def test_basic():
     assert len([s for s in reserve_stars if s['chipnum'] == 1]) == 0
     assert len([s for s in reserve_stars if s['chipnum'] == 2]) == 4
 
+    # If no stars, raise error
+    # (normally because all stars have errors, but easier to just limit to 0 to test this.)
+    config['nstars'] = 0
+    with np.testing.assert_raises(RuntimeError):
+        input = piff.Input.process(config, logger=logger)
+
 
 @timer
 def test_invalid():
@@ -209,9 +215,9 @@ def test_invalid():
 
     # Leaving off either image_file_name or cat_file_name is an error
     config = { 'image_file_name' : os.path.join('input',image_file) }
-    np.testing.assert_raises(AttributeError, piff.InputFiles, config)
+    np.testing.assert_raises(TypeError, piff.InputFiles, config)
     config = { 'cat_file_name': os.path.join('input',cat_file) }
-    np.testing.assert_raises(AttributeError, piff.InputFiles, config)
+    np.testing.assert_raises(TypeError, piff.InputFiles, config)
 
     # Invalid values for image or cat name
     config = { 'image_file_name' : os.path.join('input',image_file), 'cat_file_name' : 17 }
@@ -250,6 +256,10 @@ def test_invalid():
     np.testing.assert_raises(ValueError, piff.InputFiles, config)
     config = { 'dir' : 'input', 'image_file_name' : image_file, 'cat_file_name' : [] }
     np.testing.assert_raises(ValueError, piff.InputFiles, config)
+
+    # Missing nimages (required when using dict)
+    config = { 'image_file_name' : image_files_1, 'cat_file_name': cat_files }
+    np.testing.assert_raises(TypeError, piff.InputFiles, config)
 
 
 @timer
@@ -476,6 +486,8 @@ def test_cols():
     input = piff.InputFiles(dict(sky='sky', **base_config))
     np.testing.assert_raises(KeyError, input.getRawImageData, 0)
     input = piff.InputFiles(dict(gain='gain', **base_config))
+    np.testing.assert_raises(KeyError, input.getRawImageData, 0)
+    input = piff.InputFiles(dict(satur='satur', **base_config))
     np.testing.assert_raises(KeyError, input.getRawImageData, 0)
 
 

--- a/tests/test_knn_interp.py
+++ b/tests/test_knn_interp.py
@@ -169,7 +169,7 @@ def test_decam_wavefront():
     if __name__ == '__main__':
         logger = piff.config.setup_logger(verbose=2)
     else:
-        logger = None
+        logger = piff.config.setup_logger(log_file='output/test_decamlog')
     knn = piff.des.DECamWavefront(file_name, extname, logger=logger)
 
     n_samples = 2000
@@ -212,6 +212,14 @@ def test_decam_wavefront():
     np.testing.assert_array_almost_equal(y_predicted[:,0], y_misaligned[:,0] - misalignment['z04d'])
     np.testing.assert_array_almost_equal(y_predicted[:,5], y_misaligned[:,5] - misalignment['z09y'] * X[:,0])
     np.testing.assert_array_almost_equal(y_predicted[:,6], y_misaligned[:,6] - misalignment['z10x'] * X[:,1])
+
+    # Check shape of misalignment if array
+    np.testing.assert_raises(ValueError, knn.misalign_wavefront, knn.misalignment[:,:2])
+    np.testing.assert_raises(ValueError, knn.misalign_wavefront, knn.misalignment[:-1,:])
+
+    # empty dict is equivalent to no misalignment
+    knn.misalign_wavefront({})
+    np.testing.assert_equal(knn.misalignment, 0.)
 
 
 @timer

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -17,16 +17,24 @@ import numpy as np
 import piff
 import os
 import fitsio
+import galsim
 
 from piff_test_helper import timer
 
 
 @timer
 def test_init():
-    print('test init')
     # make sure we can init with defaults
     model = piff.Optical(template='des')
-    return model
+    prof = model.getProfile([])
+    print('prof = ',prof)
+    assert isinstance(prof, galsim.Convolution)
+
+    # make a simple optical-only model
+    model = piff.Optical(diam=4, lam=700)
+    prof = model.getProfile([])
+    print('prof = ',prof)
+    assert isinstance(prof, galsim.OpticalPSF)
 
 
 @timer

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -53,6 +53,14 @@ def test_optical(model=None):
     np.testing.assert_almost_equal(star_fitted.fit.flux, star.fit.flux)
     np.testing.assert_almost_equal(star_fitted.fit.params, star.fit.params)
 
+    # Reflux actually updates these to something reasonable.
+    logger = piff.config.setup_logger(verbose=2)
+    star_wrong = star.withFlux(2, (0.1,0.2))
+    star_reflux = model.reflux(star_wrong, logger=logger)
+    # There is no noise, but this is still not completely perfect.
+    assert star_reflux.fit.chisq < 1.e-2
+    np.testing.assert_allclose(star_reflux.fit.flux, 1.0, rtol=0.1)
+
     # test copy_image
     star_copy = model.draw(star, copy_image=True)
     star_nocopy = model.draw(star, copy_image=False)

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2016 by Mike Jarvis and the other collaborators on GitHub at
+# https://github.com/rmjarvis/Piff  All rights reserved.
+#
+# Piff is free software: Redistribution and use in source and binary forms
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+
+from __future__ import print_function
+import galsim
+import numpy as np
+import piff
+import os
+import sys
+import fitsio
+
+from piff_test_helper import timer
+
+@timer
+def test_chisq():
+    """Test the Chisq outlier class
+    """
+    if __name__ == '__main__':
+        logger = piff.config.setup_logger(verbose=2)
+    else:
+        logger = piff.config.setup_logger(log_file='output/test_single_image.log')
+
+    # Make the image
+    image = galsim.Image(512, 512, scale=0.26)
+
+    nstars = 1000  # enough that there could be some overlaps.  Also, some over the edge.
+    rng = np.random.RandomState(1234)
+    x = rng.random_sample(nstars) * 512
+    y = rng.random_sample(nstars) * 512
+    sigma = np.ones_like(x) * 0.4   # Most have this sigma
+    g1 = np.ones_like(x) * 0.023    # Most are pretty round.
+    g2 = np.ones_like(x) * 0.012
+    flux = np.exp(rng.normal(size=nstars))
+    print('flux range = ',np.min(flux),np.max(flux),np.median(flux),np.mean(flux))
+
+    # Make a few intentionally wrong.
+    g1[35] = 0.29
+    g1[188] = -0.15
+    sigma[239] = 0.2
+    g2[347] = -0.15
+    sigma[551] = 1.3
+    g2[809] = 0.05
+    g1[922] = -0.03
+
+    # Draw a Gaussian PSF at each location on the image.
+    for i in range(nstars):
+        psf = galsim.Gaussian(sigma=sigma[i]).shear(g1=g1[i], g2=g2[i])
+        stamp = psf.drawImage(scale=0.26, center=galsim.PositionD(x[i],y[i]))
+        b = stamp.bounds & image.bounds
+        image[b] += stamp[b]
+
+    noise = 0.02
+    image.addNoise(galsim.GaussianNoise(rng=galsim.BaseDeviate(1234), sigma=noise))
+
+    image_file = os.path.join('output','test_chisq_im.fits')
+    image.write(image_file)
+
+    # Write out the catalog to a file
+    dtype = [ ('x','f8'), ('y','f8') ]
+    data = np.empty(len(x), dtype=dtype)
+    data['x'] = x
+    data['y'] = y
+    cat_file = os.path.join('output','test_chisq_cat.fits')
+    fitsio.write(cat_file, data, clobber=True)
+
+    # Read the catalog in as stars.
+    config = { 'image_file_name' : image_file,
+               'cat_file_name': cat_file,
+               'noise': noise**2,  # Variance here is sigma^2
+               'stamp_size' : 15,
+               'use_partial' : True,
+             }
+    input = piff.InputFiles(config, logger=logger)
+    stars = input.makeStars()
+
+    # Skip the solve step.  Just give it the right answer and see what it finds for outliers
+    model = piff.Gaussian()
+    interp = piff.Mean()
+    interp.mean = np.array([0.4, 0.023, 0.012])
+    psf = piff.SimplePSF(model, interp)
+    stars = psf.interpolateStarList(stars)
+    stars = [ psf.model.reflux(s,logger=logger) for s in stars ]
+
+    outliers1 = piff.ChisqOutliers(nsigma=5)
+    stars1, nremoved1 = outliers1.removeOutliers(stars,logger=logger)
+    print('nremoved1 = ',nremoved1)
+    assert len(stars1) == len(stars) - nremoved1
+
+    # This is what nsigma=5 means in terms of probability
+    outliers2 = piff.ChisqOutliers(prob=5.733e-7)
+    stars2, nremoved2 = outliers2.removeOutliers(stars,logger=logger)
+    print('nremoved2 = ',nremoved2)
+    assert len(stars2) == len(stars) - nremoved2
+    assert nremoved1 == nremoved2
+
+    # This is equivalent for dof=219 (what most of these have)
+
+    # This is nearly equivalent for this particular data set.
+    # For dof=219 (what most of these have, this probability converts to
+    # thresh = 464.84402251
+    # or ndof = 2.1225754452511416
+    # But note that when using the above prop or nsigma, the code uses a tailored threshold
+    # different for each star's particular dof, which varies (since some are off the edge).
+    outliers3 = piff.ChisqOutliers(thresh=464.844)
+    stars3, nremoved3 = outliers3.removeOutliers(stars,logger=logger)
+    print('nremoved3 = ',nremoved3)
+    assert len(stars3) == len(stars) - nremoved3
+
+    outliers4 = piff.ChisqOutliers(ndof=2.12258)
+    stars4, nremoved4 = outliers4.removeOutliers(stars,logger=logger)
+    print('nremoved4 = ',nremoved4)
+    assert len(stars4) == len(stars) - nremoved4
+    assert nremoved3 == nremoved4
+
+    # Regression tests.  If these change, make sure we understand why.
+    assert nremoved1 == nremoved2 == 67
+    assert nremoved3 == nremoved4 == 14  # Much less, since edge objects aren't being removed
+                                         # nearly as often as when they have a custom thresh.
+
+    # Can't provide multiple thresh specifications
+    np.testing.assert_raises(TypeError, piff.ChisqOutliers, nsigma=5, prob=1.e-3)
+    np.testing.assert_raises(TypeError, piff.ChisqOutliers, nsigma=5, thresh=100)
+    np.testing.assert_raises(TypeError, piff.ChisqOutliers, nsigma=5, ndof=3)
+    np.testing.assert_raises(TypeError, piff.ChisqOutliers, prob=1.e-3, thresh=100)
+    np.testing.assert_raises(TypeError, piff.ChisqOutliers, prob=1.e-3, ndof=3)
+    np.testing.assert_raises(TypeError, piff.ChisqOutliers, thresh=100, ndof=3)
+
+    # Need to specifiy it somehow.
+    np.testing.assert_raises(TypeError, piff.ChisqOutliers)
+
+@timer
+def test_base():
+    """Test Outliers base class
+    """
+    # type is required
+    config = { 'nsigma' : 4, }
+    with np.testing.assert_raises(ValueError):
+        out = piff.Outliers.process(config)
+
+    # Invalid to read a type that isn't a piff.Outliers type.
+    # Mock this by pretending that MADOutliers is the only subclass of Outliers.
+    if sys.version_info < (3,): return  # mock only available on python 3
+    from unittest import mock
+    filename = os.path.join('input','D00240560_r_c01_r2362p01_piff.fits')
+    with mock.patch('piff.util.get_all_subclasses', return_value=[piff.outliers.MADOutliers]):
+        with fitsio.FITS(filename,'r') as f:
+            np.testing.assert_raises(ValueError, piff.Outliers.read, f, extname='psf_outliers')
+
+
+if __name__ == '__main__':
+    test_chisq()
+    test_base()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 import os
 import shutil
+import numpy as np
 import piff
 
 from piff_test_helper import timer
@@ -53,5 +54,23 @@ def test_ensure_dir():
     assert s == 'test'
 
 
+@timer
+def test_base_output():
+    """Test the base Output class.
+    """
+    # A bit gratuitous, since no one should ever call these, but just check that the
+    # trivial implementation (or NotImplementedErrors) in the base class work as expected.
+    config = { 'file_name' : 'dummy_file' }
+
+    out = piff.Output()
+
+    kwargs = out.parseKwargs(config)
+    assert kwargs == config
+
+    np.testing.assert_raises(NotImplementedError, out.write, None)
+    np.testing.assert_raises(NotImplementedError, out.read)
+
+
 if __name__ == '__main__':
     test_ensure_dir()
+    test_base_output()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2016 by Mike Jarvis and the other collaborators on GitHub at
+# https://github.com/rmjarvis/Piff  All rights reserved.
+#
+# Piff is free software: Redistribution and use in source and binary forms
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+
+from __future__ import print_function
+import os
+import shutil
+import piff
+
+from piff_test_helper import timer
+
+@timer
+def test_ensure_dir():
+    """Test the ensure_dir utiltity
+    """
+    d = os.path.join('output', 'test_dir')
+    if os.path.exists(d):
+        shutil.rmtree(d)
+
+    assert not os.path.exists(d)
+
+    f = os.path.join(d, 'test_file')
+
+    # ensure that the directory needed to write f exisits
+    piff.util.ensure_dir(f)
+
+    assert os.path.exists(d)
+    assert os.path.isdir(d)
+
+    # write something to f
+    with open(f,'w') as fout:
+        fout.write('test')
+
+    # doing it again doesn't destroy f
+    piff.util.ensure_dir(f)
+
+    assert os.path.exists(d)
+    assert os.path.isdir(d)
+
+    with open(f) as fin:
+        s = fin.read()
+    print(s)
+    assert s == 'test'
+
+
+if __name__ == '__main__':
+    test_ensure_dir()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -631,6 +631,65 @@ def test_extra_interp():
     with np.testing.assert_raises(TypeError):
         psf2.draw(x=5, y=7, chipnum=0)
 
+@timer
+def test_load_images():
+    """Test the load_images function
+    """
+    if __name__ == '__main__':
+        logger = piff.config.setup_logger(verbose=2)
+    else:
+        logger = piff.config.setup_logger(log_file='output/test_load_image2.log')
+
+    # Same setup as test_single_image, but without flags
+    image = galsim.Image(2048, 2048, scale=0.26)
+    x_list = [ 123.12, 345.98, 567.25, 1094.94, 924.15, 1532.74, 1743.11, 888.39, 1033.29, 1409.31 ]
+    y_list = [ 345.43, 567.45, 1094.32, 924.29, 1532.92, 1743.83, 888.83, 1033.19, 1409.20, 123.11 ]
+    sigma = 1.3
+    g1 = 0.23
+    g2 = -0.17
+    psf = galsim.Gaussian(sigma=sigma).shear(g1=g1, g2=g2)
+    for x,y in zip(x_list, y_list):
+        bounds = galsim.BoundsI(int(x-31), int(x+32), int(y-31), int(y+32))
+        psf.drawImage(image[bounds], center=galsim.PositionD(x,y), method='no_pixel')
+    image.addNoise(galsim.GaussianNoise(rng=galsim.BaseDeviate(1234), sigma=1e-6))
+    image_file = os.path.join('output','test_load_images_im.fits')
+    image.write(image_file)
+
+    dtype = [ ('x','f8'), ('y','f8') ]
+    data = np.empty(len(x_list), dtype=dtype)
+    data['x'] = x_list
+    data['y'] = y_list
+    cat_file = os.path.join('output','test_load_images_cat.fits')
+    fitsio.write(cat_file, data, clobber=True)
+
+    # Make star data
+    config = { 'image_file_name' : image_file,
+               'cat_file_name': cat_file }
+    orig_stars, wcs, pointing = piff.Input.process(config, logger)
+
+    # Fit these with a simple Mean, Gaussian
+    model = piff.Gaussian()
+    interp = piff.Mean()
+    psf = piff.SimplePSF(model, interp)
+    psf.fit(orig_stars, wcs, pointing, logger=logger)
+    psf_file = os.path.join('output','test_load_images_psf.fits')
+    psf.write(psf_file, logger)
+
+    # Read this file back in.  It has the star data, but the images are blank.
+    psf2 = piff.read(psf_file, logger)
+    assert len(psf2.stars) == 10
+    for star in psf2.stars:
+        np.testing.assert_array_equal(star.image.array, 0.)
+
+    loaded_stars = piff.Star.load_images(psf2.stars, image_file)
+    for star, orig in zip(loaded_stars, psf.stars):
+        np.testing.assert_array_equal(star.image.array, orig.image.array)
+
+    # Can optionally supply sky to subtract
+    loaded_stars = piff.Star.load_images(psf2.stars, image_file, sky=10)
+    for star, orig in zip(loaded_stars, psf.stars):
+        np.testing.assert_array_equal(star.image.array, orig.image.array-10)
+
 
 if __name__ == '__main__':
     test_Gaussian()
@@ -641,3 +700,4 @@ if __name__ == '__main__':
     test_model()
     test_interp()
     test_psf()
+    test_load_images()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -576,6 +576,7 @@ def test_psf():
     np.testing.assert_raises(NotImplementedError, psf.interpolateStarList, [star])
     np.testing.assert_raises(NotImplementedError, psf.drawStar, star)
     np.testing.assert_raises(NotImplementedError, psf.drawStarList, [star])
+    np.testing.assert_raises(NotImplementedError, psf._drawStar, star)
 
     # Invalid to read a type that isn't a piff.PSF type.
     # Mock this by pretending that SingleChip is the only subclass of PSF.

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -50,7 +50,7 @@ def test_twodstats():
                                    np.array([-0.1 * 1000 / 2048, 0, 0.1 / (0.263 * 2048), 0]),
                                    decimal=4)
 
-    stats = piff.TwoDHistStats(number_bins_u=5, number_bins_v=5, reducing_function='np.mean')
+    stats = piff.TwoDHistStats(number_bins_u=5, number_bins_v=5)  # implicitly np.median
     stats.compute(psf, stars, logger=logger)
     # check the twodhists
     # get the average value in the bin
@@ -83,6 +83,14 @@ def test_twodstats():
     # Test the plotting and writing
     twodstats_file = os.path.join('output','whiskerstats.pdf')
     stats.write(twodstats_file)
+
+    # With large number of bins, many will have no objects.  This is ok.
+    # Also, can use other np functions like max, std, instead to get different stats
+    # Not sure when these would be useful, but they are allowed.
+    stats = piff.TwoDHistStats(number_bins_u=50, number_bins_v=50, reducing_function='np.max')
+    stats.compute(psf, stars, logger=logger)
+    stats = piff.WhiskerStats(number_bins_u=100, number_bins_v=100, reducing_function='np.std')
+    stats.compute(psf, stars)
 
 @timer
 def test_shift_cmap():

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -77,20 +77,37 @@ def test_twodstats():
     twodstats_file = os.path.join('output','twodstats.pdf')
     stats.write(twodstats_file)
 
+    with np.testing.assert_raises(ValueError):
+        stats.write()  # If not given in constructor, must give file name here.
+
     # repeat for whisker
     stats = piff.WhiskerStats(number_bins_u=21, number_bins_v=21, reducing_function='np.mean')
     stats.compute(psf, stars)
     # Test the plotting and writing
-    twodstats_file = os.path.join('output','whiskerstats.pdf')
-    stats.write(twodstats_file)
+    whisker_file = os.path.join('output','whiskerstats.pdf')
+    stats.write(whisker_file)
+    with np.testing.assert_raises(ValueError):
+        stats.write()
 
     # With large number of bins, many will have no objects.  This is ok.
     # Also, can use other np functions like max, std, instead to get different stats
     # Not sure when these would be useful, but they are allowed.
-    stats = piff.TwoDHistStats(number_bins_u=50, number_bins_v=50, reducing_function='np.max')
-    stats.compute(psf, stars, logger=logger)
-    stats = piff.WhiskerStats(number_bins_u=100, number_bins_v=100, reducing_function='np.std')
-    stats.compute(psf, stars)
+    # And, check usage where file_name is given in init.
+    twodstats_file2 = os.path.join('output','twodstats.pdf')
+    stats2 = piff.TwoDHistStats(number_bins_u=50, number_bins_v=50, reducing_function='np.std',
+                                file_name=twodstats_file2)
+    with np.testing.assert_raises(RuntimeError):
+        stats2.write()  # Cannot write before compute
+    stats2.compute(psf, stars, logger=logger)
+    stats2.write()
+
+    whisker_file2 = os.path.join('output','whiskerstats.pdf')
+    stats2 = piff.WhiskerStats(number_bins_u=100, number_bins_v=100, reducing_function='np.max',
+                               file_name=whisker_file2)
+    with np.testing.assert_raises(RuntimeError):
+        stats2.write()  # Cannot write before compute
+    stats2.compute(psf, stars)
+    stats2.write()
 
 @timer
 def test_shift_cmap():
@@ -357,6 +374,8 @@ def test_rhostats_config():
     psf = piff.read(psf_file)
     orig_stars, wcs, pointing = piff.Input.process(config['input'], logger)
     stats = piff.RhoStats(min_sep=min_sep, max_sep=max_sep, bin_size=bin_size)
+    with np.testing.assert_raises(RuntimeError):
+        stats.write('dummy')  # Cannot write before compute
     stats.compute(psf, orig_stars)
 
     rhos = [stats.rho1, stats.rho2, stats.rho3, stats.rho4, stats.rho5]
@@ -449,6 +468,8 @@ def test_shapestats_config():
     psf = piff.read(psf_file)
     shapeStats = piff.ShapeHistogramsStats()
     orig_stars, wcs, pointing = piff.Input.process(config['input'], logger)
+    with np.testing.assert_raises(RuntimeError):
+        shapeStats.write()  # Cannot write before compute
     shapeStats.compute(psf, orig_stars)
     shapeStats.plot(psf, histtype='bar', log=True)  # can supply additional args for matplotlib
 
@@ -514,6 +535,8 @@ def test_starstats_config():
     psf = piff.read(psf_file)
     starStats = piff.StarStats()
     orig_stars, wcs, pointing = piff.Input.process(config['input'], logger)
+    with np.testing.assert_raises(RuntimeError):
+        starStats.write()  # Cannot write before compute
     starStats.compute(psf, orig_stars)
     assert starStats.number_plot == len(starStats.stars)
     assert starStats.number_plot == len(starStats.models)
@@ -652,8 +675,12 @@ def test_hsmcatalog():
     psf = piff.PSF.read(psf_file)
     stars, _, _ = piff.Input.process(config['input'])
     hsmcat = piff.stats.HSMCatalogStats()
+    with np.testing.assert_raises(RuntimeError):
+        hsmcat.write('dummy')  # Cannot write before compute
     hsmcat.compute(psf, stars)
     hsm_file2 = os.path.join('output', 'test_hsmcatalog2.fits')
+    with np.testing.assert_raises(ValueError):
+        hsmcat.write()  # Must supply file_name if not given in constructor
     hsmcat.write(hsm_file2)
     data2 = fitsio.read(hsm_file2)
     for key in data.dtype.names:
@@ -754,6 +781,30 @@ def test_bad_hsm():
 
     for f in [twodhist_file, rho_file, shape_file, star_file, hsm_file]:
         assert os.path.exists(f)
+
+@timer
+def test_base_stats():
+    """Test the base Stats class.
+    """
+    # type is required
+    config = { 'file_name' : 'dummy_file' }
+    with np.testing.assert_raises(ValueError):
+        stats = piff.Stats.process(config)
+
+    # ... for all stats in list.
+    config = [ { 'type': 'TwoDHist', 'file_name': 'f1' },
+               { 'type': 'Whisker', 'file_name': 'f2', },
+               { 'type': 'Rho', 'file_name': 'f3' },
+               { 'file_name' : 'dummy_file' },
+             ]
+    with np.testing.assert_raises(ValueError):
+        stats = piff.Stats.process(config)
+
+    # Can't do much with a base Stats class
+    stats = piff.Stats()
+    np.testing.assert_raises(NotImplementedError, stats.compute, None, None)
+    np.testing.assert_raises(NotImplementedError, stats.plot)
+
 
 if __name__ == '__main__':
     setup()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -333,7 +333,12 @@ def test_rhostats_config():
             'file_name' : psf_file,
             'stats' : {  # Note: stats doesn't have to be a list.
                 'type': 'Rho',
-                'file_name': rho_file
+                'file_name': rho_file,
+                'min_sep': 30,
+                'max_sep': 600,
+                'sep_units': 'arcsec',
+                'bin_type': 'Linear',
+                'bin_size': 30,
             }
         },
     }
@@ -445,6 +450,7 @@ def test_shapestats_config():
     shapeStats = piff.ShapeHistogramsStats()
     orig_stars, wcs, pointing = piff.Input.process(config['input'], logger)
     shapeStats.compute(psf, orig_stars)
+    shapeStats.plot(psf, histtype='bar', log=True)  # can supply additional args for matplotlib
 
     # test their characteristics
     sigma = 1.3  # (copied from setup())

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -265,8 +265,10 @@ def test_single():
 
     if __name__ == '__main__':
         nstars = 20  # per ccd
+        logger = piff.config.setup_logger(verbose=2)
     else:
         nstars = 6  # per ccd
+        logger = piff.config.setup_logger(log_file='output/test_single.log')
     rng = np.random.RandomState(1234)
     x = rng.random_sample(nstars) * 2000 + 24
     y = rng.random_sample(nstars) * 2000 + 24
@@ -301,11 +303,6 @@ def test_single():
     dec12 = np.concatenate([dec1,dec2])
     data12 = np.array(list(zip(ra12,dec12)), dtype=[('ra',float), ('dec',float)])
     fitsio.write('output/test_single_cat12.fits', data12, clobber=True)
-
-    # im3 is blank.  Will give errors trying to measure PSF from it.
-    im3 = galsim.Image(2048,2048, wcs=wcs2)
-    im3.write('output/test_single_im3.fits')
-    fitsio.write('output/test_single_cat3.fits', data2, clobber=True)
 
     # Try to fit with the right model (Moffat) and interpolant (2nd order polyomial)
     # Should work very well, since no noise.
@@ -367,7 +364,69 @@ def test_single():
             #print('  fitted s,e1,e2 = ',star.fit.params)
             np.testing.assert_almost_equal(star.fit.params, [s,e1,e2], decimal=6)
 
-    # Do again in parallel.  Also check I/O and using a single input catalog.
+    # Chipnum is required as a property to use SingleCCDPSF
+    star1 = piff.Star.makeTarget(x=x, y=y, wcs=wcs, stamp_size=48, pointing=field_center)
+    with np.testing.assert_raises(ValueError):
+        psf.drawStar(star1)
+    star2 = piff.Star(star1.data, star.fit)  # If has a fit, it hits a different error
+    with np.testing.assert_raises(ValueError):
+        psf.drawStar(star2)
+
+
+@timer
+def test_parallel():
+    # Run the same test as test_single, but using nproc
+    wcs1 = galsim.TanWCS(
+            galsim.AffineTransform(0.26, 0.05, -0.08, -0.24, galsim.PositionD(1024,1024)),
+            galsim.CelestialCoord(-5 * galsim.arcmin, -25 * galsim.degrees)
+            )
+    wcs2 = galsim.TanWCS(
+            galsim.AffineTransform(0.25, -0.02, 0.01, 0.24, galsim.PositionD(1024,1024)),
+            galsim.CelestialCoord(5 * galsim.arcmin, -25 * galsim.degrees)
+            )
+    field_center = galsim.CelestialCoord(0 * galsim.degrees, -25 * galsim.degrees)
+
+    if __name__ == '__main__':
+        nstars = 20  # per ccd
+    else:
+        nstars = 6  # per ccd
+    rng = np.random.RandomState(1234)
+    x = rng.random_sample(nstars) * 2000 + 24
+    y = rng.random_sample(nstars) * 2000 + 24
+    ra1, dec1 = wcs1.toWorld(x,y,units='rad')
+    u, v = field_center.project_rad(ra1,dec1, projection='gnomonic')
+    e1 = 0.02 + 2.e-5 * u - 3.e-9 * u**2 + 2.e-9 * v**2
+    e2 = -0.04 - 3.e-5 * v + 1.e-9 * u*v + 3.e-9 * v**2
+    s = 0.3 + 8.e-9 * (u**2 + v**2) - 1.e-9 * u*v
+
+    data1 = np.array(list(zip(x,y,e1,e2,s)),
+                     dtype=[ ('x',float), ('y',float), ('e1',float), ('e2',float), ('s',float) ])
+    im1 = drawImage(2048, 2048, wcs1, x, y, e1, e2, s)
+    im1.write('output/test_parallel_im1.fits')
+
+    x = rng.random_sample(nstars) * 2000 + 24
+    y = rng.random_sample(nstars) * 2000 + 24
+    ra2, dec2 = wcs2.toWorld(x,y,units='rad')
+    u, v = field_center.project_rad(ra1,dec1, projection='gnomonic')
+    # Same functions of u,v, but using the positions on chip 2
+    e1 = 0.02 + 2.e-5 * u - 3.e-9 * u**2 + 2.e-9 * v**2
+    e2 = -0.04 - 3.e-5 * v + 1.e-9 * u*v + 3.e-9 * v**2
+    s = 0.3 + 8.e-9 * (u**2 + v**2) - 1.e-9 * u*v
+
+    data2 = np.array(list(zip(x,y,e1,e2,s)),
+                     dtype=[ ('x',float), ('y',float), ('e1',float), ('e2',float), ('s',float) ])
+    im2 = drawImage(2048, 2048, wcs2, x, y, e1, e2, s)
+    im2.write('output/test_parallel_im2.fits')
+
+    ra12 = np.concatenate([ra1,ra2])
+    dec12 = np.concatenate([dec1,dec2])
+    data12 = np.array(list(zip(ra12,dec12)), dtype=[('ra',float), ('dec',float)])
+    fitsio.write('output/test_parallel.fits', data12, clobber=True)
+
+    # im3 is blank.  Will give errors trying to measure PSF from it.
+    im3 = galsim.Image(2048,2048, wcs=wcs2)
+    im3.write('output/test_parallel_im3.fits')
+
     psf_file = os.path.join('output','test_single.fits')
     config = {
         'input' : {
@@ -376,10 +435,10 @@ def test_single():
             'nimages' : 2,
             'image_file_name' : {
                 'type' : 'FormattedStr',
-                'format' : '%s/test_single_im%d.fits',
+                'format' : '%s/test_parallel_im%d.fits',
                 'items' : [ 'output', '$image_num+1' ],
             },
-            'cat_file_name' : 'output/test_single_cat12.fits',
+            'cat_file_name' : 'output/test_parallel.fits',
             'chipnum' : '$image_num+1',
             'ra_col' : 'ra',
             'dec_col' : 'dec',


### PR DESCRIPTION
I spent the weekend fleshing out the unit test coverage of Piff, and I got it up to 100%.  I'd like to keep it there for version 1.0 and onwards, which we are planning to release soon. 

We can also start keeping track of changes after the 1.0 release in a CHANGELOG.  I added a blank one here.

In addition to a whole bunch of unit test updates (mostly assert_raises, since exceptions were by far the predominant lines that were uncovered), I made the following code changes:

1. Removed ModelFitError.  At some point, we should probably build up a set of piff-specific error classes, but so far that was our only one, so it didn't really seem useful to keep it.  I converted it to a RuntimeError for the couple places where we raise it.
2. Made the util.hsm function a method of Star, so now rather than `piff.util.hsm(star)`, you write `star.hsm()`.
3. Removed a few unused functions: `StarData.setData`, `StarData.maskPixels`, `StarFit.__getitem__`, `DECamInfo.getPosition_chipnum` (was exactly equivalent to `getPosition`), `DECamInfo.getPosition_extname`, `DECamInfo.getPixel_extname`
4. Moved the new `interpolateStar` and `interpolateStarList` PSF methods to the base class, so they are now required to be implemented for all PSF classes.
5. Moved the `GSObjectModel.reflux` implementation to the `Model` base class, since it it pretty generic actually, so other classes can use that if they don't have anything more specific to do.  In particular, this gives an implementation of this method to the `OpticalModel` class.
6. Changed some classes being raised to be more consistent with standard error types: ValueError when a value is wrong, TypeError when a parameter is missing or the wrong type, etc.
7. Various bug fixes and minor code refactorings that turned up during the unit test work.  Which was of course the point to find these kinds of things. :)