### PR TITLE
Add center option to PSF.draw method

### DIFF
--- a/piff/basis_interp.py
+++ b/piff/basis_interp.py
@@ -385,7 +385,8 @@ class BasisPolynomial(BasisInterp):
         # Start with 1d arrays giving orders in all dimensions
         ord_ranges = [np.arange(order+1,dtype=int) for order in self._orders]
         # Nifty trick to produce n-dim array holding total order
-        sumorder = np.sum(np.ix_(*ord_ranges))
+        #sumorder = np.sum(np.ix_(*ord_ranges))  # This version doesn't work in numpy 1.19
+        sumorder = np.sum(np.meshgrid(*ord_ranges, indexing='ij'), axis=0)
         self._mask = sumorder <= self._max_order
 
     def getProperties(self, star):
@@ -407,7 +408,8 @@ class BasisPolynomial(BasisInterp):
             p[1:] = vals[i]
             pows1d.append(np.cumprod(p))
         # Use trick to produce outer product of all these powers
-        pows2d = np.prod(np.ix_(*pows1d))
+        #pows2d = np.prod(np.ix_(*pows1d))
+        pows2d = np.prod(np.meshgrid(*pows1d, indexing='ij'), axis=0)
         # Return linear array of terms making total power constraint
         return pows2d[self._mask]
 

--- a/piff/model.py
+++ b/piff/model.py
@@ -160,7 +160,7 @@ class Model(object):
                                        dof = new_dof,
                                        params_var = star.fit.params_var))
 
-    def draw(self, star, copy_image=True):
+    def draw(self, star, copy_image=True, center=None):
         """Draw the model on the given image.
 
         :param star:        A Star instance with the fitted parameters to use for drawing and a
@@ -168,6 +168,8 @@ class Model(object):
         :param copy_image:  If False, will use the same image object.
                             If True, will copy the image and then overwrite it.
                             [default: True]
+        :param center:      An optional tuple (x,y) location for where to center the drawn profile
+                            in the image. [default: None, which draws at the star's location.]
 
         :returns: a new Star instance with the data field having an image of the drawn model.
         """
@@ -176,7 +178,11 @@ class Model(object):
             image = star.image.copy()
         else:
             image = star.image
-        prof.drawImage(image, method=self._method, offset=(star.image_pos-image.true_center))
+        if center is None:
+            center = star.image_pos
+        else:
+            center = galsim.PositionD(*center)
+        prof.drawImage(image, method=self._method, center=center)
         data = StarData(image, star.image_pos, star.weight, star.data.pointing)
         return Star(data, star.fit)
 

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -124,15 +124,39 @@ class PSF(object):
         sky coordinates rather than image coordinates, you can provide an image with just a
         pixel scale for the WCS.
 
-        :param x:           The image x position.
-        :param y:           The image y position.
+        When drawing the PSF, there are a few options regarding how the profile will be
+        centered on the image.
+
+        1. The default behavior (``center==None``) is to draw the profile centered at the same
+           (x,y) as you requested for the location of the PSF in the original image coordinates.
+           The returned image will not (normally) be as large as the full image -- it will just be
+           a postage stamp centered roughly around (x,y).  The image.bounds give the bounding box
+           of this stamp, and within this, the PSF will be centered at position (x,y).
+        2. If you want to center the profile at some other arbitrary position, you may provide
+           a ``center`` parameter, which should be a tuple (xc,yc) giving the location at which
+           you want the PSF to be centered.  The bounding box will still be around the nominal
+           (x,y) position, so this should only be used for small adjustments to the (x,y) value
+           if you want it centered at a slightly different location.
+        3. If you provide your own image with the `image` parameter, then you may set the ``center``
+           to any location in this box (or technically off it -- it doesn't check that the center
+           is actually inside the bounding box).  This may be useful if you want to draw on an
+           image with origin at (0,0) or (1,1) and just put the PSF at the location you want.
+        4. If you want the PSf centered exactly in the center of the image, then you can use
+           ``center='image'``.  This will work for either an automatically built image or one
+           that you provide.
+        5. With any of the above options you may additionally supply an ``offset`` parameter, which
+           will apply a slight offset to the calculated center.  This is probably only useful in
+           conjunction with the default ``center=None`` or ``center='image'``.
+
+        :param x:           The x position of the desired PSF in the original image coordinates.
+        :param y:           The y position of the desired PSF in the original image coordinates.
         :param chipnum:     Which chip to use for WCS information. [default: 0, which is
                             appropriate if only using a single chip]
         :param flux:        Flux of PSF to be drawn [default: 1.0]
