### PR TITLE
Add new 'select' field for selecting which objects to use as stars.

### DIFF
--- a/piff/__init__.py
+++ b/piff/__init__.py
@@ -91,6 +91,7 @@ from .outliers import Outliers, ChisqOutliers
 
 # Input handlers are named InputBlah where Blah is what they are called in the config file
 from .input import Input, InputFiles
+from .select import Select, SelectFlag
 from .star import Star, StarData, StarFit
 
 # Output handlers are named OutputBlah where Blah is what they are called in the config file

--- a/piff/config.py
+++ b/piff/config.py
@@ -105,6 +105,7 @@ def process(config, logger=None):
     :returns: the psf model
     """
     from .input import Input
+    from .select import Select
     from .psf import PSF
 
     if logger is None:
@@ -119,8 +120,11 @@ def process(config, logger=None):
     if 'modules' in config:
         galsim.config.ImportModules(config)
 
+    # TODO: Allow the select keys to be in config['input'], but give a warning.
+
     # read in the input images
-    stars, wcs, pointing = Input.process(config['input'], logger=logger)
+    objects, wcs, pointing = Input.process(config['input'], logger=logger)
+    stars = Select.process(config.get('select',{}), objects, logger=logger)
 
     psf = PSF.process(config['psf'], logger=logger)
     psf.fit(stars, wcs, pointing, logger=logger)
@@ -174,6 +178,9 @@ def plotify(config, logger=None):
         galsim.config.ImportModules(config)
 
     # read in the input images
+    # TODO: This isn't right for plotify.  Nor is it right to run a non-trivial selection.
+    #       Rather, we should take the stars from the psf object and just attach the
+    #       image stamps to them.
     stars, wcs, pointing = Input.process(config['input'], logger=logger)
 
     # load psf by looking at output file

--- a/piff/config.py
+++ b/piff/config.py
@@ -120,7 +120,18 @@ def process(config, logger=None):
     if 'modules' in config:
         galsim.config.ImportModules(config)
 
-    # TODO: Allow the select keys to be in config['input'], but give a warning.
+    # We used to allow a bunch of items in config['input'], which now belong in config['select']
+    # For the 1.x series, allow the old API, but give a warning.
+    select_keys = set(Select.base_keys)
+    user_input_keys = set(config['input'].keys())
+    depr_keys = select_keys & user_input_keys
+    if len(depr_keys) > 0:
+        logger.error("WARNING: Items %r should now be in the 'select' field of the config file.",
+                     sorted(depr_keys))
+        if 'select' not in config:
+            config['select'] = {}
+        for key in depr_keys:
+            config['select'][key] = config['input'].pop(key)
 
     # read in the input images
     objects, wcs, pointing = Input.process(config['input'], logger=logger)

--- a/piff/config.py
+++ b/piff/config.py
@@ -169,9 +169,10 @@ def plotify(config, logger=None):
     :param config:      The configuration file that defines how to build the model
     :param logger:      A logger object for logging progress. [default: None]
     """
-    from .input import Input
+    import piff
     from .psf import PSF
     from .output import Output
+    from .star import Star
 
     if logger is None:
         verbose = config.get('verbose', 1)
@@ -188,12 +189,6 @@ def plotify(config, logger=None):
     if 'modules' in config:
         galsim.config.ImportModules(config)
 
-    # read in the input images
-    # TODO: This isn't right for plotify.  Nor is it right to run a non-trivial selection.
-    #       Rather, we should take the stars from the psf object and just attach the
-    #       image stamps to them.
-    stars, wcs, pointing = Input.process(config['input'], logger=logger)
-
     # load psf by looking at output file
     file_name = config['output']['file_name']
     if 'dir' in config['output']:
@@ -201,7 +196,17 @@ def plotify(config, logger=None):
     logger.info("Looking for PSF at %s", file_name)
     psf = PSF.read(file_name, logger=logger)
 
-    # we don't want to rewrite the PSF to disk, so jump straight to the stats_list
+    # The stars we care about for plotify are psf.stars, not what would be made from scratch by
+    # processing the input and select fields.  For one, there may be a random component to that
+    # process, which would be different this time.  But also, some input objects might have been
+    # removed as outliers, so we don't want to include them here.
+    # However, the psf.stars do not have the images loaded (to save space in the output file
+    # so it's not enormous).  So we need to load in the images for the stats.
+    input_handler_class = getattr(piff, 'Input' + config['input'].get('type','Files'))
+    input_handler = input_handler_class(config['input'], logger)
+    stars = input_handler.load_images(psf.stars, logger=logger)
+
+    # We don't want to rewrite the PSF to disk, so jump straight to the stats_list
     output = Output.process(config['output'], logger=logger)
     logger.debug("stats_list = %s",output.stats_list)
     for stats in output.stats_list:

