### PR TITLE
#142 Add optional fourth_order=True and raw_moments=True options for HSMCatalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
+              with:
+                # Helpful for a reliable codcov upload.
+                fetch-depth: 0
 
             - name: Set up Python ${{ matrix.py }}
               uses: actions/setup-python@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,4 +27,4 @@ Bug fixes
 ---------
 
 - Fixed bug in output stats that what we called T was really sigma.  Now, it's correctly
-  T = Ixx + Iyy = 2*sigma^2. (#133)
+  T = Ixx + Iyy = 2*sigma^2. (#133, #142)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ New features
   use with the Optical model. (#134)
 - Made chipnum optional whenever the input model only covers a single chip, regardless of whether
   the chipnum was specified in the config file. (#140)
+- Added option to output fourth_order moments in HSM output file. (#142)
+- Added option to output all raw moments in HSM output file. (#142)
 - Added star.withProperties method. (#143)
 - Added model_properties option for stats to use e.g. a specific color rather than the stars'
   own colors for the model measurements. (#143)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,11 @@ Output file changes
   written to an output file (e.g HSMCatalog) (#141)
 
 
-Performance improvements
-------------------------
+Output file changes
+-------------------
+
+- Changed the HSM file output column name from flag_truth to flag_data to match the other
+  \*_data columns. (#142)
 
 - Changed default interpolant for PixelGrid to Lanczos(7) rather than Lanczos(3), since we found
   some significant inaccuracies in some cases when using Lanczos(3), so this seems like a safer
@@ -21,6 +24,7 @@ New features
 
 - Made chipnum optional whenever the input model only covers a single chip, regardless of whether
   the chipnum was specified in the config file. (#140)
+
 
 
 Bug fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Output file changes
 
 - Changed the HSM file output column name from flag_truth to flag_data to match the other
   \*_data columns. (#142)
+- Fixed type of reserve output column to be int rather than float. (#143)
+- Automatically write any extra_properties from the input file into the output file. (#143)
 
 - Changed default interpolant for PixelGrid to Lanczos(7) rather than Lanczos(3), since we found
   some significant inaccuracies in some cases when using Lanczos(3), so this seems like a safer
@@ -22,9 +24,13 @@ Output file changes
 New features
 ------------
 
+- Added Wavefront class to allow for more general descriptions of an optical wavefront for
+  use with the Optical model. (#134)
 - Made chipnum optional whenever the input model only covers a single chip, regardless of whether
   the chipnum was specified in the config file. (#140)
-
+- Added star.withProperties method. (#143)
+- Added model_properties option for stats to use e.g. a specific color rather than the stars'
+  own colors for the model measurements. (#143)
 
 
 Bug fixes

--- a/piff/star.py
+++ b/piff/star.py
@@ -70,7 +70,8 @@ class Star(object):
         star.flux       The flux of the object
         star.center     The nominal center of the object (not necessarily the centroid)
         star.is_reserve Whether the star is reserved from being used to fit the PSF
-        star.hsm        HSM measurements for this star as a tuple: (flux, cenu, cenv, sigma, g1, g2)
+        star.hsm        HSM measurements for this star as a tuple:
+                        (flux, cenu, cenv, sigma, g1, g2, flag)
 
     :param data: A StarData instance (invariant)
     :param fit:  A StarFit instance (invariant)

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -154,9 +154,12 @@ class Stats(object):
                                  for any properties that are not overridden by model_properties.
                                  [default: None]
         :param fourth_order:     Whether to include the fourth-order quantities as well in columns
-                                 7 through 11 of the output array.
+                                 7 through 11 of the output array. [default: False]
         :param raw_moments:      Whether to include the complete set of raw moments as calculated
-                                 by `calculate_moments`. [default: False]
+                                 by `calculate_moments`.  If requested, these come after the
+                                 fourth-order quantities if those are being returned or after the
+                                 regular quantities otherwise.  Either way they are the last 18
+                                 columns in the output array. [default: False]
         :param logger:           A logger object for logging debug info. [default: None]
 
         :returns:           positions of stars, shapes of stars, and shapes of
@@ -186,7 +189,7 @@ class Stats(object):
                             m['M31']/m['M11']**2, m['M13']/m['M11']**2,
                             m['M40']/m['M11']**2, m['M04']/m['M11']**2])
 
-                    # Subtract of 3e from the 4th order shapes to remove the leading order
+                    # Subtract off 3e from the 4th order shapes to remove the leading order
                     # term from the overall ellipticity, which is already captured in the
                     # second order shape.  (For a Gaussian, this makes g4 very close to 0.)
                     shape = galsim.Shear(g1=star.hsm[4], g2=star.hsm[5])
@@ -755,8 +758,8 @@ class HSMCatalogStats(Stats):
                              The default behavior is to use the properties of the star itself
                              for any properties that are not overridden by model_properties.
                              [default: None]
-    :param fourth_order:     Whether to include the fourth-order quantities as well as
-                             additional output columns. [default: False]
+    :param fourth_order:     Whether to include the additional fourth-order quantities described
+                             above. [default: False]
     :param raw_moments:      Whether to include the complete set of raw moments as calculated
                              by piff.util.calculate_moments. [default: False]
     """

--- a/piff/util.py
+++ b/piff/util.py
@@ -405,10 +405,10 @@ def calculate_moments(star, third_order=False, fourth_order=False, radial=False,
 
     :returns: A dict of the calculated moments, with the following keys/values:
 
-        * M_00, M_10, M_01, M_11, M_20, M_02
-        * M_21, M_12, M_30, M_03                          if ``third_order`` = True
-        * M_22, M_31, M_13, M_40, M_04                    if ``fourth_order`` = True
-        * M_22n, M_33n, M_44n                             if ``radial`` = True
+        * M00, M10, M01, M11, M20, M02
+        * M21, M12, M30, M03                          if ``third_order`` = True
+        * M22, M31, M13, M40, M04                     if ``fourth_order`` = True
+        * M22n, M33n, M44n                            if ``radial`` = True
 
     If ``errors`` = True, then also a second dict (with the same keys) giving the variances.
     """
@@ -467,7 +467,7 @@ def calculate_moments(star, third_order=False, fourth_order=False, radial=False,
     M20 = np.sum(WI * usqmvsq)
     M02 = 2 * np.sum(WIuv)
 
-    # Keep track of the tuple to return.  We may add more.
+    # Keep track of the dict to return.  We may add more.
     ret = dict(M00=M00, M10=M10, M01=M01, M11=M11, M20=M20, M02=M02)
 
     # 3rd moments
@@ -724,7 +724,7 @@ def calculate_moments(star, third_order=False, fourth_order=False, radial=False,
         varM20 = 4 * np.sum(WV * (B*usqmvsq + A*M20 * (rsq/M11 - 1))**2)
         varM02 = 4 * np.sum(WV * (2*B*uv + A*M02 * (rsq/M11 - 1))**2)
 
-        # Add these to the return tuple
+        # The dict to return for variance values.
         ret_var = dict(M00=varM00, M10=varM10, M01=varM01, M11=varM11, M20=varM20, M02=varM02)
 
         #

--- a/piff/util.py
+++ b/piff/util.py
@@ -352,12 +352,12 @@ def calculate_moments(star, third_order=False, fourth_order=False, radial=False,
 
     .. math::
 
-        M_00 &= \sum W(u,v) I(u,v) \\
-        M_10 &= \sum W(u,v) I(u,v) du \\
-        M_01 &= \sum W(u,v) I(u,v) dv \\
-        M_11 &= \sum W(u,v) I(u,v) (du^2 + dv^2) \\
-        M_20 &= \sum W(u,v) I(u,v) (du^2 - dv^2) \\
-        M_02 &= \sum W(u,v) I(u,v) (2 du dv)
+        M_{00} &= \sum W(u,v) I(u,v) \\
+        M_{10} &= \sum W(u,v) I(u,v) du \\
+        M_{01} &= \sum W(u,v) I(u,v) dv \\
+        M_{11} &= \sum W(u,v) I(u,v) (du^2 + dv^2) \\
+        M_{20} &= \sum W(u,v) I(u,v) (du^2 - dv^2) \\
+        M_{02} &= \sum W(u,v) I(u,v) (2 du dv)
 
     where W(u,v) is the weight from the HSM fit and du,dv are the positions relative to the
     HSM measured centroid.
@@ -366,20 +366,20 @@ def calculate_moments(star, third_order=False, fourth_order=False, radial=False,
 
     .. math::
 
-        M_21 &= \sum W(u,v) I(u,v) du (du^2 + dv^2) \\
-        M_12 &= \sum W(u,v) I(u,v) dv (du^2 + dv^2) \\
-        M_30 &= \sum W(u,v) I(u,v) du (du^2 - 3 dv^2) \\
-        M_03 &= \sum W(u,v) I(u,v) dv (3 du^2 - dv^2)
+        M_{21} &= \sum W(u,v) I(u,v) du (du^2 + dv^2) \\
+        M_{12} &= \sum W(u,v) I(u,v) dv (du^2 + dv^2) \\
+        M_{30} &= \sum W(u,v) I(u,v) du (du^2 - 3 dv^2) \\
+        M_{03} &= \sum W(u,v) I(u,v) dv (3 du^2 - dv^2)
 
     If ``fourth_order`` is set to True, then 4th order moments are also calculated and returned:
 
     .. math::
 
-        M_22 &= \sum W(u,v) I(u,v) (du^2 + dv^2)^2 \\
-        M_31 &= \sum W(u,v) I(u,v) (du^2 + dv^2) (du^2 - dv^2) \\
-        M_13 &= \sum W(u,v) I(u,v) (du^2 + dv^2) (2 du dv) \\
-        M_40 &= \sum W(u,v) I(u,v) (du^4 - 6 du^2 dv^2 + dv^4) \\
-        M_04 &= \sum W(u,v) I(u,v) (du^2 - dv^2) (4 du dv)
+        M_{22} &= \sum W(u,v) I(u,v) (du^2 + dv^2)^2 \\
+        M_{31} &= \sum W(u,v) I(u,v) (du^2 + dv^2) (du^2 - dv^2) \\
+        M_{13} &= \sum W(u,v) I(u,v) (du^2 + dv^2) (2 du dv) \\
+        M_{40} &= \sum W(u,v) I(u,v) (du^4 - 6 du^2 dv^2 + dv^4) \\
+        M_{04} &= \sum W(u,v) I(u,v) (du^2 - dv^2) (4 du dv)
 
     Higher order normalized radial moments (4th through 8th, even) are calculated if ``radial``
     is set to True:
@@ -387,12 +387,12 @@ def calculate_moments(star, third_order=False, fourth_order=False, radial=False,
     .. math::
 
         r^2 &\equiv du^2 + dv^2 \\
-        M_22 &= \sum W(u,v) I(u,v) r^4 \\
-        M_33 &= \sum W(u,v) I(u,v) r^6 \\
-        M_44 &= \sum W(u,v) I(u,v) r^8  \\
-        M_22n &= M_22/M_11^2 \\
-        M_33n &= M_33/M_11^3 \\
-        M_44n &= M_44/M_11^4
+        M_{22} &= \sum W(u,v) I(u,v) r^4 \\
+        M_{33} &= \sum W(u,v) I(u,v) r^6 \\
+        M_{44} &= \sum W(u,v) I(u,v) r^8  \\
+        M_{22n} &= M_{22}/M_{11}^2 \\
+        M_{33n} &= M_{33}/M_{11}^3 \\
+        M_{44n} &= M_{44}/M_{11}^4
 
     For all of these, one can also have error estimates returned if ``errors`` is set to True.
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -64,7 +64,8 @@ def test_twodstats():
     jcenter = 2000
     # the average value in the bin should match up with the model for the average coordinates
     sigma, g1, g2 = psf_model(icen, jcen, icenter, jcenter)
-    T = 2*sigma**2
+    gsq = g1**2 + g2**2
+    T = 2*sigma**2 * (1+gsq)/(1-gsq)
     T_average = stats.twodhists['T'][v_i, u_i]
     g1_average = stats.twodhists['g1'][v_i, u_i]
     g2_average = stats.twodhists['g2'][v_i, u_i]
@@ -476,9 +477,10 @@ def test_shapestats_config():
 
     # test their characteristics
     sigma = 1.3  # (copied from setup())
-    T = 2*sigma**2
     g1 = 0.23
     g2 = -0.17
+    gsq = g1**2 + g2**2
+    T = 2*sigma**2 * (1+gsq)/(1-gsq)
     np.testing.assert_array_almost_equal(T, shapeStats.T, decimal=4)
     np.testing.assert_array_almost_equal(T, shapeStats.T_model, decimal=3)
     np.testing.assert_array_almost_equal(g1, shapeStats.g1, decimal=4)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -648,7 +648,7 @@ def test_hsmcatalog():
     for col in ['ra', 'dec', 'x', 'y', 'u', 'v',
                 'T_data', 'g1_data', 'g2_data',
                 'T_model', 'g1_model', 'g2_model',
-                'flux', 'reserve', 'flag_truth', 'flag_model']:
+                'flux', 'reserve', 'flag_data', 'flag_model']:
         assert len(data[col]) == 10
     true_data = fitsio.read(cat_file)
 
@@ -664,7 +664,7 @@ def test_hsmcatalog():
     np.testing.assert_allclose(data['g2_model'], data['g2_data'], rtol=1.e-4)
 
     # On this file, no hsm errors
-    np.testing.assert_array_equal(data['flag_truth'], 0)
+    np.testing.assert_array_equal(data['flag_data'], 0)
     np.testing.assert_array_equal(data['flag_model'], 0)
 
     image = galsim.fits.read(image_file)
@@ -814,11 +814,11 @@ def test_bad_hsm():
     for col in ['ra', 'dec', 'x', 'y', 'u', 'v',
                 'T_data', 'g1_data', 'g2_data',
                 'T_model', 'g1_model', 'g2_model',
-                'flux', 'reserve', 'flag_truth', 'flag_model']:
+                'flux', 'reserve', 'flag_data', 'flag_model']:
         assert len(data[col]) == 1
-    print('flag_truth = ',data['flag_truth'])
+    print('flag_data = ',data['flag_data'])
     print('flag_model = ',data['flag_model'])
-    np.testing.assert_array_equal(data['flag_truth'], 7)
+    np.testing.assert_array_equal(data['flag_data'], 7)
     np.testing.assert_array_equal(data['flag_model'], 7)
 
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1059,7 +1059,6 @@ def test_fourth_order():
         np.testing.assert_allclose(data['g1_data'][i], shape.g1, rtol=1.e-5)
         np.testing.assert_allclose(data['g2_data'][i], shape.g2, rtol=1.e-5)
         T4 = moments['M22'] / T
-        T4 = moments['M22'] / T
         np.testing.assert_allclose(data['T4_data'][i], moments['M22']/moments['M11'], rtol=1.e-5)
         np.testing.assert_allclose(data['g41_data'][i],
                                    moments['M31']/moments['M11']**2 - 3*shape.e1, atol=1.e-5)
@@ -1125,7 +1124,6 @@ def test_fourth_order():
         np.testing.assert_allclose(data['T_data'][i], T, rtol=1.e-5)
         np.testing.assert_allclose(data['g1_data'][i], shape.g1, rtol=1.e-5)
         np.testing.assert_allclose(data['g2_data'][i], shape.g2, rtol=1.e-5)
-        T4 = moments['M22'] / T
         T4 = moments['M22'] / T
         np.testing.assert_allclose(data['T4_data'][i], moments['M22']/moments['M11'], rtol=1.e-5)
         np.testing.assert_allclose(data['g41_data'][i],


### PR DESCRIPTION
This PR adds two options to include higher-order moments in the HSM output file.

The first one, fourth_order=True, is the one I expect to be more useful in practice.  It outputs additional columns: T4, g41, g42, h41, h42. 

T4 is a spin-0 quantity with units of area (like T) based on fourth order moments.  Specifically T4 = <r^4> / T.  For a round Gaussian, it comes out equal to 2T.  For an elliptical Gaussian, there is a correction of approximately (1-e^2)^0.5.

g4 is a spin-2 dimensionless quantity (like g).  For this one, we subtract off the leading effect of the overall ellipticity (=3e), so g4 is really probing some additional spin-2 effect beyond the trivial geometry already indicated by the regular second-moment shape, g.  For an elliptical Gaussian, this is close to 0.  (Thanks for @ztq1996 for this suggestion.)

h5 is a spin-4 dimensionless quantity.  I'm not sure what the uses for this might be, but it seemed worth including.

The second optional arguments is raw_moments=True.  This is simply the raw output of calculate_moments, outputting all the moments that it can calculate without any scalings or correction terms.  @aaronroodman thought this would be useful for checking the accuracy of the optical PSF fits, to check things like trefoil and such are accurately modeled.

Along the way, I discovered that the calculation of T from sigma that we did in #133 wasn't quite right.  The sigma that HSM outputs is the fourth root of the determinant of the moment matrix, not the square root of half the trace.  So there is a correction required involving the measured shape to get the definition of T that we want (i.e. the trace of the moment matrix).  So I fixed that here.