-        :param center:      (x0,y0) tuple giving the location on the image where you want the
+        :param center:      (xc,yc) tuple giving the location on the image where you want the
                             nominal center of the profile to be drawn.  Also allowed is the
                             string center='image' to place in the center of the image.
-                            [default: None, which means draw at the position (x,y) of the star.]
+                            [default: None, which means draw at the position (x,y) of the PSF.]
         :param offset:      Optional (dx,dy) tuple giving an additional offset relative to the
                             center. [default: None]
         :param stamp_size:  The size of the image to construct if no image is provided.

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -178,19 +178,19 @@ class PSF(object):
             raise ValueError("Invalid center parameter: %r. Must be tuple or None or 'image'"%(
                              center))
 
-        # Convert to centroid shift in (u,v) coordinates
-        offset = (center[0] - x + offset[0], center[1] - y + offset[1])
-        center = star.offset_to_center(offset)
+        # Handle offset if given
+        if offset is not None:
+            center = (center[0] + offset[0], center[1] + offset[1])
 
-        # Adjust the flux, center of the star.
-        star = star.withFlux(flux, center)
+        # Adjust the flux of the star.
+        star = star.withFlux(flux)
 
         # if a user specifies an image, then we want to preserve that image, so
         # copy_image = False. If a user doesn't specify an image, then it
         # doesn't matter if we overwrite it, so use copy_image=False
         copy_image = False
         # Draw the star and return the image
-        star = self.drawStar(star, copy_image=copy_image)
+        star = self.drawStar(star, copy_image=copy_image, center=center)
         return star.data.image
 
     def interpolateStarList(self, stars):
@@ -241,7 +241,7 @@ class PSF(object):
             stars = self.interpolateStarList(stars)
         return [self._drawStar(star, copy_image=copy_image) for star in stars]
 
-    def drawStar(self, star, copy_image=True):
+    def drawStar(self, star, copy_image=True, center=None):
         """Generate PSF image for a given star.
 
         .. note::
@@ -259,6 +259,8 @@ class PSF(object):
         :param copy_image:  If False, will use the same image object.
                             If True, will copy the image and then overwrite it.
                             [default: True]
+        :param center:      An optional tuple (x,y) location for where to center the drawn profile
+                            in the image. [default: None, which draws at the star's location.]
 
         :returns:           Star instance with its image filled with rendered PSF
         """
@@ -266,9 +268,9 @@ class PSF(object):
         if star.fit is None or star.fit.params is None:
             star = self.interpolateStar(star)
         # Render the image
-        return self._drawStar(star, copy_image=copy_image)
+        return self._drawStar(star, copy_image=copy_image, center=center)
 
-    def _drawStar(self, star, copy_image=True):
+    def _drawStar(self, star, copy_image=True, center=None):
         # Derived classes may choose to override any of the above functions
         # But they have to at least override this one and interpolateStar to implement
         # their actual PSF model.

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -132,8 +132,9 @@ class PSF(object):
         :param offset:      (dx,dy) tuple giving offset of stellar center relative
                             to star.data.image_pos [default: (0,0)]
         :param center:      (x0,y0) tuple giving the location on the image where you want the
