### PR TITLE
Guard against bad HSM fit when fourth_order=True

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -716,6 +716,7 @@ def test_bad_hsm():
     shape_file = os.path.join('output','bad_hsm_shape.pdf')
     star_file = os.path.join('output','bad_hsm_star.pdf')
     hsm_file = os.path.join('output','bad_hsm_hsm.fits')
+    hsm4_file = os.path.join('output','bad_hsm_hsm_fourth.fits')
     sizemag_file = os.path.join('output','bad_hsm_sizemag.png')
 
     stamp_size = 25
@@ -770,6 +771,11 @@ def test_bad_hsm():
                 {
                     'type': 'HSMCatalog',
                     'file_name': hsm_file,
+                },
+                {
+                    'type': 'HSMCatalog',
+                    'file_name': hsm4_file,
+                    'fourth_order': True,
                 },
             ],
         },


### PR DESCRIPTION
We forgot to guard against the possibility of bad hsm fits (which are relatively common actually) when doing the fourth order moments in the HSM output file.  This fixes it.