--- a/piff/input.py
+++ b/piff/input.py
@@ -913,6 +913,10 @@ class InputFiles(Input):
                                      "%s is not a column in %s"%(col_name,cat_file_name))
                 extra_props[col_name] = cat[col_name]
 
+        # If we used a flag column, keep it as a property.
+        if flag_col is not None:
+            extra_props[flag_col] = cat[flag_col]
+
         # Make the list of sky values:
         if sky_col is not None:
             if sky_col not in cat.dtype.names:

--- a/piff/model.py
+++ b/piff/model.py
@@ -220,7 +220,7 @@ class Model(object):
                                        dof = new_dof,
                                        params_var = star.fit.params_var))
 
-    def draw(self, star, copy_image=True, center=None):
+    def draw(self, star, copy_image=True):
         """Draw the model on the given image.
 
         :param star:        A Star instance with the fitted parameters to use for drawing and a
@@ -228,8 +228,6 @@ class Model(object):
         :param copy_image:  If False, will use the same image object.
                             If True, will copy the image and then overwrite it.
                             [default: True]
-        :param center:      An optional tuple (x,y) location for where to center the drawn profile
-                            in the image. [default: None, which draws at the star's location.]
 
         :returns: a new Star instance with the data field having an image of the drawn model.
         """
@@ -238,11 +236,7 @@ class Model(object):
             image = star.image.copy()
         else:
             image = star.image
-        if center is None:
-            center = star.image_pos
-        else:
-            center = galsim.PositionD(*center)
-        prof.drawImage(image, method=self._method, center=center)
+        prof.drawImage(image, method=self._method, center=star.image_pos)
         data = StarData(image, star.image_pos, star.weight, star.data.pointing)
         return Star(data, star.fit)
 

--- a/piff/model.py
+++ b/piff/model.py
@@ -220,7 +220,7 @@ class Model(object):
                                        dof = new_dof,
                                        params_var = star.fit.params_var))
 
-    def draw(self, star, copy_image=True):
+    def draw(self, star, copy_image=True, center=None):
         """Draw the model on the given image.
 
         :param star:        A Star instance with the fitted parameters to use for drawing and a
@@ -228,6 +228,8 @@ class Model(object):
         :param copy_image:  If False, will use the same image object.
                             If True, will copy the image and then overwrite it.
                             [default: True]
+        :param center:      An optional tuple (x,y) location for where to center the drawn profile
+                            in the image. [default: None, which draws at the star's location.]
 
         :returns: a new Star instance with the data field having an image of the drawn model.
         """
@@ -236,7 +238,11 @@ class Model(object):
             image = star.image.copy()
         else:
             image = star.image
-        prof.drawImage(image, method=self._method, center=star.image_pos)
+        if center is None:
+            center = star.image_pos
+        else:
+            center = galsim.PositionD(*center)
+        prof.drawImage(image, method=self._method, center=center)
         data = StarData(image, star.image_pos, star.weight, star.data.pointing)
         return Star(data, star.fit)
 

