### PR TITLE
Fix some issues that turned up in Y6 Piff run.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,3 +23,11 @@ Changes from version 1.2.2 to 1.2.3
 
 - Don't skip stars in HSM output file.  Rather just mark failed HSM measurements with
   flag_truth=-1 or flag_model=-1 as appropriate.
+
+Changes from version 1.2.3 to 1.2.4
+-----------------------------------
+
+- Flag objects when HSM returns a negative flux or moves the centroid by more than 1 pixel. (#136)
+- Fixed labeling error in SizeMag plot (model and data were reversed). (#136)
+- Fixed bug in StarStat plot when nplot=0. (#136)
+- Fixed bug in SizeMag selector that the reserve and reject steps were applied twice. (#136)

--- a/piff/_version.py
+++ b/piff/_version.py
@@ -12,5 +12,5 @@
 #    this list of conditions and the disclaimer given in the documentation
 #    and/or other materials provided with the distribution.
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/piff/select.py
+++ b/piff/select.py
@@ -57,7 +57,7 @@ class Select(object):
             self.hsm_size_reject = 10.
 
     @classmethod
-    def process(cls, config_select, objects, logger=None):
+    def process(cls, config_select, objects, logger=None, select_only=False):
         """Parse the select field of the config dict.
 
         This stage handles three somewhat separate actions:
@@ -119,6 +119,7 @@ class Select(object):
         :param objects:         A list of Star instances, which are at this point all potential
                                 objects to consider as possible stars.
         :param logger:          A logger object for logging debug info. [default: None]
+        :param select_only:     Whether to stop after the primary selection step. [default: False]
 
         :returns: stars, the subset of objects which are to be considered stars
         """
@@ -137,8 +138,14 @@ class Select(object):
         if len(stars) == 0:
             raise RuntimeError("No stars were selected.")
 
+        if select_only:
+            return stars
+
         # Reject bad stars
         stars = select_handler.rejectStars(stars, logger)
+
+        if len(stars) == 0:
+            raise RuntimeError("All stars were rejected.")
 
         # Mark the reserve stars
         select_handler.reserveStars(stars, logger)

--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -397,7 +397,7 @@ class SizeMagSelect(Select):
 
         logger.info("Selecting stars according to locus in size-magnitude diagram")
 
-        stars = Select.process(self.initial_select, objects, logger=logger)
+        stars = Select.process(self.initial_select, objects, logger=logger, select_only=True)
 
         logger.debug("N objects = %s", len(objects))
         logger.debug("N initial stars = %s", len(stars))

--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -63,19 +63,19 @@ class SizeMagStats(Stats):
 
         # Pull out the sizes and fluxes
         flag_star = star_shapes[:, 6]
-        mask = (flag_star == 0) & (star_shapes[:,0] > 0)
+        mask = flag_star == 0
         self.f_star = star_shapes[mask, 0]
         self.T_star = star_shapes[mask, 3]
         flag_psf = psf_shapes[:, 6]
-        mask = (flag_psf == 0) & (psf_shapes[:,0] > 0)
+        mask = flag_psf == 0
         self.f_psf = psf_shapes[mask, 0]
         self.T_psf = psf_shapes[mask, 3]
         flag_obj = obj_shapes[:, 6]
-        mask = (flag_obj == 0) & (obj_shapes[:,0] > 0)
+        mask = flag_obj == 0
         self.f_obj = obj_shapes[mask, 0]
         self.T_obj = obj_shapes[mask, 3]
         flag_init = init_shapes[:, 6]
-        mask = (flag_init == 0) & (init_shapes[:,0] > 0)
+        mask = flag_init == 0
         self.f_init = init_shapes[mask, 0]
         self.T_init = init_shapes[mask, 3]
 

--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -205,7 +205,7 @@ class SmallBrightSelect(Select):
         """
         logger = galsim.config.LoggerWrapper(logger)
 
-        logger.info("Selecting small/bright objects as stars")
+        logger.warning("Selecting small/bright objects as stars")
 
         logger.debug("Initial count = %s", len(objects))
 
@@ -311,6 +311,7 @@ class SmallBrightSelect(Select):
         stars = [objects[i] for i in select_index]
         logger.debug("sizes of stars = %s",[2*s.hsm[3]**2 for s in stars])
         logger.debug("fluxs of stars = %s",[s.hsm[0] for s in stars])
+        logger.warning("Bright/small selection found %d likely stars",len(stars))
 
         return stars
 
@@ -395,7 +396,7 @@ class SizeMagSelect(Select):
         """
         logger = galsim.config.LoggerWrapper(logger)
 
-        logger.info("Selecting stars according to locus in size-magnitude diagram")
+        logger.warning("Selecting stars according to locus in size-magnitude diagram")
 
         stars = Select.process(self.initial_select, objects, logger=logger, select_only=True)
 
@@ -530,14 +531,16 @@ class SizeMagSelect(Select):
             logT_star = logT_obj[select]
             u_star = u_obj[select]
             v_star = v_obj[select]
-            logger.info("SizeMag iteration %d => N stars = %d", i_iter, len(logf_star))
-            logger.info("Mean logT of stars = %s, std = %s", np.mean(logT_star), np.std(logT_star))
+            logger.warning("SizeMag iteration %d => N stars = %d", i_iter, len(logf_star))
+            logger.warning("Mean logT of stars = %s, std = %s", np.mean(logT_star), np.std(logT_star))
 
         select_index = orig_index[select]
         logger.debug("select_index = %s",select_index)
         stars = [objects[i] for i in select_index]
         logger.debug("sizes of stars = %s",[2*s.hsm[3]**2 for s in stars])
         logger.debug("fluxs of stars = %s",[s.hsm[0] for s in stars])
+        logger.warning("SizeMag selection found %d likely stars",len(stars))
+
         return stars
 
     @staticmethod

--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -136,11 +136,11 @@ class SizeMagStats(Stats):
                              color='black', marker='o', s=2., **kwargs)
             init = ax.scatter(m[s][g[s] == 2], T[s][g[s] == 2],
                               color='magenta', marker='o', s=8., **kwargs)
-            psf = ax.scatter(m[s][g[s] == 3], T[s][g[s] == 3],
+            star = ax.scatter(m[s][g[s] == 3], T[s][g[s] == 3],
+                              color='green', marker='*', s=40., **kwargs)
+            psf = ax.scatter(m[s][g[s] == 4], T[s][g[s] == 4],
                              marker='o', s=50.,
                              facecolors='none', edgecolors='cyan', **kwargs)
-            star = ax.scatter(m[s][g[s] == 4], T[s][g[s] == 4],
-                              color='green', marker='*', s=40., **kwargs)
 
         ax.legend([obj, init, star, psf],
               ['Detected Object', 'Candidate Star', 'PSF Star', 'PSF Model'],

--- a/piff/star.py
+++ b/piff/star.py
@@ -192,7 +192,15 @@ class Star(object):
 
         localwcs = image.wcs.local(image_pos)
         center = localwcs.toWorld(mom.moments_centroid) - localwcs.toWorld(image_pos)
+
+        # Do a few sanity checks and flag likely bad fits.
         flag = mom.moments_status
+        if flag != 0:
+            flag = 1
+        if flux < 0:
+            flag |= 2
+        if center.x**2 + center.y**2 > 1:
+            flag |= 4
 
         return flux, center.x, center.y, sigma, shape.g1, shape.g2, flag
 

--- a/piff/star_stats.py
+++ b/piff/star_stats.py
@@ -145,7 +145,8 @@ class StarStats(Stats):
         logger = galsim.config.LoggerWrapper(logger)
 
         # 6 x nplot/2 images, with each image (3.5 x 3)
-        nrows = (self.nplot+1)//2
+        nplot = len(self.indices)
+        nrows = (nplot+1)//2
         fig = Figure(figsize = (21,3*nrows))
         axs = fig.subplots(ncols=6, nrows=nrows, squeeze=False)
 

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -591,6 +591,18 @@ class HSMCatalogStats(Stats):
     This will compute the size and shapes of the observed stars and the PSF models
     and write these data to a file.
 
+    The HSM adaptive momemnt measurements sometimes fail in various ways.  When it does,
+    we still output the information that we have for a star, but mark the failure with
+    a flag: flag_truth for errors in the data measurement, flag_model for errors in the
+    model measurement.  The meaning of these flags are (treated as a bit mask):
+
+    Flags:
+
+        0 = Success
+        1 = HSM returned a non-zero moments_status.
+        2 = HSM returned a negative flux.
+        4 = HSM's centroid moved by more than 1 pixel from the input position.
+
     The output file will include the following columns:
 
         :ra:        The RA of the star in degrees. (or 0 if the wcs is not a CelestialWCS)
@@ -606,8 +618,8 @@ class HSMCatalogStats(Stats):
         :g1_model:  The g1 component of the PSF model.
         :g2_model:  The g2 component of the PSF model.
         :reserve:   Whether the star was a reserve star.
-        :flag_truth: 0 where HSM succeeded on the observed star, -1 where it failed.
-        :flag_model: 0 where HSM succeeded on the PSF model, -1 where it failed.
+        :flag_truth: 0 where HSM succeeded on the observed star, >0 where it failed (see above).
+        :flag_model: 0 where HSM succeeded on the PSF model, >0 where it failed (see above).
     """
     def __init__(self, file_name=None, logger=None):
         """

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -657,6 +657,13 @@ def test_flag_select():
     with np.testing.assert_raises(RuntimeError):
         piff.Select.process(config['select'], stars1)
 
+    # Raises at different place if all stars are rejected.
+    config['select']['use_flag'] = 1
+    config['select']['reject_where'] = 'True'
+    with np.testing.assert_raises(RuntimeError):
+        piff.Select.process(config['select'], stars1)
+    del config['select']['reject_where']
+
     # Base class selectStars function is not implemented.
     select = piff.Select(config['select'])
     with np.testing.assert_raises(NotImplementedError):

--- a/tests/test_sizemag.py
+++ b/tests/test_sizemag.py
@@ -234,7 +234,7 @@ def test_sizemag():
 
     # This finds more stars than the simple SmallBright selector found.
     print('nstars = ',len(stars))
-    assert len(stars) == 142
+    assert len(stars) == 140
 
     # A few of these have lower CLASS_STAR values, but still most are > 0.95
     class_star = np.array([s['CLASS_STAR'] for s in stars])
@@ -273,13 +273,13 @@ def test_sizemag():
 
     # Somewhat fewer, but still works reasonably ok.
     print('nstars = ',len(stars))
-    assert len(stars) == 119
+    assert len(stars) == 135
 
     class_star = np.array([s['CLASS_STAR'] for s in stars])
     print('class_star = ',class_star)
     print('min class_star = ',np.min(class_star))
     print('N class_star > 0.95 = ',np.sum(class_star > 0.95))
-    assert np.sum(class_star > 0.95) == 117
+    assert np.sum(class_star > 0.95) == 135
 
     sizes = [s.hsm[3] for s in stars]
     print('mean size = ',np.mean(sizes))

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -558,6 +558,7 @@ def test_starstats_config():
     # if use all stars, no randomness
     np.testing.assert_array_equal(starStats.stars[3].image.array, orig_stars[3].image.array)
     np.testing.assert_array_equal(starStats.indices, np.arange(len(orig_stars)))
+    starStats.plot()  # Make sure this runs without error and in finite time.
 
     # check nplot = 0
     starStats = piff.StarStats(nplot=0)
@@ -566,6 +567,7 @@ def test_starstats_config():
     # if use all stars, no randomness
     np.testing.assert_array_equal(starStats.stars[3].image.array, orig_stars[3].image.array)
     np.testing.assert_array_equal(starStats.indices, np.arange(len(orig_stars)))
+    starStats.plot()  # Make sure this runs without error.
 
     # rerun with adjust stars and see if it did the right thing
     # first with starstats == False

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -815,8 +815,8 @@ def test_bad_hsm():
         assert len(data[col]) == 1
     print('flag_truth = ',data['flag_truth'])
     print('flag_model = ',data['flag_model'])
-    np.testing.assert_array_equal(data['flag_truth'], -1)
-    np.testing.assert_array_equal(data['flag_model'], -1)
+    np.testing.assert_array_equal(data['flag_truth'], 7)
+    np.testing.assert_array_equal(data['flag_model'], 7)
 
 
 @timer


### PR DESCRIPTION
The main problem being fixed here is that sometimes for the reserve stars, the hsm fits get influenced by a neighbor and slide off to the side, ending up either with a bad flux or size or both.  Here is an example:
<img width="320" alt="Screen Shot 2022-06-23 at 10 35 28 AM" src="https://user-images.githubusercontent.com/623887/175394932-dc8b72eb-b458-40f2-aca0-f2a2febfcd78.png">

To fix this, I have the hsm code check for either negative flux or a centroid shift of more than 1 pixel and flag them.  So now the hsm flags are: 1 = HSM itself reported failure, 2 = returned flux < 0, 4 = centroid shift.  These are added bitwise.

While looking into this I fixed a few other things as well:
* When the SizeMag selector calls the initial_select function to get the starting selection of likely stars, it called the normal Select.process function.  This function first selects, but then does some other things including calculate snr values, apply various rejections, and assign reserve stars.  We don't actually want to do any of these other things until we're done with SizeMag.  So now the initial selection stops after just the selection step.
* I noticed that the SizeMag plot that I make was mislabeling the data and models.  Somehow I had these reversed.  So I fixed that.
* I discovered a bug in the StarStat plot when nplot=0, which I fixed.
* I cleaned up the logging a bit where I thought it was being over-verbose on the default verbosity (=1).  I also added some information that I thought was useful to see, but which was absent from the log.
