### PR TITLE
Fix output T values that had been incorrectly really sigma.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
                 pwd -P
                 cd tests
                 ls -la
-                coverage combine
+                coverage combine || true
                 coverage report
                 ls -la
                 #codecov  # This didn't work.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,3 +12,6 @@ New features
 
 Bug fixes
 ---------
+
+- Fixed bug in output stats that what we called T was really sigma.  Now, it's correctly
+  T = Ixx + Iyy = 2*sigma^2.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-Changes from version 1.0 to 1.1
+Changes from version 1.2 to 1.3
 ===============================
 
 
@@ -14,4 +14,4 @@ Bug fixes
 ---------
 
 - Fixed bug in output stats that what we called T was really sigma.  Now, it's correctly
-  T = Ixx + Iyy = 2*sigma^2.
+  T = Ixx + Iyy = 2*sigma^2. (#133)

--- a/piff/_version.py
+++ b/piff/_version.py
@@ -12,5 +12,5 @@
 #    this list of conditions and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
-__version__ = '1.1'
+__version__ = '1.3'
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -215,7 +215,7 @@ class SmallBrightSelect(Select):
         obj_shapes = np.array([ obj.hsm for obj in objects ])
         flag_obj = obj_shapes[:, 6]
         f_obj = obj_shapes[:, 0]
-        T_obj = obj_shapes[:, 3]
+        T_obj = 2*obj_shapes[:, 3]**2
 
         # Getting rid of the flags will mess with the indexing, so keep track of the original
         # index numbers.
@@ -304,7 +304,7 @@ class SmallBrightSelect(Select):
         select_index = orig_index[select]
         logger.debug("select_index = %s",select_index)
         stars = [objects[i] for i in select_index]
-        logger.debug("sizes of stars = %s",[s.hsm[3] for s in stars])
+        logger.debug("sizes of stars = %s",[2*s.hsm[3]**2 for s in stars])
         logger.debug("fluxs of stars = %s",[s.hsm[0] for s in stars])
 
         return stars
@@ -401,7 +401,7 @@ class SizeMagSelect(Select):
         obj_shapes = np.array([ obj.hsm for obj in objects ])
         flag_obj = obj_shapes[:, 6]
         f_obj = obj_shapes[:, 0]
-        T_obj = obj_shapes[:, 3]
+        T_obj = 2*obj_shapes[:, 3]**2
         u_obj = np.array([ obj.u for obj in objects ])
         v_obj = np.array([ obj.v for obj in objects ])
 
@@ -433,7 +433,7 @@ class SizeMagSelect(Select):
         star_shapes = np.array([ star.hsm for star in stars ])
         mask = star_shapes[:, 6] == 0
         logf_star = np.log(star_shapes[mask, 0])
-        logT_star = np.log(star_shapes[mask, 3])
+        logT_star = np.log(2*star_shapes[mask, 3]**2)
         u_star = np.array([ star.u for star in stars ])[mask]
         v_star = np.array([ star.v for star in stars ])[mask]
         logger.debug("logf_star = %s",logf_star)
@@ -531,7 +531,7 @@ class SizeMagSelect(Select):
         select_index = orig_index[select]
         logger.debug("select_index = %s",select_index)
         stars = [objects[i] for i in select_index]
-        logger.debug("sizes of stars = %s",[s.hsm[3] for s in stars])
+        logger.debug("sizes of stars = %s",[2*s.hsm[3]**2 for s in stars])
         logger.debug("fluxs of stars = %s",[s.hsm[0] for s in stars])
         return stars
 

--- a/piff/star.py
+++ b/piff/star.py
@@ -70,7 +70,7 @@ class Star(object):
         star.flux       The flux of the object
         star.center     The nominal center of the object (not necessarily the centroid)
         star.is_reserve Whether the star is reserved from being used to fit the PSF
-        star.hsm        HSM measurements for this star as a tuple: (flux, cenu, cenv, size, g1, g2)
+        star.hsm        HSM measurements for this star as a tuple: (flux, cenu, cenv, sigma, g1, g2)
     """
     def __init__(self, data, fit):
         """Constructor for Star instance.
@@ -165,7 +165,7 @@ class Star(object):
         This usually isn't called directly.  The results are accessible as star.hsm,
         which caches the results, so repeated access is efficient.
 
-        :returns: (flux, cenu, cenv, size, g1, g2, flag)
+        :returns: (flux, cenu, cenv, sigma, g1, g2, flag)
         """
         image, weight, image_pos = self.data.getImage()
         # Note that FindAdaptiveMom only respects the weight function in a binary sense.

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -161,6 +161,9 @@ class Stats(object):
         # but makes things work right if len(stars)=0.
         shapes_truth = shapes_truth.reshape((len(stars),7))
 
+        # Convert from sigma to T
+        shapes_truth[:,3] = 2*shapes_truth[:,3]**2
+
         # Pull out the positions to return
         positions = np.array([ (star.data.properties['u'], star.data.properties['v'])
                                for star in stars ])
@@ -172,6 +175,7 @@ class Stats(object):
             logger.debug("Generating and Measuring Model Stars")
             shapes_model = np.array([ star.hsm for star in psf.drawStarList(stars)])
             shapes_model = shapes_model.reshape((len(stars),7))
+            shapes_model[:,3] = 2*shapes_model[:,3]**2
             for star, shape in zip(stars, shapes_model):
                 logger.debug("model shape for star at %s is %s",star.image_pos, shape)
 

--- a/tests/test_sizemag.py
+++ b/tests/test_sizemag.py
@@ -101,7 +101,7 @@ def test_smallbright():
 
     # Fewer stars since limited to brighter subset
     print('nstars = ',len(stars))
-    assert len(stars) == 51
+    assert len(stars) == 53
 
     # But still finds all high confidence stars
     class_star = np.array([s['CLASS_STAR'] for s in stars])

--- a/tests/test_sizemag.py
+++ b/tests/test_sizemag.py
@@ -100,8 +100,9 @@ def test_smallbright():
     stars = piff.Select.process(config['select'], objects, logger=logger)
 
     # Fewer stars since limited to brighter subset
+    # Different systems give slightly different results here.  So give a range.
     print('nstars = ',len(stars))
-    assert len(stars) == 34
+    assert 30 < len(stars) < 40
 
     # But still finds all high confidence stars
     class_star = np.array([s['CLASS_STAR'] for s in stars])

--- a/tests/test_sizemag.py
+++ b/tests/test_sizemag.py
@@ -100,8 +100,9 @@ def test_smallbright():
     stars = piff.Select.process(config['select'], objects, logger=logger)
 
     # Fewer stars since limited to brighter subset
+    # Note: I get either 51 or 53 on different systems, so just allow a range here.
     print('nstars = ',len(stars))
-    assert len(stars) == 53
+    assert len(stars) < 60 and len(stars) > 40
 
     # But still finds all high confidence stars
     class_star = np.array([s['CLASS_STAR'] for s in stars])

--- a/tests/test_sizemag.py
+++ b/tests/test_sizemag.py
@@ -67,9 +67,9 @@ def test_smallbright():
     objects, _, _ = piff.Input.process(config['input'], logger=logger)
     stars = piff.Select.process(config['select'], objects, logger=logger)
 
-    # This does a pretty decent job actually.  Finds 94 stars.
+    # This does a pretty decent job actually.  Finds 88 stars.
     print('nstars = ',len(stars))
-    assert len(stars) == 94
+    assert len(stars) == 88
 
     # They are all ones that CLASS_STAR also identified as stars.
     class_star = np.array([s['CLASS_STAR'] for s in stars])
@@ -100,9 +100,8 @@ def test_smallbright():
     stars = piff.Select.process(config['select'], objects, logger=logger)
 
     # Fewer stars since limited to brighter subset
-    # Note: I get either 51 or 53 on different systems, so just allow a range here.
     print('nstars = ',len(stars))
-    assert len(stars) < 60 and len(stars) > 40
+    assert len(stars) == 34
 
     # But still finds all high confidence stars
     class_star = np.array([s['CLASS_STAR'] for s in stars])
@@ -149,9 +148,9 @@ def test_smallbright():
     }
     # If sizes are spaced such that the small ones are consistently farther apart than bigger
     # ones, then the median/iqr iteration will keep slowly shifting to a larger size.
-    # Having sizes go as 1/sqrt(i+1) seems to work to make this happen.
+    # Having T go as 1/sqrt(i+1) seems to work to make this happen.
     for i in range(len(objects)):
-        objects[i]._hsm = (1., 0., 0., 1./(i+1.)**0.5, 0., 0., 0)
+        objects[i]._hsm = (1., 0., 0., 1./(i+1.)**0.25, 0., 0., 0)
     select = piff.SmallBrightSelect(config['select'])
     with CaptureLog() as cl:
         stars = select.selectStars(objects, logger=cl.logger)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -64,13 +64,14 @@ def test_twodstats():
     jcenter = 2000
     # the average value in the bin should match up with the model for the average coordinates
     sigma, g1, g2 = psf_model(icen, jcen, icenter, jcenter)
-    sigma_average = stats.twodhists['T'][v_i, u_i]
+    T = 2*sigma**2
+    T_average = stats.twodhists['T'][v_i, u_i]
     g1_average = stats.twodhists['g1'][v_i, u_i]
     g2_average = stats.twodhists['g2'][v_i, u_i]
     # assert equal to 4th decimal
-    print('sigma, g1, g2 = ',[sigma,g1,g2])
-    print('av sigma, g1, g2 = ',[sigma_average,g1_average,g2_average])
-    np.testing.assert_almost_equal([sigma, g1, g2], [sigma_average, g1_average, g2_average],
+    print('T, g1, g2 = ',[T,g1,g2])
+    print('av T, g1, g2 = ',[T_average,g1_average,g2_average])
+    np.testing.assert_almost_equal([T, g1, g2], [T_average, g1_average, g2_average],
                                    decimal=2)
 
     # Test the plotting and writing
@@ -475,10 +476,11 @@ def test_shapestats_config():
 
     # test their characteristics
     sigma = 1.3  # (copied from setup())
+    T = 2*sigma**2
     g1 = 0.23
     g2 = -0.17
-    np.testing.assert_array_almost_equal(sigma, shapeStats.T, decimal=4)
-    np.testing.assert_array_almost_equal(sigma, shapeStats.T_model, decimal=3)
+    np.testing.assert_array_almost_equal(T, shapeStats.T, decimal=4)
+    np.testing.assert_array_almost_equal(T, shapeStats.T_model, decimal=3)
     np.testing.assert_array_almost_equal(g1, shapeStats.g1, decimal=4)
     np.testing.assert_array_almost_equal(g1, shapeStats.g1_model, decimal=3)
     np.testing.assert_array_almost_equal(g2, shapeStats.g2, decimal=4)


### PR DESCRIPTION
@theoschutt noticed a bug in the Piff output catalogs that the columns labeled "T" were really "sigma".  This PR fixes them to be T as advertised according to T = 2 sigma^2.