--- a/piff/select.py
+++ b/piff/select.py
@@ -1,0 +1,327 @@
+# Copyright (c) 2016 by Mike Jarvis and the other collaborators on GitHub at
+# https://github.com/rmjarvis/Piff  All rights reserved.
+#
+# Piff is free software: Redistribution and use in source and binary forms
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+
+"""
+.. module:: input
+"""
+
+import numpy as np
+import scipy
+import glob
+import os
+import galsim
+
+from .util import run_multi, calculateSNR
+from .star import Star, StarData
+
+class Select(object):
+    """The base class for selecting which stars to use for characterizing the PSF.
+
+    This is essentially an abstract base class intended to define the methods that should be
+    implemented by any derived class.
+    """
+    # Parameters that derived classes should ignore if they appear in the config dict
+    # (since they are handled by the base class).
+    base_keys= ['min_snr', 'max_snr', 'hsm_size_reject',
+                'max_edge_frac', 'stamp_center_size', 'max_mask_pixels',
+                'reserve_frac', 'seed']
+
+    def __init__(self, config, logger=None):
+        # Read the optional parameters that are used by the base class.
+        self.min_snr = config.get('min_snr', None)
+        self.max_snr = config.get('max_snr', 100)
+        self.max_edge_frac = config.get('max_edge_frac', None)
+        self.stamp_center_size = config.get('stamp_center_size', 13)
+        self.max_mask_pixels = config.get('max_mask_pixels', None)
+        self.hsm_size_reject = config.get('hsm_size_reject', 0.)
+        self.reserve_frac = config.get('reserve_frac', 0.)
+        self.rng = np.random.default_rng(config.get('seed', None))
+
+        if self.hsm_size_reject == 1:
+            # Enable True to be equivalent to 10.  True comes in as 1.0, which would be a
+            # silly value to use, so it shouldn't be a problem to turn 1.0 -> 10.0.
+            self.hsm_size_reject = 10.
+
+    @classmethod
+    def process(cls, config_select, objects, logger=None):
+        """Parse the select field of the config dict.
+
+        This stage handles three somewhat separate actions:
+
+        1. Select which objects in the input catalog are likely to be stars.
+        2. Reject stars according to a number of possible criteria.
+        3. Reserve some fraction of the remaining stars to not use for PSF fitting.
+
+        The first step is handled by the derived classes.  There are a number of possible
+        algorithms for doing that.  The default select type (Flag) selects objects that
+        are not flagged, or if no flag property is specified, then uses all input objects.
+
+        The second and third steps are common to all types and are handled by the base class.
+
+        The following parameters are relevant to steps 2 and 3 and are allowed for all
+        select types:
+
+            :min_snr:       The minimum S/N ratio to use.  If an input star is too faint, it is
+                            removed from the input list of PSF stars.
+            :max_snr:       The maximum S/N ratio to allow for any given star.  If an input star
+                            is too bright, it can have too large an influence on the interpolation,
+                            so this parameter limits the effective S/N of any single star.
+                            Basically, it adds noise to bright stars to lower their S/N down to
+                            this value.  [default: 100]
+            :max_edge_frac: Cutoff on the fraction of the flux comming from pixels on the edges of
+                            the postage stamp. [default: None]
+            :stamp_center_size: Distance from center of postage stamp (in pixels) to consider as
+                            defining the edge of the stamp for the purpose of the max_edge_fact cut.
+                            The default value of 13 is most of the radius of a 32x32 stamp size.
+                            If you change stamp_size, you should consider what makes sense here.
+                            [default 13].
+            :max_mask_pixels: If given, reject stars with more than this many masked pixels
+                            (i.e. those with w=0). [default: None]
+            :hsm_size_reject: Whether to reject stars with a very different hsm-measured size than
+                            the other stars in the input catalog.  (Used to reject objects with
+                            neighbors or other junk in the postage stamp.) [default: False]
+                            If this is a float value, it gives the number of inter-quartile-ranges
+                            to use for rejection relative to the median.  hsm_size_reject=True
+                            is equivalent to hsm_size_reject=10.
+            :reserve_frac:  Reserve a fraction of the stars from the PSF calculations, so they
+                            can serve as fair points for diagnostic testing.  These stars will
+                            not be used to constrain the PSF model, but the output files will
+                            contain the reserve stars, flagged as such.  Generally 0.2 is a
+                            good choice if you are going to use this. [default: 0.]
+            :seed:          A seed to use for numpy.random.default_rng, if desired. [default: None]
+
+        .. note::
+
+            The max_snr parameter is not actually a "selection" parameter.  It doesn't change
+            what stars are used.  Rather, it adjusts the relative weight that is given to the
+            brightest stars (so that they don't dominate the fit).
+
+        :param config_select:   The configuration dict.
+        :param objects:         A list of Star instances, which are at this point all potential
+                                objects to consider as possible stars.
+        :param logger:          A logger object for logging debug info. [default: None]
+
+        :returns: stars, the subset of objects which are to be considered stars
+        """
+        import piff
+
+        # Get the class to use for handling the selection
+        # Default type is 'Files'
+        select_handler_class = getattr(piff, 'Select' + config_select.get('type','Flag'))
+
+        # Build handler object
+        select_handler = select_handler_class(config_select)
+
+        # Creat a list of Star objects
+        stars = select_handler.selectStars(objects, logger)
+
+        if len(stars) == 0:
+            raise RuntimeError("No stars were selected.")
+
+        # Reject bad stars
+        stars = select_handler.rejectStars(stars, logger)
+
+        # Mark the reserve stars
+        select_handler.reserveStars(stars, logger)
+
+        return stars
+
+    def selectStars(self, objects, logger=None):
+        """Select which of the input objects should be considered stars.
+
+        :param objects:     A list of input objects to be considered as potential stars.
+        :param logger:      A logger object for logging debug info. [default: None]
+
+        :returns: a list of Star instances
+        """
+        raise NotImplementedError("Derived classes must define the selectStars function")
+
+    def reserveStars(self, stars, logger=None):
+        """Mark some of the stars as reserve stars.
+
+        This operates on the star list in place, adding the property `is_reserve`
+        to each star (only if some stars are being reserved).
+
+        :param stars:       A list of Star instances.
+        :param logger:      A logger object for logging debug info. [default: None]
+        """
+        if self.reserve_frac == 0:
+            return
+
+        logger = galsim.config.LoggerWrapper(logger)
+
+        # Apply the reserve separately on each ccd, so they each reserve 20% of their stars
+        # (or whatever fraction).  We wouldn't want to accidentally reserve all the stars on
+        # one of the ccds by accident, for instance.
+        chipnums = np.unique(list(s['chipnum'] for s in stars))
+        all_stars = [ [s for s in stars if s['chipnum'] == chipnum] for chipnum in chipnums]
+        for chip_stars in all_stars:
+            # Mark a fraction of the stars as reserve stars
+            nreserve = int(self.reserve_frac * len(chip_stars))  # round down
+            logger.info("Reserve %s of %s (reserve_frac=%s) input stars on chip %s",
+                        nreserve, len(stars), self.reserve_frac, chip_stars[0]['chipnum'])
+            reserve_list = self.rng.choice(len(chip_stars), nreserve, replace=False)
+            for i, star in enumerate(chip_stars):
+                star.data.properties['is_reserve'] = i in reserve_list
+
+    def rejectStars(self, stars, logger=None):
+        """Reject some nominal stars that may not be good exemplars of the PSF.
+
+        :param stars:       A list of Star instances.
+        :param logger:      A logger object for logging debug info. [default: None]
+
+        :returns: The subset of the input list that passed the rejection cuts.
+        """
+        logger = galsim.config.LoggerWrapper(logger)
+
+        if self.max_edge_frac is not None and len(stars) > 0:
+            stamp_size = stars[0].image.array.shape[0]
+            cen = (stamp_size-1.)/2.            # index at center of array.  May be half-integral.
+            i,j = np.ogrid[0:stamp_size,0:stamp_size]
+            edge_mask = (i-cen)**2 + (j-cen)**2 > self.stamp_center_size**2
+        else:
+            edge_mask = None
+
+        good_stars = []
+        for star in stars:
+
+            # Here we remove stars that have been at least partially covered by a mask
+            # and thus have weight exactly 0 in at least a certain number of pixels of their
+            # postage stamp
+            if self.max_mask_pixels is not None:
+                n_masked = np.prod(star.weight.array.shape) - np.count_nonzero(star.weight.array)
+                if n_masked >= self.max_mask_pixels:
+                    logger.warning("Star at position %f,%f has %i masked pixels, ",
+                                   star.image_pos.x, star.image_pos.y, n_masked)
+                    logger.warning("Skipping this star.")
+                    continue
+
+            # Check the snr and limit it if appropriate
+            snr = calculateSNR(star.image, star.weight)
+            logger.debug("SNR = %f",snr)
+            if self.min_snr is not None and snr < self.min_snr:
+                logger.info("Skipping star at position %f,%f with snr=%f.",
+                            star.image_pos.x, star.image_pos.y, snr)
+                continue
+            if self.max_snr > 0 and snr > self.max_snr:
+                factor = (self.max_snr / snr)**2
+                logger.debug("Scaling noise by factor of %f to achieve snr=%f",
+                             factor, self.max_snr)
+                star.data.weight *= factor
+                snr = self.max_snr
+            star.data.properties['snr'] = snr
+
+            # Reject stars with lots of flux near the edge of the stamp.
+            if self.max_edge_frac is not None and self.max_edge_frac < 1:
+                flux = np.sum(star.image.array)
+                try:
+                    flux_extra = np.sum(star.image.array[edge_mask])
+                    flux_frac = flux_extra / flux
+                except IndexError:
+                    logger.warning("Star at position %f,%f overlaps the edge of the image and "+
+                                   "max_edge_frac cut is set.",
+                                   star.image_pos.x, star.image_pos.y)
+                    logger.warning("Skipping this star.")
+                    continue
+                if flux_frac > self.max_edge_frac:
+                    logger.warning("Star at position %f,%f fraction of flux near edge of stamp "+
+                                   "exceeds cut: %f > %f",
+                                   star.image_pos.x, star.image_pos.y,
+                                   flux_frac, self.max_edge_frac)
+                    logger.warning("Skipping this star.")
+                    continue
+
+            # Add Poisson noise now.  It's not a rejection step, but it's something we want
+            # to do to all the stars at the start, so they have the right noise level.
+            # We didn't do it earlier for efficiency reasons, in case the full set of objects
+            # included lots of non-stars.
+            star = star.addPoisson()
+
+            good_stars.append(star)
+
+        # Calculate the hsm size for each star and throw out extreme outliers.
+        if self.hsm_size_reject != 0:
+            sigma = [star.hsm[3] for star in good_stars]
+            med_sigma = np.median(sigma)
+            iqr_sigma = scipy.stats.iqr(sigma)
+            logger.debug("Doing hsm sigma rejection.")
+            while np.max(np.abs(sigma - med_sigma)) > self.hsm_size_reject * iqr_sigma:
+                logger.debug("median = %s, iqr = %s, max_diff = %s",
+                                med_sigma, iqr_sigma, np.max(np.abs(sigma-med_sigma)))
+                k = np.argmax(np.abs(sigma-med_sigma))
+                logger.debug("remove k=%d: sigma = %s, pos = %s",k,sigma[k],good_stars[k].image_pos)
+                del sigma[k]
+                del good_stars[k]
+                med_sigma = np.median(sigma)
+                iqr_sigma = scipy.stats.iqr(sigma)
+
+        return good_stars
+
+
+class SelectFlag(Select):
+    """An Select handler that picks stars according to a flag column in the input catalog.
+    """
+    def __init__(self, config, logger=None):
+        """
+        Parse the config dict (Normally the 'select' field in the overall configuration dict).
+
+        The Flag type uses the following parameters, all optional.
+
+            :flag_name:     The name of the flag property (typically the column name in the
+                            input file) to use for selecting stars. [default: None]
+            :use_flag:      The flag indicating which items to use. [default: None]
+                            Items with flag & use_flag != 0 will be used.
+            :skip_flag:     The flag indicating which items not to use. [default: -1]
+                            Items with flag & skip_flag != 0 will be skipped.
+
+        The default behavior if flag_name is not given is to consier all input objects as stars.
+        If flag_name is given, but the others are not, then it selects all objects with flag=0.
+        Otherwise, it will select according to the prescriptions given above.
+
+        :param config:      The configuration dict used to define the above parameters.
+        :param logger:      A logger object for logging debug info. [default: None]
+        """
+        super(SelectFlag, self).__init__(config, logger)
+
+        self.flag_name = config.get('flag_name', None)
+        self.skip_flag = config.get('skip_flag', -1)
+        self.use_flag = config.get('skip_flag', None)
+
+    def selectStars(self, objects, logger=None):
+        """Select which of the input objects should be considered stars.
+
+        :param objects:     A list of input objects to be considered as potential stars.
+        :param logger:      A logger object for logging debug info. [default: None]
+
+        :returns: a list of Star instances
+        """
+        if self.flag_name is None:
+            return objects
+
+        logger = galsim.config.LoggerWrapper(logger)
+
+        try:
+            flag_array = [obj[self.flag_name] for obj in objects]
+        except KeyError:
+            raise ValueError("flag_name = {} is invalid.".format(self.flag_name))
+
+        # Follow the same logic as we used in InputFiles for selecting on an overall flag.
+        if self.use_flag is not None:
+            select = InputFiles._flag_select(flag_array, use_flag) != 0
+            if self.skip_flag != -1:
+                select &= InputFiles._flag_select(flag_array, skip_flag) == 0
+        else:
+            select = InputFiles._flag_select(flag_array, skip_flag) == 0
+
+        return objects[select]

