### PR TITLE
Refactor SimplePSF fitting procedure

### DIFF
--- a/piff/config.py
+++ b/piff/config.py
@@ -137,9 +137,6 @@ def process(config, logger=None):
     objects, wcs, pointing = Input.process(config['input'], logger=logger)
     stars = Select.process(config.get('select',{}), objects, logger=logger)
 
-    if len(stars) == 0:
-        raise RuntimeError("No stars.  Cannot find PSF model.")
-
     psf = PSF.process(config['psf'], logger=logger)
     psf.fit(stars, wcs, pointing, logger=logger)
 

--- a/piff/config.py
+++ b/piff/config.py
@@ -137,6 +137,9 @@ def process(config, logger=None):
     objects, wcs, pointing = Input.process(config['input'], logger=logger)
     stars = Select.process(config.get('select',{}), objects, logger=logger)
 
+    if len(stars) == 0:
+        raise RuntimeError("No stars.  Cannot find PSF model.")
+
     psf = PSF.process(config['psf'], logger=logger)
     psf.fit(stars, wcs, pointing, logger=logger)
 

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -139,10 +139,6 @@ class PSF(object):
         # Select the non-reserve stars for performing the fit
         use_stars = [star for star in stars if not star.is_reserve]
 
-        if len(use_stars) != len(stars):
-            logger.warning("             (%d stars are reserved)",
-                            len(stars)-len(use_stars))
-
         return use_stars
 
     def remove_outliers(self, stars, iteration, logger):
@@ -195,6 +191,9 @@ class PSF(object):
             if len(use_stars) == 0:
                 raise RuntimeError("No stars.  Cannot find PSF model.")
             logger.warning("Iteration %d: Fitting %d stars", iteration+1, len(use_stars))
+            if len(use_stars) != len(stars):
+                logger.warning("             (%d stars are reserved)",
+                                len(stars)-len(use_stars))
 
             # Run a single iteration of the fitter.
             # Different PSF types do different things here.

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -98,7 +98,7 @@ class PSF(object):
         """
         raise NotImplementedError("Derived classes must define the parseKwargs function")
 
-    def initialize(self, stars, logger):  # pragma: no cover
+    def initialize(self, stars, logger):
         """Initialize the psf solver to begin an iterative solution.
 
         :param stars:           The initial list of Star instances that will be used to constrain

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -215,8 +215,9 @@ class PSF(object):
 
             # Keep track of the total number removed in all iterations.
             self.nremoved += iter_nremoved
+            self.niter = iteration+1
 
-            # Also store the stars that weren't removed for the output file.
+            # Also save the current state of stars for the output file.
             self.stars = stars
 
             # Very simple convergence test here:

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -352,10 +352,10 @@ class PSF(object):
         convolve the PSF by some other (e.g. galaxy) profile and then draw that.
 
         If the PSF interpolation used extra properties for the interpolation (cf.
-        psf.extra_interp_properties), you need to provide them as additional kwargs.
+        psf.interp_property_names), you need to provide them as additional kwargs.
 
-            >>> print(psf.extra_interp_properties)
-            ('ri_color',)
+            >>> print(psf.interp_property_names)
+            ('u','v','ri_color')
             >>> prof, method = psf.get_profile(chipnum=4, x=103.3, y=592.0, ri_color=0.23)
 
         :param x:           The x position of the desired PSF in the original image coordinates.

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -60,6 +60,7 @@ class SimplePSF(PSF):
         self.last_delta_chisq = 0.
         self.dof = 0
         self.nremoved = 0
+        self.niter = 0
 
     @property
     def interp_property_names(self):
@@ -228,6 +229,7 @@ class SimplePSF(PSF):
             'last_delta_chisq' : self.last_delta_chisq,
             'dof' : self.dof,
             'nremoved' : self.nremoved,
+            'niter' : self.niter,
         }
         write_kwargs(fits, extname + '_chisq', chisq_dict)
         logger.debug("Wrote the chisq info to extension %s",extname + '_chisq')