-                            nominal center of the profile to be drawn. [default: None, which means
-                            draw at the position (x,y) of the star.]
+                            nominal center of the profile to be drawn.  Also allowed is the
+                            string center='image' to place in the center of the image.
+                            [default: None, which means draw at the position (x,y) of the star.]
         :param stamp_size:  The size of the image to construct if no image is provided.
                             [default: 48]
         :param image:       An existing image on which to draw, if desired. [default: None]
@@ -170,6 +171,12 @@ class PSF(object):
         # Handle the input center
         if center is None:
             center = (x, y)
+        elif center == 'image':
+            center = star.data.image.true_center
+            center = (center.x, center.y)
+        elif not isinstance(center, tuple):
+            raise ValueError("Invalid center parameter: %r. Must be tuple or None or 'image'"%(
+                             center))
 
         # Convert to centroid shift in (u,v) coordinates
         offset = (center[0] - x + offset[0], center[1] - y + offset[1])

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -100,7 +100,7 @@ class PSF(object):
         """
         raise NotImplementedError("Derived classes must define the parseKwargs function")
 
-    def draw(self, x, y, chipnum=0, flux=1.0, offset=(0,0), center=None, stamp_size=48,
+    def draw(self, x, y, chipnum=0, flux=1.0, center=None, offset=None, stamp_size=48,
              image=None, logger=None, **kwargs):
         r"""Draws an image of the PSF at a given location.
 
@@ -129,12 +129,12 @@ class PSF(object):
         :param chipnum:     Which chip to use for WCS information. [default: 0, which is
                             appropriate if only using a single chip]
         :param flux:        Flux of PSF to be drawn [default: 1.0]
-        :param offset:      (dx,dy) tuple giving offset of stellar center relative
-                            to star.data.image_pos [default: (0,0)]
         :param center:      (x0,y0) tuple giving the location on the image where you want the
                             nominal center of the profile to be drawn.  Also allowed is the
                             string center='image' to place in the center of the image.
                             [default: None, which means draw at the position (x,y) of the star.]
+        :param offset:      Optional (dx,dy) tuple giving an additional offset relative to the
+                            center. [default: None]
         :param stamp_size:  The size of the image to construct if no image is provided.
                             [default: 48]
         :param image:       An existing image on which to draw, if desired. [default: None]

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -155,7 +155,7 @@ class PSF(object):
         :param flux:        Flux of PSF to be drawn [default: 1.0]
         :param center:      (xc,yc) tuple giving the location on the image where you want the
                             nominal center of the profile to be drawn.  Also allowed is the
-                            string center=True to place in the center of the image.
+                            value center=True to place in the center of the image.
                             [default: None, which means draw at the position (x,y) of the PSF.]
         :param offset:      Optional (dx,dy) tuple giving an additional offset relative to the
                             center. [default: None]

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -142,11 +142,11 @@ class PSF(object):
            is actually inside the bounding box).  This may be useful if you want to draw on an
            image with origin at (0,0) or (1,1) and just put the PSF at the location you want.
         4. If you want the PSf centered exactly in the center of the image, then you can use
-           ``center='image'``.  This will work for either an automatically built image or one
+           ``center=True``.  This will work for either an automatically built image or one
            that you provide.
         5. With any of the above options you may additionally supply an ``offset`` parameter, which
            will apply a slight offset to the calculated center.  This is probably only useful in
-           conjunction with the default ``center=None`` or ``center='image'``.
+           conjunction with the default ``center=None`` or ``center=True``.
 
         :param x:           The x position of the desired PSF in the original image coordinates.
         :param y:           The y position of the desired PSF in the original image coordinates.
@@ -155,7 +155,7 @@ class PSF(object):
         :param flux:        Flux of PSF to be drawn [default: 1.0]
         :param center:      (xc,yc) tuple giving the location on the image where you want the
                             nominal center of the profile to be drawn.  Also allowed is the