--- a/piff/util.py
+++ b/piff/util.py
@@ -275,8 +275,8 @@ def run_multi(func, nproc, raise_except, args, logger, kwargs=None):
             else:  # pragma: no cover  (We don't use this option currently)
                 k = kwargs[i]
             result = pool.apply_async(_run_multi_helper,
-                                        args=(func, i, args[i], k, logger.logger.level),
-                                        callback=log_output)
+                                      args=(func, i, args[i], k, logger.logger.level),
+                                      callback=log_output)
             results.append(result)
         # Make sure we get all the results.  Without this, it works fine on success, but
         # errors seems to be swallowed.

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -1056,14 +1056,16 @@ def test_des_image():
             'ra' : 'TELRA',
             'dec' : 'TELDEC',
             'gain' : 'GAINA',
-            'reserve_frac' : 0.2,
-            'seed' : 1234,
             # Test explicitly specifying the wcs (although it is the same here as what is in the
             # image anyway).
             'wcs' : {
                 'type': 'Fits',
                 'file_name': image_file
             },
+        },
+        'select' : {
+            'reserve_frac' : 0.2,
+            'seed' : 1234,
         },
         'output' : {
             'file_name' : psf_file,
@@ -1281,10 +1283,11 @@ def test_des2():
             'dec' : 'TELDEC',
             'gain' : 1.0,
             # Real version uses pixmappy WCS, but that's not important for this test, so skip it
-
+            'stamp_size' : 25
+        },
+        'select' : {
             'max_snr' : 100,
             'min_snr' : 20,
-            'stamp_size' : 25
         },
         'output' : {
             'file_name' : psf_file,

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -303,6 +303,10 @@ def test_single_image():
         assert test_star_nocopy.image.array[1,1] == target_star_copy.image.array[1,1]
         assert test_star_copy.image.array[1,1] == target_star_copy.image.array[1,1]
 
+        test_star_center = draw(test_star_copy, copy_image=True, center=(x+1,y+1))
+        np.testing.assert_almost_equal(test_star_center.image.array[1:,1:],
+                                       test_star_copy.image.array[:-1,:-1])
+
     # test that draw works
     test_image = psf.draw(x=target['x'], y=target['y'], stamp_size=config['input']['stamp_size'],
                           flux=target.fit.flux, offset=target.fit.center)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -512,6 +512,21 @@ def test_reserve():
         # Fits should be good for both reserve and non-reserve stars
         np.testing.assert_almost_equal(star.fit.params, true_params, decimal=4)
 
+    # Check the old API of putting reserve_frac in input
+    config['input']['reserve_frac'] = 0.2
+    del config['select']
+    with CaptureLog() as cl:
+        piff.piffify(config, cl.logger)
+    assert "WARNING: Items ['reserve_frac'] should now be in the 'select' field" in cl.output
+    psf = piff.read(psf_file)
+    assert type(psf.model) is piff.Gaussian
+    assert type(psf.interp) is piff.Mean
+    nreserve = len([s for s in psf.stars if s.is_reserve])
+    ntot = len(psf.stars)
+    assert nreserve == 2
+    assert ntot == 10
+
+
 @timer
 def test_model():
     """Test Model base class

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -481,8 +481,10 @@ def test_reserve():
         'input' : {
             'image_file_name' : image_file,
             'cat_file_name' : cat_file,
-            'reserve_frac' : 0.2,
             'stamp_size' : 32,
+        },
+        'select' : {
+            'reserve_frac' : 0.2,
         },
         'psf' : {
             'model' : { 'type' : 'Gaussian',

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -614,6 +614,8 @@ def test_hsmcatalog():
             'image_file_name' : image_file,
             'cat_file_name' : cat_file,
             'stamp_size' : 48,
+        },
+        'select' : {
             'reserve_frac' : 0.2,
             'seed' : 123
         },
@@ -674,6 +676,7 @@ def test_hsmcatalog():
     # Use class directly, rather than through config.
     psf = piff.PSF.read(psf_file)
     stars, _, _ = piff.Input.process(config['input'])
+    stars = piff.Select.process(config['select'], stars)
     hsmcat = piff.stats.HSMCatalogStats()
     with np.testing.assert_raises(RuntimeError):
         hsmcat.write('dummy')  # Cannot write before compute


### PR DESCRIPTION
This PR is mostly a feature-preserving refactoring, but it adds a new optional field in the config file called 'select'.  This field is intended to be where we specify which objects to consider stars, and then which of those objects to potentially exclude for various reasons or to mark as reserved.

The various config options for excluding and reserving stars should now be placed in the `select` field, rather than `input`.  The old API of putting them in `input` will still work, but it gives a warning that this usage is deprecated.

So far, the only valid select type is 'Flag', which is also the default.  This essentially does the flag-based selection that we have had so far.  But it provides a hook for adding a "findstars" kind of selection as a new type.  (I'm planning to call that one `SizeMag` to be more descriptive of what the algorithm is doing than the name `findstars`.)

I'll work on adding `type=SizeMag` next, but I figured it was simpler for code review if did this refactoring separately from that effort.