### PR TITLE
Add reject option max_pixel_cut

### DIFF
--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1093,7 +1093,28 @@ def test_stars():
     assert len(stars) == 84
     del config['input']['satur']
 
-    # hsm_size_reject=True rejects a few of these.
+    # maxpixel_cut is almost the same thing, but figures out an equivalent flux cut and uses
+    # that to avoid imparting a size selection bias.
+    # For this set, it pulls in a few more to reject.
+    config['select']['max_pixel_cut'] = 1900
+    input = piff.InputFiles(config['input'], logger=logger)
+    select = piff.SelectFlag(config['select'], logger=logger)
+    stars = input.makeStars(logger=logger)
+    stars = select.rejectStars(stars, logger=logger)
+    assert len(stars) == 78
+
+    # Gratuitous coverage test.  If all objects have snr < 40, then max_pixel_cut doesn't
+    # remove anything, since it only considers stars with snr > 40.
+    config['select']['max_snr'] = 30
+    input = piff.InputFiles(config['input'], logger=logger)
+    select = piff.SelectFlag(config['select'], logger=logger)
+    stars = input.makeStars(logger=logger)
+    stars = select.rejectStars(stars, logger=logger)
+    assert len(stars) == 91
+    del config['select']['max_snr']
+    del config['select']['max_pixel_cut']
+
+    # hsm_size_reject=True rejects a few of these.  But mostly objects with neighbors.
     config['select']['hsm_size_reject'] = True
     input = piff.InputFiles(config['input'], logger=logger)
     select = piff.SelectFlag(config['select'], logger=logger)


### PR DESCRIPTION
@aaronroodman pointed out that our saturation cut can potentially bias the selection to favor larger stars.  At a given flux, larger stars will have smaller peak pixel values and thus be more more likely to survive the cut compared to smaller stars.

This PR adds a new selection option `max_pixel_cut`, which rejects stars when their flux implies that the maximum pixel value is greater than the given value.  Presumably, this should be unbiased with respect to size and yet still be able to exclude according to e.g. a bright/fatter effect upper-limit.