-                            string center='image' to place in the center of the image.
+                            string center=True to place in the center of the image.
                             [default: None, which means draw at the position (x,y) of the PSF.]
         :param offset:      Optional (dx,dy) tuple giving an additional offset relative to the
                             center. [default: None]
@@ -195,11 +195,11 @@ class PSF(object):
         # Handle the input center
         if center is None:
             center = (x, y)
-        elif center == 'image':
+        elif center is True:
             center = star.data.image.true_center
             center = (center.x, center.y)
         elif not isinstance(center, tuple):
-            raise ValueError("Invalid center parameter: %r. Must be tuple or None or 'image'"%(
+            raise ValueError("Invalid center parameter: %r. Must be tuple or None or True"%(
                              center))
 
         # Handle offset if given

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -266,8 +266,8 @@ class SimplePSF(PSF):
         self.model.normalize(star)
         return star
 
-    def _drawStar(self, star, copy_image=True):
-        return self.model.draw(star, copy_image=copy_image)
+    def _drawStar(self, star, copy_image=True, center=None):
+        return self.model.draw(star, copy_image=copy_image, center=center)
 
     def _finish_write(self, fits, extname, logger):
         """Finish the writing process with any class-specific steps.

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -135,11 +135,11 @@ class SingleChipPSF(PSF):
         chipnum = star['chipnum']
         return self.psf_by_chip[chipnum].interpolateStar(star)
 
-    def _drawStar(self, star, copy_image=True):
+    def _drawStar(self, star, copy_image=True, center=None):
         if 'chipnum' not in star.data.properties:
             raise ValueError("SingleChip requires the star to have a chipnum property")
         chipnum = star['chipnum']
-        return self.psf_by_chip[chipnum].drawStar(star, copy_image=copy_image)
+        return self.psf_by_chip[chipnum].drawStar(star, copy_image=copy_image, center=center)
 
     def _finish_write(self, fits, extname, logger):
         """Finish the writing process with any class-specific steps.

--- a/piff/star.py
+++ b/piff/star.py
@@ -266,10 +266,6 @@ class Star(object):
                 scale = 1.
             wcs = galsim.PixelScale(scale)
 
-        # Make the blank image
-        if image is None:
-            image = galsim.Image(stamp_size, stamp_size, dtype=float)
-
         # Make field_pos if we have u,v
         if u is not None:
             field_pos = galsim.PositionD(float(u),float(v))
@@ -284,13 +280,17 @@ class Star(object):
         else:
             image_pos = galsim.PositionD(float(x),float(y))
 
-        # Make the center of the image (close to) the image_pos
-        image.setCenter(int(x+0.5), int(y+0.5))
+        # Make the blank image
+        if image is None:
+            image = galsim.Image(stamp_size, stamp_size, dtype=float)
+            # Make the center of the image (close to) the image_pos
+            xcen = int(np.ceil(x - (0.5 if image.array.shape[1] % 2 == 1 else 0)))
+            ycen = int(np.ceil(y - (0.5 if image.array.shape[0] % 2 == 1 else 0)))
+            image.setCenter(xcen, ycen)
         if image.wcs is None:
             image.wcs = wcs
         if weight is not None:
-            weight = galsim.Image(weight.array.copy(), wcs=image.wcs)
-            weight.setCenter(int(x+0.5), int(y+0.5))
+            weight = galsim.Image(weight.array, wcs=image.wcs, copy=True, bounds=image.bounds)
 
         # Build the StarData instance
         data = StarData(image, image_pos, field_pos=field_pos, properties=properties, 

--- a/tests/test_gsobject_model.py
+++ b/tests/test_gsobject_model.py
@@ -52,6 +52,7 @@ def make_data(gsobject, scale, g1, g2, u0, v0, flux, noise=0., pix_scale=1., fpu
     star = piff.Star.makeTarget(x=nside/2+nom_u0/pix_scale, y=nside/2+nom_v0/pix_scale,
                                 u=fpu, v=fpv, scale=pix_scale, stamp_size=nside, weight=weight)
     star.image.setOrigin(0,0)
+    star.weight.setOrigin(0,0)
     method = 'auto' if include_pixel else 'no_pixel'
     k.drawImage(star.image, method=method,
                 offset=galsim.PositionD(nom_u0/pix_scale, nom_v0/pix_scale), use_true_center=False)

--- a/tests/test_knn_interp.py
+++ b/tests/test_knn_interp.py
@@ -169,7 +169,7 @@ def test_decam_wavefront():
     if __name__ == '__main__':
         logger = piff.config.setup_logger(verbose=2)
     else:
-        logger = piff.config.setup_logger(log_file='output/test_decamlog')
+        logger = piff.config.setup_logger(log_file='output/test_decam.log')
     knn = piff.des.DECamWavefront(file_name, extname, logger=logger)
 
     n_samples = 2000

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -1275,6 +1275,10 @@ def test_des2():
     orig_stamp = orig_image[stars[0].image.bounds] - stars[0]['sky']
     np.testing.assert_almost_equal(fit_stamp.array/flux, orig_stamp.array/flux, decimal=2)
 
+    # Test the offset_to_center function, which we don't use in code anymore.
+    # Not sure if it's still particularly useful, but might as well test it.
+    np.testing.assert_allclose(stars[0].fit.center, stars[0].offset_to_center(offset))
+
     # Now check a location far from any input stars where this used to get a checkerboard pattern.
     test_x = 2200
     test_y = 0

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -48,6 +48,7 @@ def make_gaussian_data(sigma, u0, v0, flux, noise=0., du=1., fpu=0., fpv=0., nsi
     star = piff.Star.makeTarget(x=nside/2+nom_u0/du, y=nside/2+nom_v0/du,
                                 u=fpu, v=fpv, scale=du, stamp_size=nside, weight=weight)
     star.image.setOrigin(0,0)
+    star.weight.setOrigin(0,0)
 
     g.drawImage(star.image, method='no_pixel', use_true_center=False,
                 offset=galsim.PositionD(nom_u0/du,nom_v0/du))

--- a/tests/test_poly.py
+++ b/tests/test_poly.py
@@ -349,7 +349,7 @@ def poly_load_save_sub(type1, type2, fname):
     assert interp2.order==interp.order
     np.testing.assert_array_equal(interp2.orders,interp.orders)
     assert interp2.nvariables==interp.nvariables
-    np.testing.assert_array_equal(interp2.indices,interp.indices)
+    assert interp2.indices == interp.indices
 
     # Check that the old and new interpolators generate the same
     # value

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -824,6 +824,20 @@ def test_draw():
         np.testing.assert_raises(ValueError, psf.draw, x, y, chipnum, center='imgae')
         np.testing.assert_raises(ValueError, psf.draw, x, y, chipnum, center=im8.true_center)
 
+        # If providing your own image with bounds far away from the star (say centered at 0),
+        # then center='image' works fine to draw in the center of that image.
+        im9 = im8.copy()
+        im9.setCenter(0,0)
+        psf.draw(x, y, chipnum, center='image', image=im9)
+        assert im9.bounds.center == galsim.PositionI(0,0)
+        np.testing.assert_allclose(im9.array.sum(), 1., rtol=1.e-3)
+        hsm = im9.FindAdaptiveMom()
+        center = im9.true_center
+        np.testing.assert_allclose(hsm.moments_centroid.x, center.x, atol=0.01)
+        np.testing.assert_allclose(hsm.moments_centroid.y, center.y, atol=0.01)
+        np.testing.assert_allclose(im9.array, im8.array, rtol=1.e-14, atol=1.e-14)
+
+
 
 
 if __name__ == '__main__':

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -808,6 +808,22 @@ def test_draw():
         assert im7.bounds == im1.bounds
         np.testing.assert_allclose(im7.array, im3.array, rtol=1.e-14, atol=1.e-14)
 
+        # Also allowed it center='image' to place in the center of the image.
+        im8 = psf.draw(x, y, chipnum, center='image')
+        assert im8.bounds == im1.bounds
+        assert im8.array.shape == (48,48)
+        np.testing.assert_allclose(im8.bounds.true_center.x, x, atol=0.5)
+        np.testing.assert_allclose(im8.bounds.true_center.y, y, atol=0.5)
+        np.testing.assert_allclose(im8.array.sum(), 1., rtol=1.e-3)
+        hsm = im8.FindAdaptiveMom()
+        center = im8.true_center
+        np.testing.assert_allclose(hsm.moments_centroid.x, center.x, atol=0.01)
+        np.testing.assert_allclose(hsm.moments_centroid.y, center.y, atol=0.01)
+
+        # Some invalid ways to try to do this. (Must be either 'image' or a tuple.)
+        np.testing.assert_raises(ValueError, psf.draw, x, y, chipnum, center='imgae')
+        np.testing.assert_raises(ValueError, psf.draw, x, y, chipnum, center=im8.true_center)
+
 
 
 if __name__ == '__main__':

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -797,6 +797,16 @@ def test_draw():
         np.testing.assert_allclose(hsm.moments_centroid.x, x+1.3, atol=0.01)
         np.testing.assert_allclose(hsm.moments_centroid.y, y-0.8, atol=0.01)
 
+        # Using center will draw the profile at the given center
+        # First, the default is equivalent to center=(x,y)
+        im6 = psf.draw(x, y, chipnum, center=(x,y))
+        assert im6.bounds == im1.bounds
+        np.testing.assert_allclose(im6.array, im1.array, rtol=1.e-14, atol=1.e-14)
+
+        # Other locations are equivalent to offset = center - image_pos
+        im7 = psf.draw(x, y, chipnum, center=(x+1.3,y-0.8))
+        assert im7.bounds == im1.bounds
+        np.testing.assert_allclose(im7.array, im3.array, rtol=1.e-14, atol=1.e-14)
 
 
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -832,15 +832,20 @@ def test_draw():
         np.testing.assert_allclose(hsm.moments_centroid.x, x+1.3, atol=0.01)
         np.testing.assert_allclose(hsm.moments_centroid.y, y-0.8, atol=0.01)
 
-        # Finally, test the old offset parameter, now deprecated.
+        # The offset parameter can add an additional to whatever center is used.
+        # Here center=None, so this is equivalent to im4 above.
         im9 = psf.draw(x, y, chipnum, offset=(1.3,-0.8))
         assert im9.bounds == im1.bounds
         hsm = im9.FindAdaptiveMom()
-        np.testing.assert_allclose(hsm.moments_centroid.x, x+1.3, atol=0.01)
-        np.testing.assert_allclose(hsm.moments_centroid.y, y-0.8, atol=0.01)
         np.testing.assert_allclose(im9.array, im4.array, rtol=1.e-14, atol=1.e-14)
 
-
+        # With both, they are effectively added together.  Not sure if there would be a likely
+        # use for this, but it's allowed.  (The above with default center is used in unit
+        # tests a number of times, so that version at least is useful if only for us.
+        # I'm hard pressed to imaging end users wanting to specify things this way though.)
+        im10 = psf.draw(x, y, chipnum, center=(x+0.8, y-0.3), offset=(0.5,-0.5))
+        assert im10.bounds == im1.bounds
+        np.testing.assert_allclose(im10.array, im4.array, rtol=1.e-14, atol=1.e-14)
 
 
 if __name__ == '__main__':

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -783,8 +783,8 @@ def test_draw():
         np.testing.assert_allclose(hsm.moments_centroid.x, x+1.3, atol=0.01)
         np.testing.assert_allclose(hsm.moments_centroid.y, y-0.8, atol=0.01)
 
-        # Also allowed is center='image' to place in the center of the image.
-        im5 = psf.draw(x, y, chipnum, center='image')
+        # Also allowed is center=True to place in the center of the image.
+        im5 = psf.draw(x, y, chipnum, center=True)
         assert im5.bounds == im1.bounds
         assert im5.array.shape == (48,48)
         np.testing.assert_allclose(im5.bounds.true_center.x, x, atol=0.5)
@@ -795,15 +795,15 @@ def test_draw():
         np.testing.assert_allclose(hsm.moments_centroid.x, center.x, atol=0.01)
         np.testing.assert_allclose(hsm.moments_centroid.y, center.y, atol=0.01)
 
-        # Some invalid ways to try to do this. (Must be either 'image' or a tuple.)
-        np.testing.assert_raises(ValueError, psf.draw, x, y, chipnum, center='imgae')
+        # Some invalid ways to try to do this. (Must be either True or a tuple.)
+        np.testing.assert_raises(ValueError, psf.draw, x, y, chipnum, center='image')
         np.testing.assert_raises(ValueError, psf.draw, x, y, chipnum, center=im5.true_center)
 
         # If providing your own image with bounds far away from the star (say centered at 0),
-        # then center='image' works fine to draw in the center of that image.
+        # then center=True works fine to draw in the center of that image.
         im6 = im5.copy()
         im6.setCenter(0,0)
-        psf.draw(x, y, chipnum, center='image', image=im6)
+        psf.draw(x, y, chipnum, center=True, image=im6)
         assert im6.bounds.center == galsim.PositionI(0,0)
         np.testing.assert_allclose(im6.array.sum(), 1., rtol=1.e-3)
         hsm = im6.FindAdaptiveMom()

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -601,7 +601,10 @@ def test_olddes():
     regression_array = np.array([[0.02920381, 0.03528429, 0.03267081],
                                  [0.03597827, 0.04419591, 0.04229439],
                                  [0.03001573, 0.03743261, 0.03300782]])
-    np.testing.assert_allclose(image.array[23:26,23:26], regression_array, rtol=1.e-5)
+    # Note: the centering mechanics have changed since this regression was set up to make the
+    # nominal PSF center closer to the image center.  So the second slice changed from
+    # 23:26 -> 22:25.
+    np.testing.assert_allclose(image.array[23:26,22:25], regression_array, rtol=1.e-5)
 
     # Also check that it is picklable.
     psf2 = copy.deepcopy(psf)
@@ -653,7 +656,10 @@ def test_newdes():
     regression_array = np.array([[0.03305565, 0.04500969, 0.0395154],
                                  [0.03765249, 0.05419811, 0.04867231],
                                  [0.02734579, 0.0418797, 0.03928504]])
-    np.testing.assert_allclose(image.array[23:26,23:26], regression_array, rtol=1.e-5)
+    # Note: the centering mechanics have changed since this regression was set up to make the
+    # nominal PSF center closer to the image center.  So the second slice changed from
+    # 23:26 -> 22:25.
+    np.testing.assert_allclose(image.array[23:26,22:25], regression_array, rtol=1.e-5)
 
     # Also check that it is picklable.
     psf2 = copy.deepcopy(psf)


### PR DESCRIPTION
This PR adds a `center` parameter to the `PSF.draw` method, which should be more intuitive for most users in terms of how to use it to specify where the profile should be centered on the resulting image.

As described in #73 the options are:
* `center=None` draws the PSF at the same (x,y) as was used for the interpolation.  This matches the current behavior.
* `center=(xc,yc)` draws the PSF centered at the given (xc,yc) location.
* `center=True` draws the PSF at the exact center of the image.
* `offset=(dx,dy)` still exists and acts as an additional offset to any of the above.