--- a/piff/star.py
+++ b/piff/star.py
@@ -95,7 +95,7 @@ class Star(object):
         return Star(self.data, fit)
 
     def withProperties(self, **kwargs):
-        """Set or change any properties in the star.
+        r"""Set or change any properties in the star.
 
         :param \*\*kwargs:   Each named kwarg is taken to be a property to set in the returned star.
 
@@ -919,7 +919,7 @@ class StarFit(object):
         return self.A.T.dot(self.b)
 
     def newParams(self, params, **kwargs):
-        """Return new StarFit that has the array params installed as new parameters.
+        r"""Return new StarFit that has the array params installed as new parameters.
 
         :param params:  A 1d array holding new parameters; must match size of current ones
         :param \*\*kwargs:  Any other additional properties for the star. Takes current flux and

--- a/piff/util.py
+++ b/piff/util.py
@@ -215,7 +215,7 @@ def _run_multi_helper(func, i, args, kwargs, log_level): # pragma: no cover
 
 
 def run_multi(func, nproc, raise_except, args, logger, kwargs=None):
-    """Run a function possibly in multiprocessing mode.
+    r"""Run a function possibly in multiprocessing mode.
 
     This is basically just doing a Pool.map, but it handles the logger properly (which cannot
     be pickled, so it cannot be passed to the function being run by the workers).
@@ -230,7 +230,7 @@ def run_multi(func, nproc, raise_except, args, logger, kwargs=None):
     :param kwargs:      a list of kwargs for func for each job to run.  May also be a single dict
                         to use for all jobs. [default: None]
 
-    :returns:   The output of func(\*args[i], \*\*kwargs[i]) for each item in the args, kwargs lists.
+    :returns: The output of func(\*args[i], \*\*kwargs[i]) for each item in the args, kwargs lists.
     """
     from multiprocessing import Pool
     if galsim.__version_info__ >= (2,4):

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -1222,16 +1222,19 @@ def test_des_image():
     config['psf']['outliers']['include_reserve'] = True
     config['psf']['outliers']['max_remove'] = 0.01
     piff.piffify(config)
-    psf = piff.read(psf_file)
-    nreserve = len([s for s in psf.stars if s.is_reserve])
-    ntot = len(psf.stars)
-    print('nremoved = ',psf.nremoved)
+    psf2 = piff.read(psf_file)
+    nreserve = len([s for s in psf2.stars if s.is_reserve])
+    ntot = len(psf2.stars)
+    print('nremoved = ',psf2.nremoved)
     print('nreserve = ',nreserve)
     print('ntot = ',ntot)
     assert nreserve < int(0.2 * nstars)  # I.e. some reserve stars are removed.
-    assert ntot == nstars - psf.nremoved
+    assert ntot == nstars - psf2.nremoved
     assert nreserve < 0.2 * ntot  # This isn't a priori required, but evidence that reserve
                                   # stars are preferentially targeted by the outlier rejection.
+
+    # It also took more iterations to finish.
+    assert psf2.niter > psf.niter
 
 
 @timer

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -617,6 +617,12 @@ def test_psf():
     np.testing.assert_raises(NotImplementedError, psf.drawStarList, [star])
     np.testing.assert_raises(NotImplementedError, psf._drawStar, star)
     np.testing.assert_raises(NotImplementedError, psf._getProfile, star)
+    np.testing.assert_raises(NotImplementedError, psf.single_iteration, [star], [star], None, None)
+
+    # Initialize doesn't do anything, but works
+    stars, nremove = psf.initialize([star], None)
+    assert stars == [star]
+    assert nremove == 0
 
     # Invalid to read a type that isn't a piff.PSF type.
     # Mock this by pretending that SingleChip is the only subclass of PSF.


### PR DESCRIPTION
When working on implementing the composite PSF models, I've realized that various aspects of the current code should be refactored or adjusted in various ways.  So this is the first in what I expect to be several PRs with changes that are geared toward making the Sum and Convolve PSF classes easier to implement.

This PR mostly involved breaking up the fitting iteration into separate functions.  This will for instance allow the composite classes to call these functions for each one of their components as part of their implementation of these steps.  That would not have been possible with the old way the code was structured.