### PR TITLE
Add model_properties option to hsm stat output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             matrix:
                 # First all python versions in basic linux
                 os: [ ubuntu-latest ]
-                py: [ 3.6, 3.7, 3.8, 3.9 ]
+                py: [ 3.7, 3.8, 3.9, "3.10" ]
                 CC: [ gcc ]
                 CXX: [ g++ ]
 

--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -27,7 +27,6 @@ class SizeMagStats(Stats):
 
     :param file_name:       Name of the file to output to. [default: None]
     :param zeropoint:       Zeropoint to use = the magnitude of flux=1. [default: 30]
-    :param model_properties: Optional properties to use for the model rendering. (default: None)
     :param logger:          A logger object for logging debug info. [default: None]
     """
     def __init__(self, file_name=None, zeropoint=30, logger=None):

--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -27,6 +27,7 @@ class SizeMagStats(Stats):
 
     :param file_name:       Name of the file to output to. [default: None]
     :param zeropoint:       Zeropoint to use = the magnitude of flux=1. [default: 30]
+    :param model_properties: Optional properties to use for the model rendering. (default: None)
     :param logger:          A logger object for logging debug info. [default: None]
     """
     def __init__(self, file_name=None, zeropoint=30, logger=None):

--- a/piff/star.py
+++ b/piff/star.py
@@ -94,6 +94,19 @@ class Star(object):
             fit.center = center
         return Star(self.data, fit)
 
+    def withProperties(self, **kwargs):
+        """Set or change any properties in the star.
+
+        :param **kwargs:    Each named kwarg is taken to be a property to set in the returned star.
+
+        :returns: a new Star with the given properties, but is otherwise the same as self.
+        """
+        data = self.data.copy()
+        props = data.properties.copy()
+        props.update(kwargs)
+        data.properties = props
+        return Star(data, self.fit)
+
     def __getitem__(self, key):
         """Get a property of the star.
 

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -148,7 +148,10 @@ class Stats(object):
 
         :param psf:         A PSF Object
         :param stars:       A list of Star instances.
-        :param model_properties: Optional properties to use for the model rendering.
+        :param model_properties: Optionally a dict of properties to use for the model rendering.
+                                 The default behavior is to use the properties of the star itself
+                                 for any properties that are not overridden by model_properties.
+                                 [default: None]
         :param logger:      A logger object for logging debug info. [default: None]
 
         :returns:           positions of stars, shapes of stars, and shapes of
@@ -217,7 +220,8 @@ class ShapeHistStats(Stats):
     :param nbins:       Number of bins to use. [default: sqrt(n_stars)]
     :param cut_frac:    Fraction to cut off from histograms at the high and low ends.
                         [default: 0.01]
-    :param model_properties: Optional properties to use for the model rendering. [default: None]
+    :param model_properties: Optionally a dict of properties to use for the model rendering.
+                             [default: None]
     """
     def __init__(self, file_name=None, nbins=None, cut_frac=0.01, model_properties=None,
                  logger=None):
@@ -403,7 +407,8 @@ class RhoStats(Stats):
     :param max_sep:     Maximum separation (in arcmin) for pairs. [default: 300]
     :param bin_size:    Size of bins in log(sep). [default 0.1]
     :param file_name:   Name of the file to output to. [default: None]
-    :param model_properties: Optional properties to use for the model rendering. [default: None]
+    :param model_properties: Optionally a dict of properties to use for the model rendering.
+                             [default: None]
     :param logger:      A logger object for logging debug info. [default: None]
     :param \**kwargs:    Any additional kwargs are passed on to TreeCorr.
     """
@@ -645,9 +650,9 @@ class HSMCatalogStats(Stats):
 
     :param file_name:        Name of the file to output to. [default: None]
     :param model_properties: Optionally a dict of properties to use for the model rendering.
-                             The default behavior, which applies to all relevant properties
-                             if this is None (default) or to any missing from the dict, is to
-                             use the properties of the star being compared to.
+                             The default behavior is to use the properties of the star itself
+                             for any properties that are not overridden by model_properties.
+                             [default: None]
     """
     def __init__(self, file_name=None, model_properties=None, logger=None):
         self.file_name = file_name

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -689,9 +689,8 @@ class HSMCatalogStats(Stats):
         # Also write any other properties saved in the stars.
         self.props = {}
         prop_keys = list(stars[0].data.properties)
