### PR TITLE
Change how we register the various valid type names for the config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ API Changes
   * GSObjectModel -> GSObject
   * GPInterp -> GP or GaussianProcess
   * kNNInterp -> KNN or KNearestNeighbors
+  * Star -> StarImages
 
 
 Performance improvements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,10 @@ Output file changes
 API Changes
 -----------
 
-- Deprecated some redundant type names.  GSObjectModel -> GSObject,
-
+- Deprecated some redundant or potentially unclear type names.
+  * GSObjectModel -> GSObject
+  * GPInterp -> GP or GaussianProcess
+  * kNNInterp -> KNN or KNearestNeighbors
 
 
 Performance improvements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Output file changes
 API Changes
 -----------
 
+- Deprecated some redundant type names.  GSObjectModel -> GSObject,
+
 
 
 Performance improvements

--- a/examples/Tutorial.ipynb
+++ b/examples/Tutorial.ipynb
@@ -544,7 +544,7 @@
     "    -\n",
     "        # Show images of stars, models and differences.\n",
     "        # By default, it selects a subset of all the stars, but one can force it to show all of them.\n",
-    "        type: Star\n",
+    "        type: StarImages\n",
     "        file_name: star.png\n",
     "    -\n",
     "        # So-called \"rho statistics\".  These are correlation functions of the residuals, which are\n",
@@ -586,11 +586,11 @@
      "text": [
       "Reading PSF from file output/D00572501_z_c01.piff\n",
       "Getting wcs from image file 572501/D00572501_z_c01_r3624p01_immasked.fits.fz\n",
-      "Writing TwoDHistStats plot to file output/twod_hist.png\n",
-      "Writing StarStats plot to file output/star.png\n",
+      "Writing TwoDHist plot to file output/twod_hist.png\n",
+      "Writing StarImages plot to file output/star.png\n",
       "Calculating rho statistics for 111 stars\n",
-      "Writing RhoStats plot to file output/rho.png\n",
-      "Writing SizeMagStats plot to file output/size_mag.png\n",
+      "Writing Rho plot to file output/rho.png\n",
+      "Writing SizeMag plot to file output/size_mag.png\n",
       "Calculating shape histograms for 111 stars\n",
       "Writing HSM catalog to file output/hsm.fits\n"
      ]
@@ -868,11 +868,11 @@
       "             (24 stars are reserved)\n",
       "             Total chisq = 2841.98 / 61689 dof\n",
       "Writing PSF to file output/D00572501_z_c01.piff\n",
-      "Writing TwoDHistStats plot to file output/twod_hist.png\n",
-      "Writing StarStats plot to file output/star.png\n",
+      "Writing TwoDHist plot to file output/twod_hist.png\n",
+      "Writing StarImages plot to file output/star.png\n",
       "Calculating rho statistics for 124 stars\n",
-      "Writing RhoStats plot to file output/rho.png\n",
-      "Writing SizeMagStats plot to file output/size_mag.png\n",
+      "Writing Rho plot to file output/rho.png\n",
+      "Writing SizeMag plot to file output/size_mag.png\n",
       "Calculating shape histograms for 124 stars\n",
       "Writing HSM catalog to file output/hsm.fits\n"
      ]

--- a/piff/__init__.py
+++ b/piff/__init__.py
@@ -83,7 +83,7 @@ from .interp import Interp
 from .mean_interp import Mean
 from .polynomial_interp import Polynomial, polynomial_types
 from .basis_interp import BasisInterp, BasisPolynomial
-from .knn_interp import kNNInterp
+from .knn_interp import KNNInterp
 from .gp_interp import GPInterp
 
 # Outlier handlers are named BlahOutliers where Blah is what they are called in teh config file

--- a/piff/basis_interp.py
+++ b/piff/basis_interp.py
@@ -48,6 +48,8 @@ class BasisInterp(Interp):
     Note: This is an abstract base class.  The concrete class you probably want to use
     is BasisPolynomial.
     """
+    _type_name = None
+
     def __init__(self):
         self.degenerate_points = True  # This Interpolator uses chisq quadratic forms
         self.use_qr = False  # The default.  May be overridden by subclasses.
@@ -351,6 +353,8 @@ class BasisPolynomial(BasisInterp):
                         Therefore, it may be preferred for some use cases. [default: False]
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'BasisPolynomial'
+
     def __init__(self, order, keys=('u','v'), max_order=None, use_qr=False, logger=None):
         super(BasisPolynomial, self).__init__()
 

--- a/piff/config.py
+++ b/piff/config.py
@@ -177,8 +177,8 @@ def plotify(config, logger=None):
     :param config:      The configuration file that defines how to build the model
     :param logger:      A logger object for logging progress. [default: None]
     """
-    import piff
     from .psf import PSF
+    from .input import Input
     from .output import Output
     from .star import Star
 
@@ -210,8 +210,9 @@ def plotify(config, logger=None):
     # removed as outliers, so we don't want to include them here.
     # However, the psf.stars do not have the images loaded (to save space in the output file
     # so it's not enormous).  So we need to load in the images for the stats.
-    input_handler_class = getattr(piff, 'Input' + config['input'].get('type','Files'))
-    input_handler = input_handler_class(config['input'], logger)
+    input_type = config['input'].get('type', 'Files')
+    input_class = Input.valid_input_types[input_type]
+    input_handler = input_class(config['input'], logger)
     stars = input_handler.load_images(psf.stars, logger=logger)
 
     # We don't want to rewrite the PSF to disk, so jump straight to the stats_list

--- a/piff/des/decam_wavefront.py
+++ b/piff/des/decam_wavefront.py
@@ -16,18 +16,19 @@
 .. module:: decam_wavefront
 """
 
-from ..knn_interp import kNNInterp
+from ..knn_interp import KNNInterp
 
 import numpy as np
 import fitsio
 import galsim
 
-class DECamWavefront(kNNInterp):
+class DECamWavefront(KNNInterp):
     """
     An interpolator of the DECam Wavefront as measured by out-of-focus stars.
     If you specify the location of the fits file and the extension, this will
     take care of the rest for you.
     """
+    _type_name = 'DECamWavefront'
 
     def __init__(self, file_name, extname, n_neighbors=15, weights='uniform', algorithm='auto',
                  p=2, logger=None):

--- a/piff/gp_interp.py
+++ b/piff/gp_interp.py
@@ -19,7 +19,7 @@
 import numpy as np
 import warnings
 import copy
-
+import galsim
 import treegp
 
 from .interp import Interp
@@ -101,6 +101,7 @@ class GPInterp(Interp):
                          [defaulf: 4]
     :param logger:       A logger object for logging debug info. [default: None]
     """
