### PR TITLE
Fix error in sizemag plot when there are negative flux measurements or no stars

### DIFF
--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -63,19 +63,19 @@ class SizeMagStats(Stats):
 
         # Pull out the sizes and fluxes
         flag_star = star_shapes[:, 6]
-        mask = flag_star == 0
+        mask = (flag_star == 0) & (star_shapes[:,0] > 0)
         self.f_star = star_shapes[mask, 0]
         self.T_star = star_shapes[mask, 3]
         flag_psf = psf_shapes[:, 6]
-        mask = flag_psf == 0
+        mask = (flag_psf == 0) & (psf_shapes[:,0] > 0)
         self.f_psf = psf_shapes[mask, 0]
         self.T_psf = psf_shapes[mask, 3]
         flag_obj = obj_shapes[:, 6]
-        mask = flag_obj == 0
+        mask = (flag_obj == 0) & (obj_shapes[:,0] > 0)
         self.f_obj = obj_shapes[mask, 0]
         self.T_obj = obj_shapes[mask, 3]
         flag_init = init_shapes[:, 6]
-        mask = flag_init == 0
+        mask = (flag_init == 0) & (init_shapes[:,0] > 0)
         self.f_init = init_shapes[mask, 0]
         self.T_init = init_shapes[mask, 3]
 
@@ -98,11 +98,16 @@ class SizeMagStats(Stats):
         fig = Figure(figsize=(8,6))
         ax = fig.add_subplot(1,1,1)
 
-        xmin = np.floor(np.min(self.m_star))
-        xmin = np.min(self.m_init, initial=xmin)  # Do it this way in case m_init is empty.
-        xmax = np.ceil(np.max(self.m_star))
-        xmax = np.max(self.m_obj, initial=xmax)   # Likewise, m_obj might be empty.
-        ymax = max(np.median(self.T_star)*2, np.max(self.T_star)*1.01)
+        if len(self.m_star) == 0:
+            xmin = np.floor(np.min(self.m_obj, initial=0))
+            xmax = np.ceil(np.max(self.m_obj, initial=100))
+            ymax = np.median(self.T_obj)*2 if len(self.T_obj) > 0 else 1.0
+        else:
+            xmin = np.floor(np.min(self.m_star))
+            xmin = np.min(self.m_init, initial=xmin)  # Do it this way in case m_init is empty.
+            xmax = np.ceil(np.max(self.m_star))
+            xmax = np.max(self.m_obj, initial=xmax)   # Likewise, m_obj might be empty.
+            ymax = max(np.median(self.T_star)*2, np.max(self.T_star)*1.01)
         ax.set_xlim(xmin, xmax)
         ax.set_ylim(0, ymax)
         ax.set_xlabel('Magnitude (ZP=%s)'%self.zeropoint, fontsize=15)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -706,6 +706,7 @@ def test_bad_hsm():
     shape_file = os.path.join('output','bad_hsm_shape.pdf')
     star_file = os.path.join('output','bad_hsm_star.pdf')
     hsm_file = os.path.join('output','bad_hsm_hsm.fits')
+    sizemag_file = os.path.join('output','bad_hsm_sizemag.png')
 
     stamp_size = 25
 
@@ -753,6 +754,10 @@ def test_bad_hsm():
                     'file_name': star_file,
                 },
                 {
+                    'type': 'SizeMag',
+                    'file_name': sizemag_file,
+                },
+                {
                     'type': 'HSMCatalog',
                     'file_name': hsm_file,
                 },
@@ -791,7 +796,7 @@ def test_bad_hsm():
     assert len(psf.stars) == 1
     assert psf.nremoved == 7    # There were 8 to start.
 
-    for f in [twodhist_file, rho_file, shape_file, star_file, hsm_file]:
+    for f in [twodhist_file, rho_file, shape_file, star_file, sizemag_file, hsm_file]:
         assert os.path.exists(f)
 
 @timer


### PR DESCRIPTION
@rgruendl found that the size-mag plot could sometimes fail, raising an exception that stops the whole program.  It happened because some hsm fluxes ended up negative, so the magnitude was nan, which caused catastrophic problesm.  This PR fixes this by excluding any objects with negative flux from the plot.  It also now behaves gracefully if there are no stars found or even no input objects (with good hsm measurements) at all.