-        # Already did the position ones.
-        for key in [ 'x', 'y', 'u', 'v' ]:
-            prop_keys.remove(key)
+        # Remove all the position ones, which are handled separately.
+        prop_keys = [key for key in prop_keys if key not in ['x', 'y', 'u', 'v', 'ra', 'dec']]
         # Add any remaining properties
         for key in prop_keys:
             self.props[key] = [ s.data.properties[key] for s in stars ]

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -217,7 +217,7 @@ class ShapeHistStats(Stats):
     :param nbins:       Number of bins to use. [default: sqrt(n_stars)]
     :param cut_frac:    Fraction to cut off from histograms at the high and low ends.
                         [default: 0.01]
-    :param model_properties: Optional properties to use for the model rendering. (default: None)
+    :param model_properties: Optional properties to use for the model rendering. [default: None]
     """
     def __init__(self, file_name=None, nbins=None, cut_frac=0.01, model_properties=None,
                  logger=None):
@@ -403,7 +403,7 @@ class RhoStats(Stats):
     :param max_sep:     Maximum separation (in arcmin) for pairs. [default: 300]
     :param bin_size:    Size of bins in log(sep). [default 0.1]
     :param file_name:   Name of the file to output to. [default: None]
-    :param model_properties: Optional properties to use for the model rendering. (default: None)
+    :param model_properties: Optional properties to use for the model rendering. [default: None]
     :param logger:      A logger object for logging debug info. [default: None]
     :param \**kwargs:    Any additional kwargs are passed on to TreeCorr.
     """

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -695,7 +695,7 @@ class HSMCatalogStats(Stats):
         dtypes = [('u', float), ('v', float),
                   ('x', float), ('y', float),
                   ('ra', float), ('dec', float),
-                  ('flux', float), ('reserve', float),
+                  ('flux', float), ('reserve', int),
                   ('flag_truth', int), ('flag_model', int),
                   ('T_data', float), ('g1_data', float), ('g2_data', float),
                   ('T_model', float), ('g1_model', float), ('g2_model', float)]

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -669,6 +669,15 @@ class HSMCatalogStats(Stats):
         else:
             self.ra = np.zeros_like(self.u)
             self.dec = np.zeros_like(self.u)