+    _type_name = 'GP'
 
     # treegp currently uses slightly different names for these
     treegp_alias = {
@@ -353,3 +354,14 @@ class GPInterp(Interp):
             gp.initialize(self._X, self._y[:,i], y_err=self._y_err[:,i])
             self.gps.append(gp)
 
+class GaussianProcess(GPInterp):
+    # An alternate name for GPInterp for people who like clearer, more verbose names
+    _type_name = 'GaussianProcess'
+
+class GPInterpDepr(GPInterp):
+    _type_name = 'GPInterp'
+
+    def __init__(self, *args, logger=None, **kwargs):
+        logger = galsim.config.LoggerWrapper(logger)
+        logger.error("WARNING: The name GPInterp is deprecated. Use GP or GaussianProcess instead.")
+        super().__init__(*args, logger=logger, **kwargs)

--- a/piff/gsobject_model.py
+++ b/piff/gsobject_model.py
@@ -39,6 +39,7 @@ class GSObjectModel(Model):
     :param scipy_kwargs: Optional kwargs to pass to scipy.optimize.least_squares [default: None]
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'GSObject'
     _model_can_be_offset = False
 
     def __init__(self, gsobj, fastfit=False, centered=True, include_pixel=True,
@@ -225,8 +226,7 @@ class GSObjectModel(Model):
 
         results = scipy.optimize.least_squares(self._resid, params, args=(star,convert_func),
                                                **self._scipy_kwargs)
-        if logger:
-            logger.debug(results)
+        logger.debug(results)
         if not results.success:
             raise RuntimeError("Error finding the full nonlinear solution")
 
@@ -329,6 +329,8 @@ class Gaussian(GSObjectModel):
     :param scipy_kwargs: Optional kwargs to pass to scipy.optimize.least_squares [default: None]
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'Gaussian'
+
     def __init__(self, fastfit=False, centered=True, include_pixel=True,
                  scipy_kwargs=None, logger=None):
         gsobj = galsim.Gaussian(sigma=1.0)
@@ -351,6 +353,8 @@ class Kolmogorov(GSObjectModel):
     :param scipy_kwargs: Optional kwargs to pass to scipy.optimize.least_squares [default: None]
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'Kolmogorov'
+
     def __init__(self, fastfit=False, centered=True, include_pixel=True,
                  scipy_kwargs=None, logger=None):
         gsobj = galsim.Kolmogorov(half_light_radius=1.0)
@@ -376,6 +380,8 @@ class Moffat(GSObjectModel):
     :param scipy_kwargs: Optional kwargs to pass to scipy.optimize.least_squares [default: None]
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'Moffat'
+
     def __init__(self, beta, trunc=0., fastfit=False, centered=True, include_pixel=True,
                  scipy_kwargs=None, logger=None):
         gsobj = galsim.Moffat(half_light_radius=1.0, beta=beta, trunc=trunc)
@@ -386,3 +392,11 @@ class Moffat(GSObjectModel):
         del self.kwargs['gsobj']
         # Need to add `beta` and `trunc` though.
         self.kwargs.update(dict(beta=beta, trunc=trunc))
+
+class GSObjectModelDepr(GSObjectModel):
+    _type_name = 'GSObjectModel'
+
+    def __init__(self, *args, logger=None, **kwargs):
+        logger = galsim.config.LoggerWrapper(logger)
+        logger.error("WARNING: The name GSObjectModel is deprecated. Use GSObject instead.")
+        super().__init__(*args, logger=logger, **kwargs)

--- a/piff/input.py
+++ b/piff/input.py
@@ -31,6 +31,10 @@ class Input(object):
     This is essentially an abstract base class intended to define the methods that should be
     implemented by any derived class.
     """
+    # This class-level dict will store all the valid input types.
+    # Each subclass should set a cls._type_name, which is the name that should
+    # appear in a config dict.  These will be the keys of valid_input_types.
+    # The values in this dict will be the Input sub-classes.
     valid_input_types = {}
 
     nproc = 1  # Sub-classes can overwrite this as an instance attribute.

--- a/piff/interp.py
+++ b/piff/interp.py
@@ -42,7 +42,7 @@ class Interp(object):
     # This class-level dict will store all the valid interp types.
     # Each subclass should set a cls._type_name, which is the name that should
     # appear in a config dict.  These will be the keys of valid_interp_types.
-    # The values in this dict will be the Model sub-classes.
+    # The values in this dict will be the Interp sub-classes.
     valid_interp_types = {}
 
     @classmethod

--- a/piff/interp.py
+++ b/piff/interp.py
@@ -39,6 +39,12 @@ class Interp(object):
     This is essentially an abstract base class intended to define the methods that should be
     implemented by any derived class.
     """
+    # This class-level dict will store all the valid interp types.
+    # Each subclass should set a cls._type_name, which is the name that should
+    # appear in a config dict.  These will be the keys of valid_interp_types.
+    # The values in this dict will be the Model sub-classes.
+    valid_interp_types = {}
+
     @classmethod
     def process(cls, config_interp, logger=None):
         """Parse the interp field of the config dict.
@@ -48,14 +54,16 @@ class Interp(object):
 
         :returns: an Interp instance
         """
-        import piff
-
+        # Get the class to use for the interpolator
         if 'type' not in config_interp:
             raise ValueError("config['interp'] has no type field")
 
-        # Get the class to use for the interpolator
-        # Not sure if this is what we'll always want, but it would be simple if we can make it work.
-        interp_class = getattr(piff, config_interp['type'])
+        interp_type = config_interp['type']
+        if interp_type not in Interp.valid_interp_types:
+            raise ValueError("type %s is not a valid interp type. "%interp_type +
+                             "Expecting one of %s"%list(Interp.valid_interp_types.keys()))
+
+        interp_class = Interp.valid_interp_types[interp_type]
 
         # Read any other kwargs in the interp field
         kwargs = interp_class.parseKwargs(config_interp, logger)
@@ -64,6 +72,16 @@ class Interp(object):
         interp = interp_class(**kwargs)
 
         return interp
+
+    @classmethod
+    def __init_subclass__(cls):
+        # Classes that don't want to register a type name can either not define _type_name
+        # or set it to None.
+        if hasattr(cls, '_type_name') and cls._type_name is not None:
+            if cls._type_name in Interp.valid_interp_types:
+                raise ValueError('Interpolation type %s already registered'%cls._type_name +
+                                 'Maybe you subclassed and forgot to set _type_name?')
+            Interp.valid_interp_types[cls._type_name] = cls
 
     @classmethod
     def parseKwargs(cls, config_interp, logger=None):
@@ -81,6 +99,7 @@ class Interp(object):
         kwargs = {}
         kwargs.update(config_interp)
         kwargs.pop('type',None)
+        kwargs['logger'] = logger
         return kwargs
 
     def getProperties(self, star):
@@ -164,7 +183,7 @@ class Interp(object):
         :param extname:     The name of the extension to write the interpolator information.
         """
         # First write the basic kwargs that works for all Interp classes
-        interp_type = self.__class__.__name__
+        interp_type = self.__class__._type_name
         write_kwargs(fits, extname, dict(self.kwargs, type=interp_type))
 
         # Now do the class-specific steps.  Typically, this will write out the solution parameters.
@@ -190,8 +209,6 @@ class Interp(object):
 
         :returns: an interpolator built with a information in the FITS file.
         """
-        import piff
-
         assert extname in fits
         assert 'type' in fits[extname].get_colnames()
         assert 'type' in fits[extname].read().dtype.names
@@ -205,11 +222,9 @@ class Interp(object):
             interp_type = interp_type[0]
 
         # Check that interp_type is a valid Interp type.
-        interp_classes = piff.util.get_all_subclasses(piff.Interp)
-        valid_interp_types = dict([ (kls.__name__, kls) for kls in interp_classes ])
-        if interp_type not in valid_interp_types:
-            raise ValueError("interpolator type %s is not a valid Piff Interpolator"%interp_type)
-        interp_cls = valid_interp_types[interp_type]
+        if interp_type not in Interp.valid_interp_types:
+            raise ValueError("interp type %s is not a valid Piff Interpolation"%interp_type)
+        interp_cls = Interp.valid_interp_types[interp_type]
 
         kwargs = read_kwargs(fits, extname)
         kwargs.pop('type',None)

--- a/piff/knn_interp.py
+++ b/piff/knn_interp.py
@@ -22,7 +22,7 @@ import galsim
 from .interp import Interp
 from .star import Star, StarFit
 
-class kNNInterp(Interp):
+class KNNInterp(Interp):
     """
     An interpolator that uses sklearn KNeighborsRegressor to interpolate a
     single surface
@@ -40,6 +40,8 @@ class kNNInterp(Interp):
                         p=1 is manhattan. [default: 2]
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'KNN'
+
     def __init__(self, keys=('u','v'), n_neighbors=15, weights='uniform', algorithm='auto',
                  p=2,logger=None):
         self.kwargs = {
@@ -184,3 +186,16 @@ class kNNInterp(Interp):
 
         # self.locations and self.targets assigned in _fit
         self._fit(data['LOCATIONS'][0], data['TARGETS'][0])
+
+class KNearestNeighbors(KNNInterp):
+    # An alternate name for KNNInterp for people who like clearer, more verbose names
+    _type_name = 'KNearestNeighbors'
+
+class kNNInterp(KNNInterp):
+    _type_name = 'kNNInterp'
+
+    def __init__(self, *args, logger=None, **kwargs):
+        logger = galsim.config.LoggerWrapper(logger)
+        logger.error("WARNING: The name kNNInterp is deprecated. "
+                     "Use KNN or KNearestNeighbors instead.")
+        super().__init__(*args, logger=logger, **kwargs)

--- a/piff/mean_interp.py
+++ b/piff/mean_interp.py
@@ -25,6 +25,8 @@ class Mean(Interp):
     """The simplest possible interpolation scheme.  It just finds the mean of the parameter
     vectors and uses that at every position.
     """
+    _type_name = 'Mean'
+
     def __init__(self, logger=None):
         self.degenerate_points = False
         self.kwargs = {}

--- a/piff/model.py
+++ b/piff/model.py
@@ -304,8 +304,6 @@ class Model(object):
 
         :returns: a model built with a information in the FITS file.
         """
-        import piff
-
         assert extname in fits
         assert 'type' in fits[extname].get_colnames()
         model_type = fits[extname].read()['type']

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -146,9 +146,10 @@ class Optical(Model):
     Note that the Zernike coeffients (zernike_coeff), Atmospheric parameters (ie. r0,L0) and Shear (g1,g2) are
     fitted parameters, passed via the arguments to getProfile.
     """
+    _type_name = 'Optical'
     _method = 'auto'
-    _model_can_be_offset = True
     _centered = True
+    _model_can_be_offset = False 
 
     def __init__(self, template=None, gsparams=None, atmo_type='VonKarman', logger=None, **kwargs):
         self.logger = galsim.config.LoggerWrapper(logger)

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -149,7 +149,7 @@ class Optical(Model):
     _type_name = 'Optical'
     _method = 'auto'
     _centered = True
-    _model_can_be_offset = False 
+    _model_can_be_offset = False
 
     def __init__(self, template=None, gsparams=None, atmo_type='VonKarman', logger=None, **kwargs):
         self.logger = galsim.config.LoggerWrapper(logger)

--- a/piff/outliers.py
+++ b/piff/outliers.py
@@ -30,6 +30,10 @@ class Outliers(object):
     This is essentially an abstract base class intended to define the methods that should be
     implemented by any derived class.
     """
+    # This class-level dict will store all the valid outlier types.
+    # Each subclass should set a cls._type_name, which is the name that should
+    # appear in a config dict.  These will be the keys of valid_outliers_types.
+    # The values in this dict will be the Outliers sub-classes.
     valid_outliers_types = {}
 
     @classmethod

--- a/piff/output.py
+++ b/piff/output.py
@@ -27,6 +27,10 @@ class Output(object):
     This is essentially an abstract base class intended to define the methods that should be
     implemented by any derived class.
     """
+    # This class-level dict will store all the valid output types.
+    # Each subclass should set a cls._type_name, which is the name that should
+    # appear in a config dict.  These will be the keys of valid_output_types.
+    # The values in this dict will be the Output sub-classes.
     valid_output_types = {}
 
     @classmethod

--- a/piff/pixelgrid.py
+++ b/piff/pixelgrid.py
@@ -47,6 +47,7 @@ class PixelGrid(Model):
     :param logger:      A logger object for logging debug info. [default: None]
     """
 
+    _type_name = 'PixelGrid'
     _method = 'no_pixel'
     _model_can_be_offset = True  # Indicate that in reflux, the centroid should also move by the
                                  # current centroid of the model.  This way on later iterations,

--- a/piff/polynomial_interp.py
+++ b/piff/polynomial_interp.py
@@ -56,6 +56,8 @@ class Polynomial(Interp):
                         polynomial_types with the value of a function with
                         the signature of numpy.polynomial.polynomial.polyval2d
     """
+    _type_name = 'Polynomial'
+
     def __init__(self, order=None, orders=None, poly_type="poly", logger=None):
         if order is None and orders is None:
             raise TypeError("Either order or orders is required")

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -535,7 +535,7 @@ class PSF(object):
         if len(fits) == 1:
             header = {'piff_version': piff_version}
             fits.write(data=None, header=header)
-        psf_type = self.__class__.__name__
+        psf_type = self._type_name
         write_kwargs(fits, extname, dict(self.kwargs, type=psf_type, piff_version=piff_version))
         logger.info("Wrote the basic PSF information to extname %s", extname)
         Star.write(self.stars, fits, extname=extname + '_stars')

--- a/piff/select.py
+++ b/piff/select.py
@@ -32,6 +32,10 @@ class Select(object):
     This is essentially an abstract base class intended to define the methods that should be
     implemented by any derived class.
     """
+    # This class-level dict will store all the valid select types.
+    # Each subclass should set a cls._type_name, which is the name that should
+    # appear in a config dict.  These will be the keys of valid_select_types.
+    # The values in this dict will be the Select sub-classes.
     valid_select_types = {}
 
     # Parameters that derived classes should ignore if they appear in the config dict

--- a/piff/select.py
+++ b/piff/select.py
@@ -32,6 +32,8 @@ class Select(object):
     This is essentially an abstract base class intended to define the methods that should be
     implemented by any derived class.
     """
+    valid_select_types = {}
+
     # Parameters that derived classes should ignore if they appear in the config dict
     # (since they are handled by the base class).
     base_keys= ['min_snr', 'max_snr', 'hsm_size_reject', 'max_pixel_cut', 'reject_where',
@@ -55,6 +57,16 @@ class Select(object):
             # Enable True to be equivalent to 10.  True comes in as 1.0, which would be a
             # silly value to use, so it shouldn't be a problem to turn 1.0 -> 10.0.
             self.hsm_size_reject = 10.
+
+    @classmethod
+    def __init_subclass__(cls):
+        # Classes that don't want to register a type name can either not define _type_name
+        # or set it to None.
+        if hasattr(cls, '_type_name') and cls._type_name is not None:
+            if cls._type_name in Select.valid_select_types:
+                raise ValueError('Select type %s already registered'%cls._type_name +
+                                 'Maybe you subclassed and forgot to set _type_name?')
+            Select.valid_select_types[cls._type_name] = cls
 
     @classmethod
     def process(cls, config_select, objects, logger=None, select_only=False):
@@ -123,14 +135,17 @@ class Select(object):
 
         :returns: stars, the subset of objects which are to be considered stars
         """
-        import piff
-
         # Get the class to use for handling the selection
-        # Default type is 'Files'
-        select_handler_class = getattr(piff, config_select.get('type','Flag') + 'Select')
+        # Default type is 'Flag'
+        select_type = config_select.get('type', 'Flag')
+        if select_type not in Select.valid_select_types:
+            raise ValueError("type %s is not a valid select type. "%select_type +
+                             "Expecting one of %s"%list(Select.valid_select_types.keys()))
+
+        select_class = Select.valid_select_types[select_type]
 
         # Build handler object
-        select_handler = select_handler_class(config_select, logger=logger)
+        select_handler = select_class(config_select, logger=logger)
 
         # Creat a list of Star objects
         stars = select_handler.selectStars(objects, logger)
@@ -343,6 +358,8 @@ class FlagSelect(Select):
                         (Normally the 'select' field in the overall configuration dict).
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'Flag'
+
     def __init__(self, config, logger=None):
         super(FlagSelect, self).__init__(config, logger)
 
@@ -404,6 +421,8 @@ class PropertiesSelect(Select):
     :param config:      The configuration dict used to define the above parameters.
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'Properties'
+
     def __init__(self, config, logger=None):
         super(PropertiesSelect, self).__init__(config, logger)
 

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -40,6 +40,8 @@ class SimplePSF(PSF):
                         [default: 0.1]
     :param max_iter:    Maximum number of iterations to try. [default: 30]
     """
+    _type_name = 'Simple'
+
     def __init__(self, model, interp, outliers=None, chisq_thresh=0.1, max_iter=30):
         self.model = model
         self.interp = interp
@@ -76,7 +78,9 @@ class SimplePSF(PSF):
 
         :returns: a kwargs dict to pass to the initializer
         """
-        import piff
+        from .model import Model
+        from .interp import Interp
+        from .outliers import Outliers
 
         kwargs = {}
         kwargs.update(config_psf)
@@ -88,15 +92,15 @@ class SimplePSF(PSF):
                 raise ValueError("%s field is required in psf field for type=Simple"%key)
 
         # make a Model object to use for the individual stellar fitting
-        model = piff.Model.process(kwargs.pop('model'), logger=logger)
+        model = Model.process(kwargs.pop('model'), logger=logger)
         kwargs['model'] = model
 
         # make an Interp object to use for the interpolation
-        interp = piff.Interp.process(kwargs.pop('interp'), logger=logger)
+        interp = Interp.process(kwargs.pop('interp'), logger=logger)
         kwargs['interp'] = interp
 
         if 'outliers' in kwargs:
-            outliers = piff.Outliers.process(kwargs.pop('outliers'), logger=logger)
+            outliers = Outliers.process(kwargs.pop('outliers'), logger=logger)
             kwargs['outliers'] = outliers
 
         return kwargs

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -46,6 +46,8 @@ class SingleChipPSF(PSF):
     :param nproc:       How many multiprocessing processes to use for running multiple
                         chips at once. [default: 1]
     """
+    _type_name = 'SingleChip'
+
     def __init__(self, single_psf, nproc=1):
         self.single_psf = single_psf
         self.nproc = nproc
@@ -69,8 +71,6 @@ class SingleChipPSF(PSF):
 
         :returns: a kwargs dict to pass to the initializer
         """
-        import piff
-
         config_psf = config_psf.copy()  # Don't alter the original dict.
         config_psf.pop('type', None)
         nproc = config_psf.pop('nproc', 1)
@@ -79,7 +79,7 @@ class SingleChipPSF(PSF):
         config_psf['type'] = config_psf.pop('single_type', 'Simple')
 
         # Now the regular PSF process function can process the dict.
-        single_psf = piff.PSF.process(config_psf, logger)
+        single_psf = PSF.process(config_psf, logger)
 
         return { 'single_psf' : single_psf, 'nproc' : nproc }
 

--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -178,6 +178,8 @@ class SmallBrightSelect(Select):
                         (Normally the 'select' field in the overall configuration dict).
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'SmallBright'
+
     def __init__(self, config, logger=None):
         super(SmallBrightSelect, self).__init__(config, logger)
 
@@ -366,6 +368,8 @@ class SizeMagSelect(Select):
                         (Normally the 'select' field in the overall configuration dict)
     :param logger:      A logger object for logging debug info. [default: None]
     """
+    _type_name = 'SizeMag'
+
     def __init__(self, config, logger=None):
         super(SizeMagSelect, self).__init__(config, logger)
 

--- a/piff/size_mag.py
+++ b/piff/size_mag.py
@@ -29,6 +29,8 @@ class SizeMagStats(Stats):
     :param zeropoint:       Zeropoint to use = the magnitude of flux=1. [default: 30]
     :param logger:          A logger object for logging debug info. [default: None]
     """
+    _type_name = 'SizeMag'
+
     def __init__(self, file_name=None, zeropoint=30, logger=None):
         self.file_name = file_name
         self.zeropoint = zeropoint

--- a/piff/star.py
+++ b/piff/star.py
@@ -97,7 +97,7 @@ class Star(object):
     def withProperties(self, **kwargs):
         r"""Set or change any properties in the star.
 
-        :param \*\*kwargs:   Each named kwarg is taken to be a property to set in the returned star.
+        :param \*\*kwargs:  Each named kwarg is taken to be a property to set in the returned star.
 
         :returns: a new Star with the given properties, but is otherwise the same as self.
         """
@@ -714,7 +714,7 @@ class StarData(object):
         return copy.deepcopy(self)
 
     def withNew(self, **kwargs):
-        """Return new StarData that has new values of some attributes.
+        r"""Return new StarData that has new values of some attributes.
 
         :param \*\*kwargs:  Any properties for the star.data you want to change.
 
@@ -925,8 +925,8 @@ class StarFit(object):
         :param \*\*kwargs:  Any other additional properties for the star. Takes current flux and
                         center if not provided, and otherwise puts in None
 
-        :returns:  New StarFit object with altered parameters.  All chisq-related parameters
-                   are set to None since they are no longer valid.
+        :returns: New StarFit object with altered parameters.  All chisq-related parameters
+                  are set to None since they are no longer valid.
         """
         npp = np.array(params)
         if self.params is not None and npp.shape != self.params.shape:
@@ -939,7 +939,7 @@ class StarFit(object):
         return copy.deepcopy(self)
 
     def withNew(self, **kwargs):
-        """Return new StarFit that has new values of some attributes.
+        r"""Return new StarFit that has new values of some attributes.
 
         :param \*\*kwargs:  Any properties for the star.fit you want to change.
 

--- a/piff/star_stats.py
+++ b/piff/star_stats.py
@@ -44,6 +44,8 @@ class StarStats(Stats):
     :param file_name:       Name of the file to output to. [default: None]
     :param logger:          A logger object for logging debug info. [default: None]
     """
+    _type_name = 'StarImages'
+
     def __init__(self, nplot=10, adjust_stars=False, file_name=None, logger=None):
         self.nplot = nplot
         self.file_name = file_name
@@ -177,3 +179,11 @@ class StarStats(Stats):
             fig.colorbar(im, ax=axs[ii][jj+2])
 
         return fig, axs
+
+class StarStatsDepr(StarStats):
+    _type_name = 'Star'
+
+    def __init__(self, *args, logger=None, **kwargs):
+        logger = galsim.config.LoggerWrapper(logger)
+        logger.error("WARNING: The name Star is deprecated. Use StarImages instead.")
+        super().__init__(*args, logger=logger, **kwargs)

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -38,6 +38,10 @@ class Stats(object):
     There is also a ``plot`` method if you want to make the matplot lib fig, ax and do something
     else with it besides just write it to a file.
     """
+    # This class-level dict will store all the valid stats types.
+    # Each subclass should set a cls._type_name, which is the name that should
+    # appear in a config dict.  These will be the keys of valid_stats_types.
+    # The values in this dict will be the Stats sub-classes.
     valid_stats_types = {}
 
     @classmethod

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -141,15 +141,15 @@ class Stats(object):
         from matplotlib.backends.backend_agg import FigureCanvasAgg
 
         logger = galsim.config.LoggerWrapper(logger)
-        logger.info("Creating plot for %s", self.__class__.__name__)
+        logger.info("Creating plot for %s", self._type_name)
         fig, ax = self.plot(logger=logger, **kwargs)
 
         if file_name is None:
             file_name = self.file_name
         if file_name is None:
-            raise ValueError("No file_name specified for %s"%self.__class__.__name__)
+            raise ValueError("No file_name specified for %s"%self._type_name)
 
-        logger.warning("Writing %s plot to file %s",self.__class__.__name__,file_name)
+        logger.warning("Writing %s plot to file %s",self._type_name, file_name)
 
         canvas = FigureCanvasAgg(fig)
         # Do this after we've set the canvas to use Agg to avoid warning.
@@ -918,7 +918,7 @@ class HSMCatalogStats(Stats):
         if file_name is None:
             file_name = self.file_name
         if file_name is None:
-            raise ValueError("No file_name specified for %s"%self.__class__.__name__)
+            raise ValueError("No file_name specified for %s"%self._type_name)
         if not hasattr(self, 'cols'):
             raise RuntimeError("Must call compute before calling write")
 

--- a/piff/twod_stats.py
+++ b/piff/twod_stats.py
@@ -49,6 +49,8 @@ class TwoDHistStats(Stats):
                                 [default: None]
     :param logger:              A logger object for logging debug info. [default: None]
     """
+    _type_name = 'TwoDHist'
+
     def __init__(self, nbins_u=20, nbins_v=20, reducing_function='np.median',
                  file_name=None, model_properties=None, logger=None):
         self.nbins_u = nbins_u
@@ -424,6 +426,8 @@ class WhiskerStats(Stats):
                                 [default: None]
     :param logger:              A logger object for logging debug info. [default: None]
     """
+    _type_name = 'Whisker'
+
     def __init__(self, file_name=None, nbins_u=20, nbins_v=20, reducing_function='np.median',
                  scale=1, resid_scale=2, model_properties=None, logger=None):
         self.file_name = file_name

--- a/piff/util.py
+++ b/piff/util.py
@@ -227,8 +227,8 @@ def run_multi(func, nproc, raise_except, args, logger, kwargs=None):
     :param raise_except: Whether to raise any exceptions that happen in individual jobs.
     :param args:        a list of args for func for each job to run.
     :param logger:      The logger you would pass to func in single-processor mode.
-    :param kwargs:      a list of kwargs for func for each job to run.  May also be a single dict
-                        to use for all jobs. [default: None]
+    :param kwargs:      A list of kwargs dicts for func for each job to run.  May also be a single
+                        dict to use for all jobs. [default: None]
 
     :returns: The output of func(\*args[i], \*\*kwargs[i]) for each item in the args, kwargs lists.
     """

--- a/piff/util.py
+++ b/piff/util.py
@@ -22,19 +22,6 @@ import sys
 import traceback
 import galsim
 
-# Courtesy of
-# http://stackoverflow.com/questions/3862310/how-can-i-find-all-subclasses-of-a-given-class-in-python
-def get_all_subclasses(cls):
-    """Get all subclasses of an existing class.
-    """
-    all_subclasses = []
-
-    for subclass in cls.__subclasses__():
-        all_subclasses.append(subclass)
-        all_subclasses.extend(get_all_subclasses(subclass))
-
-    return all_subclasses
-
 def ensure_dir(target):
     """Ensure that the directory for a target output file exists.
 

--- a/tests/test_gp_interp.py
+++ b/tests/test_gp_interp.py
@@ -423,7 +423,7 @@ def test_yaml():
             'stamp_size' : 21,
             },
         'psf' : {
-            'model' : { 'type' : 'GSObjectModel',
+            'model' : { 'type' : 'GSObject',
                         'fastfit' : True,
                         'gsobj' : 'galsim.Gaussian(sigma=1.0)' },
             'interp' : { 'type' : 'GPInterp',

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -707,6 +707,29 @@ def test_flag_select():
     with np.testing.assert_raises(ValueError):
         select.selectStars(stars1, logger=logger)
 
+    # Invalid input type
+    config = { 'type': 'invalid' }
+    with np.testing.assert_raises(ValueError):
+        piff.Select.process(config, stars1)
+
+    # Also check errors when registering other type names
+    class NoSelect1(piff.Select):
+        pass
+    assert NoSelect1 not in piff.Select.valid_select_types.values()
+    class NoSelect2(piff.Select):
+        _type_name = None
+    assert NoSelect2 not in piff.Select.valid_select_types.values()
+    class ValidSelect1(piff.Select):
+        _type_name = 'valid'
+    assert ValidSelect1 in piff.Select.valid_select_types.values()
+    assert ValidSelect1 == piff.Select.valid_select_types['valid']
+    with np.testing.assert_raises(ValueError):
+        class ValidSelect2(piff.Select):
+            _type_name = 'valid'
+    with np.testing.assert_raises(ValueError):
+        class ValidSelect3(ValidSelect1):
+            pass
+
 @timer
 def test_properties_select():
     """Test the Properties selection type

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -277,6 +277,28 @@ def test_invalid():
     config = { 'image_file_name' : image_files_1, 'cat_file_name': cat_files }
     np.testing.assert_raises(TypeError, piff.InputFiles, config)
 
+    # Invalid input type
+    config = { 'type': 'invalid' }
+    with np.testing.assert_raises(ValueError):
+        piff.Input.process(config)
+
+    # Also check errors when registering other type names
+    class NoInput1(piff.Input):
+        pass
+    assert NoInput1 not in piff.Input.valid_input_types.values()
+    class NoInput2(piff.Input):
+        _type_name = None
+    assert NoInput2 not in piff.Input.valid_input_types.values()
+    class ValidInput1(piff.Input):
+        _type_name = 'valid'
+    assert ValidInput1 in piff.Input.valid_input_types.values()
+    assert ValidInput1 == piff.Input.valid_input_types['valid']
+    with np.testing.assert_raises(ValueError):
+        class ValidInput2(piff.Input):
+            _type_name = 'valid'
+    with np.testing.assert_raises(ValueError):
+        class ValidInput3(ValidInput1):
+            pass
 
 @timer
 def test_cols():

--- a/tests/test_knn_interp.py
+++ b/tests/test_knn_interp.py
@@ -20,7 +20,7 @@ import os
 import subprocess
 import fitsio
 
-from piff_test_helper import timer
+from piff_test_helper import timer, CaptureLog
 
 keys = ['focal_x', 'focal_y']
 ntarget = 5
@@ -51,7 +51,7 @@ def generate_data(n_samples=100):
 @timer
 def test_init():
     # make sure we can init the interpolator
-    knn = piff.kNNInterp(keys)
+    knn = piff.KNNInterp(keys)
     assert knn.property_names == keys
 
 @timer
@@ -60,7 +60,7 @@ def test_interp():
     logger = None
     # make sure we can put in the data
     star_list = generate_data()
-    knn = piff.kNNInterp(keys, n_neighbors=1)
+    knn = piff.KNNInterp(keys, n_neighbors=1)
     knn.initialize(star_list, logger=logger)
     knn.solve(star_list, logger=logger)
 
@@ -90,7 +90,7 @@ def test_interp():
 
 @timer
 def test_config():
-    # Take DES test image, and test doing a psf run with kNN interpolator
+    # Take DES test image, and test doing a psf run with KNN interpolator
     # Now test running it via the config parser
     psf_file = os.path.join('output','knn_psf.fits')
     config = {
@@ -118,7 +118,7 @@ def test_config():
             'model' : { 'type': 'GSObjectModel',
                         'fastfit': True,
                         'gsobj': 'galsim.Gaussian(sigma=1.0)' },
-            'interp' : { 'type': 'kNNInterp',
+            'interp' : { 'type': 'KNN',
                          'keys': ['u', 'v'],
                          'n_neighbors': 115,}
         },
@@ -143,17 +143,31 @@ def test_config():
             test_factor*np.mean([s.fit.params for s in psf.stars], axis=0),
             err_msg="Interpolated parameters show too much variation.")
 
+    # Check alternate config name
+    config['psf']['interp']['type'] = 'KNearestNeighbors'
+    psf1 = piff.process(config)
+    # XXX: Hopefully this "private" attribute will remain stable across sklearn versions...
+    np.testing.assert_array_equal(psf1.interp.knn._fit_X, psf.interp.knn._fit_X)
+
+    # And deprecated name
+    config['psf']['interp']['type'] = 'kNNInterp'
+    with CaptureLog() as cl:
+        psf2 = piff.process(config, cl.logger)
+    assert 'kNNInterp is deprecated' in cl.output
+    np.testing.assert_array_equal(psf2.interp.knn._fit_X, psf.interp.knn._fit_X)
+
+
 @timer
 def test_disk():
     # make sure reading and writing of data works
     star_list = generate_data()
-    knn = piff.kNNInterp(keys, n_neighbors=2)
+    knn = piff.KNNInterp(keys, n_neighbors=2)
     knn.initialize(star_list)
     knn.solve(star_list)
     knn_file = os.path.join('output','knn_interp.fits')
     with fitsio.FITS(knn_file,'rw',clobber=True) as f:
         knn.write(f, 'knn')
-        knn2 = piff.kNNInterp.read(f, 'knn')
+        knn2 = piff.KNNInterp.read(f, 'knn')
     np.testing.assert_array_equal(knn.locations, knn2.locations)
     np.testing.assert_array_equal(knn.targets, knn2.targets)
     np.testing.assert_array_equal(knn.kwargs['keys'], knn2.kwargs['keys'])

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -163,6 +163,24 @@ def test_base():
         out = piff.Outliers.read(f, extname='psf_outliers')
         print(out)
 
+    # Check that registering new types works correctly
+    class NoOutliers1(piff.Outliers):
+        pass
+    assert NoOutliers1 not in piff.Outliers.valid_outliers_types.values()
+    class NoOutliers2(piff.Outliers):
+        _type_name = None
+    assert NoOutliers2 not in piff.Outliers.valid_outliers_types.values()
+    class ValidOutliers1(piff.Outliers):
+        _type_name = 'valid'
+    assert ValidOutliers1 in piff.Outliers.valid_outliers_types.values()
+    assert ValidOutliers1 == piff.Outliers.valid_outliers_types['valid']
+    with np.testing.assert_raises(ValueError):
+        class ValidOutliers2(piff.Outliers):
+            _type_name = 'valid'
+    with np.testing.assert_raises(ValueError):
+        class ValidOutliers3(ValidOutliers1):
+            pass
+
 
 if __name__ == '__main__':
     test_chisq()

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -145,15 +145,23 @@ def test_base():
     config = { 'nsigma' : 4, }
     with np.testing.assert_raises(ValueError):
         out = piff.Outliers.process(config)
+    # and it must be a valid name
+    config['type'] = 'invalid'
+    with np.testing.assert_raises(ValueError):
+        out = piff.Outliers.process(config)
 
     # Invalid to read a type that isn't a piff.Outliers type.
     # Mock this by pretending that MADOutliers is the only subclass of Outliers.
     if sys.version_info < (3,): return  # mock only available on python 3
     from unittest import mock
     filename = os.path.join('input','D00240560_r_c01_r2362p01_piff.fits')
-    with mock.patch('piff.util.get_all_subclasses', return_value=[piff.outliers.MADOutliers]):
+    with mock.patch('piff.Outliers.valid_outliers_types', {'MAD': piff.outliers.MADOutliers}):
         with fitsio.FITS(filename,'r') as f:
             np.testing.assert_raises(ValueError, piff.Outliers.read, f, extname='psf_outliers')
+
+    with fitsio.FITS(filename,'r') as f:
+        out = piff.Outliers.read(f, extname='psf_outliers')
+        print(out)
 
 
 if __name__ == '__main__':

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -70,7 +70,32 @@ def test_base_output():
     np.testing.assert_raises(NotImplementedError, out.write, None)
     np.testing.assert_raises(NotImplementedError, out.read)
 
+@timer
+def test_invalid():
+    # Invalid output type
+    config = { 'type': 'invalid' }
+    with np.testing.assert_raises(ValueError):
+        piff.Output.process(config)
+
+    # Also check errors when registering other type names
+    class NoOutput1(piff.Output):
+        pass
+    assert NoOutput1 not in piff.Output.valid_output_types.values()
+    class NoOutput2(piff.Output):
+        _type_name = None
+    assert NoOutput2 not in piff.Output.valid_output_types.values()
+    class ValidOutput1(piff.Output):
+        _type_name = 'valid'
+    assert ValidOutput1 in piff.Output.valid_output_types.values()
+    assert ValidOutput1 == piff.Output.valid_output_types['valid']
+    with np.testing.assert_raises(ValueError):
+        class ValidOutput2(piff.Output):
+            _type_name = 'valid'
+    with np.testing.assert_raises(ValueError):
+        class ValidOutput3(ValidOutput1):
+            pass
 
 if __name__ == '__main__':
     test_ensure_dir()
     test_base_output()
+    test_invalid()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -571,6 +571,11 @@ def test_model():
         with fitsio.FITS(filename,'r') as f:
             np.testing.assert_raises(ValueError, piff.Model.read, f, extname='psf_model')
 
+    # But normally this file can be read...
+    with fitsio.FITS(filename,'r') as f:
+        model = piff.Model.read(f, extname='psf_model')
+        print(model)
+
     # We don't have any abstract model base classes (as we do for interp for instance),
     # But check that it works correctly in cases someone does this.
     class NoModel1(piff.Model):
@@ -624,6 +629,11 @@ def test_interp():
     with mock.patch('piff.Interp.valid_interp_types', {'Mean': piff.Mean}):
         with fitsio.FITS(filename2,'r') as f:
             np.testing.assert_raises(ValueError, piff.Interp.read, f, extname='psf_interp')
+
+    # But normally this file can be read...
+    with fitsio.FITS(filename2,'r') as f:
+        interp = piff.Interp.read(f, extname='psf_interp')
+        print(interp)
 
     # BasisInterp is an abstract base class, so it shouldn't be in the list of valid types
     assert piff.BasisInterp not in piff.Interp.valid_interp_types.values()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -21,7 +21,7 @@ import fitsio
 import yaml
 import subprocess
 
-from piff_test_helper import get_script_name, timer
+from piff_test_helper import get_script_name, timer, CaptureLog
 
 
 @timer
@@ -519,7 +519,7 @@ def test_starstats_config():
             'file_name' : psf_file,
             'stats' : [
                 {
-                    'type': 'Star',
+                    'type': 'StarImages',
                     'file_name': star_file,
                     'nplot': 5,
                     'adjust_stars': True,
@@ -534,6 +534,15 @@ def test_starstats_config():
     os.remove(star_file)
     piff.plotify(config, logger)
     assert os.path.isfile(star_file)
+
+    # repeat with deprecated name
+    os.remove(star_file)
+    config['output']['stats'][0]['type'] = 'Star'
+    with CaptureLog() as cl:
+        piff.plotify(config, cl.logger)
+    assert os.path.isfile(star_file)
+    assert 'Star is deprecated' in cl.output
+    config['output']['stats'][0]['type'] = 'StarImages'
 
     # check default nplot
     psf = piff.read(psf_file)
@@ -761,7 +770,7 @@ def test_bad_hsm():
                     'file_name': shape_file,
                 },
                 {
-                    'type': 'Star',
+                    'type': 'StarImages',
                     'file_name': star_file,
                 },
                 {

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -847,6 +847,10 @@ def test_base_stats():
     config = { 'file_name' : 'dummy_file' }
     with np.testing.assert_raises(ValueError):
         stats = piff.Stats.process(config)
+    # and it must be a valid name
+    config['type'] = 'invalid'
+    with np.testing.assert_raises(ValueError):
+        out = piff.Stats.process(config)
 
     # ... for all stats in list.
     config = [ { 'type': 'TwoDHist', 'file_name': 'f1' },
@@ -861,6 +865,24 @@ def test_base_stats():
     stats = piff.Stats()
     np.testing.assert_raises(NotImplementedError, stats.compute, None, None)
     np.testing.assert_raises(NotImplementedError, stats.plot)
+
+    # Check that registering new types works correctly
+    class NoStats1(piff.Stats):
+        pass
+    assert NoStats1 not in piff.Stats.valid_stats_types.values()
+    class NoStats2(piff.Stats):
+        _type_name = None
+    assert NoStats2 not in piff.Stats.valid_stats_types.values()
+    class ValidStats1(piff.Stats):
+        _type_name = 'valid'
+    assert ValidStats1 in piff.Stats.valid_stats_types.values()
+    assert ValidStats1 == piff.Stats.valid_stats_types['valid']
+    with np.testing.assert_raises(ValueError):
+        class ValidStats2(piff.Stats):
+            _type_name = 'valid'
+    with np.testing.assert_raises(ValueError):
+        class ValidStats3(ValidStats1):
+            pass
 
 @timer
 def test_model_properties():


### PR DESCRIPTION
I've never been super happy with how we check for valid type names in the config dict, since the names were required to be connected to the class names, but not in a particularly consistent way.

So before I start adding even more type names for the composite PSFs, I wanted to update how this is done.  Now there is a dict for each base class (PSF, Model, Interp, Outliers, Input, Output, Select and Stats) called e.g. valid_psf_types, etc., which keeps track of the config names and the corresponding class names to use.

Each class declares their config type name with a class variable called `_type_name`, which gets registered in the dict automatically using the `__init_subclass__` method.  That's a python 3-only feature, so this implementation wasn't possible when we were still supporting python 2.7.  (At least not as easily.)

I also changed a couple of rarely used type names, which I thought were a bit awkward or not very clear.  The old names still work, but are now deprecated (until the eventual Piff version 2.0):
  * GSObjectModel -> GSObject
  * GPInterp -> GP or GaussianProcess
  * kNNInterp -> KNN or KNearestNeighbors
  * Star -> StarImages  (a Stat type)