### PR TITLE
Write piff_version in the HSM output file header

### DIFF
--- a/piff/psf.py
+++ b/piff/psf.py
@@ -386,6 +386,9 @@ class PSF(object):
         :param logger:      A logger object for logging debug info.
         """
         from . import __version__ as piff_version
+        if len(fits) == 1:
+            header = {'piff_version': piff_version}
+            fits.write(data=None, header=header)
         psf_type = self.__class__.__name__
         write_kwargs(fits, extname, dict(self.kwargs, type=psf_type, piff_version=piff_version))
         logger.info("Wrote the basic PSF information to extname %s", extname)

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -871,6 +871,7 @@ class HSMCatalogStats(Stats):
                             which is typically read from the config field.]
         :param logger:      A logger object for logging debug info. [default: None]
         """
+        from . import __version__ as piff_version
         logger = galsim.config.LoggerWrapper(logger)
         import fitsio
         if file_name is None:
@@ -883,5 +884,6 @@ class HSMCatalogStats(Stats):
         logger.warning("Writing HSM catalog to file %s",file_name)
 
         data = np.array(list(zip(*self.cols)), dtype=self.dtypes)
+        header = {'piff_version': piff_version}
         with fitsio.FITS(file_name, 'rw', clobber=True) as f:
-            f.write_table(data)
+            f.write_table(data, header=header)

--- a/piff/util.py
+++ b/piff/util.py
@@ -122,6 +122,7 @@ def write_kwargs(fits, extname, kwargs):
     :param extname:     The extension to write to
     :param kwargs:      A kwargs dict to be written as a FITS binary table.
     """
+    from . import __version__ as piff_version
     cols = []
     dtypes = []
     for key, value in kwargs.items():
@@ -133,7 +134,8 @@ def write_kwargs(fits, extname, kwargs):
         cols.append([value])
         dtypes.append(dt)
     data = np.array(list(zip(*cols)), dtype=dtypes)
-    fits.write_table(data, extname=extname)
+    header = {'piff_version': piff_version}
+    fits.write_table(data, extname=extname, header=header)
 
 def read_kwargs(fits, extname):
     """A helper function for reading a single row table from a fits file returning the values

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -335,6 +335,18 @@ def test_single_image():
     test_star = psf2.interp.interpolate(target)
     np.testing.assert_almost_equal(test_star.fit.params, true_params, decimal=4)
 
+    # The piff version is stored in the header of the first extension
+    header = fitsio.read_header(psf_file)
+    assert header['PIFF_VERSION'] == piff.__version__
+
+    # Also in ext=1, which is the first one with any real data.
+    header = fitsio.read_header(psf_file, ext=1)
+    assert header['PIFF_VERSION'] == piff.__version__
+
+    # Also called ext='psf'
+    header = fitsio.read_header(psf_file, ext='psf')
+    assert header['PIFF_VERSION'] == piff.__version__
+
     # Do the whole thing with the config parser
     os.remove(psf_file)
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -644,13 +644,15 @@ def test_hsmcatalog():
     piff.piffify(config, logger)
     assert os.path.isfile(hsm_file)
 
-    data = fitsio.read(hsm_file)
+    data, header = fitsio.read(hsm_file, header=True)
     for col in ['ra', 'dec', 'x', 'y', 'u', 'v',
                 'T_data', 'g1_data', 'g2_data',
                 'T_model', 'g1_model', 'g2_model',
                 'flux', 'reserve', 'flag_data', 'flag_model']:
         assert len(data[col]) == 10
     true_data = fitsio.read(cat_file)
+
+    assert header['PIFF_VERSION'] == piff.__version__
 
     np.testing.assert_allclose(data['x'], true_data['x'])
     np.testing.assert_allclose(data['y'], true_data['y'])


### PR DESCRIPTION
I realized on the Y6 telecon that my idea for people being able to check the piff version of an HSM catalog won't work right, because we aren't actually planning to remake the piff files -- just the HSM files. 

So this adds piff_version in the header of the HSM catalog file, which one can get by reading with `header=True`:
```
data, header = fitsio.read(hsm_file_name, header=True)
```
Then header['PIFF_VERSION'] can be used to programmatically decide what to do with the data.  E.g. don't fix T values if piff_version >= '1.3'.

I also did the same thing in a few other places, which is overkill I'm sure, but I wanted to make sure people can find the version as easily as possible if they need to know it.  :)