+        # Also write any other properties saved in the stars.
+        self.props = {}
+        prop_keys = list(stars[0].data.properties)
+        # Already did the position ones.
+        for key in [ 'x', 'y', 'u', 'v' ]:
+            prop_keys.remove(key)
+        # Add any remaining properties
+        for key in prop_keys:
+            self.props[key] = [ s.data.properties[key] for s in stars ]
 
     def write(self, file_name=None, logger=None):
         """Write catalog to file.
@@ -699,6 +708,9 @@ class HSMCatalogStats(Stats):
                   ('flag_truth', int), ('flag_model', int),
                   ('T_data', float), ('g1_data', float), ('g2_data', float),
                   ('T_model', float), ('g1_model', float), ('g2_model', float)]
+        for key, col in self.props.items():
+            dtypes.append((key, float))
+            cols.append(col)
         data = np.array(list(zip(*cols)), dtype=dtypes)
         with fitsio.FITS(file_name, 'rw', clobber=True) as f:
             f.write_table(data)

--- a/piff/twod_stats.py
+++ b/piff/twod_stats.py
@@ -45,7 +45,8 @@ class TwoDHistStats(Stats):
     :param reducing_function:   Type of function to apply to grouped objects. numpy functions
                                 are prefixed by np. [default: 'np.median']
     :param file_name:           Name of the file to output to. [default: None]
-    :param model_properties:    Optional properties to use for the model rendering. [default: None]
+    :param model_properties:    Optionally a dict of properties to use for the model rendering.
+                                [default: None]
     :param logger:              A logger object for logging debug info. [default: None]
     """
     def __init__(self, nbins_u=20, nbins_v=20, reducing_function='np.median',
@@ -419,7 +420,8 @@ class WhiskerStats(Stats):
                                 all whiskers. [default: 1]
     :param resid_scale:         An additional factor for the scale size of the residual
                                 whiskers only. [default: 2]
-    :param model_properties:    Optional properties to use for the model rendering. [default: None]
+    :param model_properties:    Optionally a dict of properties to use for the model rendering.
+                                [default: None]
     :param logger:              A logger object for logging debug info. [default: None]
     """
     def __init__(self, file_name=None, nbins_u=20, nbins_v=20, reducing_function='np.median',

--- a/piff/twod_stats.py
+++ b/piff/twod_stats.py
@@ -45,15 +45,17 @@ class TwoDHistStats(Stats):
     :param reducing_function:   Type of function to apply to grouped objects. numpy functions
                                 are prefixed by np. [default: 'np.median']
     :param file_name:           Name of the file to output to. [default: None]
+    :param model_properties:    Optional properties to use for the model rendering. (default: None)
     :param logger:              A logger object for logging debug info. [default: None]
     """
     def __init__(self, nbins_u=20, nbins_v=20, reducing_function='np.median',
-                 file_name=None, logger=None):
+                 file_name=None, model_properties=None, logger=None):
         self.nbins_u = nbins_u
         self.nbins_v = nbins_v
         self.reducing_function = eval(reducing_function)
 
         self.file_name = file_name
+        self.model_properties = model_properties
         self.skip = False
 
     def compute(self, psf, stars, logger=None):
@@ -67,7 +69,8 @@ class TwoDHistStats(Stats):
 
         # get the shapes
         logger.info("Measuring Star and Model Shapes")
-        positions, shapes_truth, shapes_model = self.measureShapes(psf, stars, logger=logger)
+        positions, shapes_truth, shapes_model = self.measureShapes(
+            psf, stars, model_properties=self.model_properties, logger=logger)
 
         # Only use stars for which hsm was successful
         flag_truth = shapes_truth[:, 6]
@@ -416,16 +419,18 @@ class WhiskerStats(Stats):
                                 all whiskers. [default: 1]
     :param resid_scale:         An additional factor for the scale size of the residual
                                 whiskers only. [default: 2]
+    :param model_properties:    Optional properties to use for the model rendering. (default: None)
     :param logger:              A logger object for logging debug info. [default: None]
     """
     def __init__(self, file_name=None, nbins_u=20, nbins_v=20, reducing_function='np.median',
-                 scale=1, resid_scale=2, logger=None):
+                 scale=1, resid_scale=2, model_properties=None, logger=None):
         self.file_name = file_name
         self.nbins_u = nbins_u
         self.nbins_v = nbins_v
         self.reducing_function = eval(reducing_function)
         self.scale = scale
         self.resid_scale = resid_scale
+        self.model_properties = model_properties
         self.skip = False
 
     def compute(self, psf, stars, logger=None):
@@ -439,7 +444,8 @@ class WhiskerStats(Stats):
 
         # get the shapes
         logger.info("Measuring Star and Model Shapes")
-        positions, shapes_truth, shapes_model = self.measureShapes(psf, stars, logger=logger)
+        positions, shapes_truth, shapes_model = self.measureShapes(
+            psf, stars, model_properties=self.model_properties, logger=logger)
 
         # Only use stars for which hsm was successful
         flag_truth = shapes_truth[:, 6]

--- a/piff/twod_stats.py
+++ b/piff/twod_stats.py
@@ -45,7 +45,7 @@ class TwoDHistStats(Stats):
     :param reducing_function:   Type of function to apply to grouped objects. numpy functions
                                 are prefixed by np. [default: 'np.median']
     :param file_name:           Name of the file to output to. [default: None]
-    :param model_properties:    Optional properties to use for the model rendering. (default: None)
+    :param model_properties:    Optional properties to use for the model rendering. [default: None]
     :param logger:              A logger object for logging debug info. [default: None]
     """
     def __init__(self, nbins_u=20, nbins_v=20, reducing_function='np.median',
@@ -419,7 +419,7 @@ class WhiskerStats(Stats):
                                 all whiskers. [default: 1]
     :param resid_scale:         An additional factor for the scale size of the residual
                                 whiskers only. [default: 2]
-    :param model_properties:    Optional properties to use for the model rendering. (default: None)
+    :param model_properties:    Optional properties to use for the model rendering. [default: None]
     :param logger:              A logger object for logging debug info. [default: None]
     """
     def __init__(self, file_name=None, nbins_u=20, nbins_v=20, reducing_function='np.median',

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch = True
 
-include = *piff/*
+include = **/piff/*
 
 # This lets coverage include lines that happen in multiprocessing mode
 concurrency = multiprocessing

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1126,7 +1126,7 @@ def test_stars():
     np.testing.assert_almost_equal(snr_list, snr_list2, decimal=5)
     print('min_snr = ',np.min(snr_list))
     print('max_snr = ',np.max(snr_list))
-    assert np.min(snr_list) < 20.
+    assert np.min(snr_list) < 30.
     assert np.max(snr_list) > 600.
 
     # max_snr increases the noise to achieve a maximum snr
@@ -1137,7 +1137,7 @@ def test_stars():
     assert len(stars) == 100
     snr_list = [ star['snr'] for star in stars ]
     print('snr = ', np.min(snr_list), np.max(snr_list))
-    assert np.min(snr_list) < 20.
+    assert np.min(snr_list) < 30.
     assert np.max(snr_list) == 120.
     snr_list2 = [ piff.util.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
     snr_list = np.array(snr_list)
@@ -1158,7 +1158,7 @@ def test_stars():
     assert len(stars) == 100
     snr_list = np.array([ star['snr'] for star in stars ])
     print('snr = ', np.min(snr_list), np.max(snr_list))
-    assert np.min(snr_list) < 20.
+    assert np.min(snr_list) < 30.
     assert np.max(snr_list) == 100.
     snr_list2 = [ piff.util.calculateSNR(star.data.image, star.data.orig_weight) for star in stars ]
     snr_list = np.array(snr_list)

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -371,6 +371,10 @@ def test_star():
     assert star.flux == 1.
     assert star.center == (0,0)
     assert star.is_reserve == False
+    assert star['color_ri'] == 0.5
+    assert star['color_iz'] == -0.2
+    with np.testing.assert_raises(KeyError):
+        star['color_gi']
 
     star = star.withFlux(7)
     assert star.flux == 7.
@@ -387,6 +391,12 @@ def test_star():
     star = star.withFlux(flux=2)
     assert star.flux == 2.
     assert star.center == (12,20)
+
+    # Test withProperties
+    star = star.withProperties(color_iz=-0.3, color_gi=1.1)
+    assert star['color_ri'] == 0.5
+    assert star['color_iz'] == -0.3
+    assert star['color_gi'] == 1.1
 
     # Test using makeTarget
     star = piff.Star.makeTarget(properties=stardata.properties, image=image, weight=weight)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -989,8 +989,6 @@ def test_model_properties():
 
 
 if __name__ == '__main__':
-    test_model_properties()
-    quit()
     setup()
     test_twodstats()
     test_shift_cmap()


### PR DESCRIPTION
We realized in DES that we need stats about the residuals when the models are not made at the same color as the stars.  This PR adds an option to set any properties you want for the model in stats to be different from the star's own properties.