### PR TITLE
Flag outliers instead of remove them.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ API Changes
   * GPInterp -> GP or GaussianProcess
   * kNNInterp -> KNN or KNearestNeighbors
   * Star -> StarImages
+- Deprecated the include_reserve=True option for outlier rejection.  Now that all objects are
+  preserved in the output file, reserve stars that would have been rejected are marked as such,
+  so you can choose whether or not to use them for any diagnostic tests.
 
 
 Performance improvements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changes from version 1.3 to 1.4
 Output file changes
 --------------------
 
+- Stars that were rejected as outliers are now included in the output file, but flagged with
+  flag_psf=1.
 
 
 API Changes

--- a/examples/Tutorial.ipynb
+++ b/examples/Tutorial.ipynb
@@ -675,7 +675,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[('u', '>f8'), ('v', '>f8'), ('x', '>f8'), ('y', '>f8'), ('ra', '>f8'), ('dec', '>f8'), ('flux', '>f8'), ('reserve', '?'), ('flag_data', '>i8'), ('flag_model', '>i8'), ('T_data', '>f8'), ('g1_data', '>f8'), ('g2_data', '>f8'), ('T_model', '>f8'), ('g1_model', '>f8'), ('g2_model', '>f8'), ('chipnum', '>f8'), ('SPREAD_MODEL', '>f8'), ('FLAGS', '>f8'), ('snr', '>f8')]\n"
+      "[('u', '>f8'), ('v', '>f8'), ('x', '>f8'), ('y', '>f8'), ('ra', '>f8'), ('dec', '>f8'), ('flux', '>f8'), ('reserve', '?'), ('flag_psf', '>i8'), ('flag_data', '>i8'), ('flag_model', '>i8'), ('T_data', '>f8'), ('g1_data', '>f8'), ('g2_data', '>f8'), ('T_model', '>f8'), ('g1_model', '>f8'), ('g2_model', '>f8'), ('chipnum', '>f8'), ('SPREAD_MODEL', '>f8'), ('FLAGS', '>f8'), ('snr', '>f8')]\n"
      ]
     }
    ],

--- a/piff/outliers.py
+++ b/piff/outliers.py
@@ -233,9 +233,9 @@ class ChisqOutliers(Outliers):
     .. note::
 
         Reserve stars do not count toward max_remove when flagging outliers.  Any reserve star
-        that is flagged as an outlier still shows up in the output file, but has the flag
-        bit set to True.  You can decide whether or not you want to include it in any diagnostic
-        tests you perform using the reserve stars.
+        that is flagged as an outlier still shows up in the output file, but has flag_psf=1.
+        You can decide whether or not you want to include it in any diagnostic tests you perform
+        using the reserve stars.
 
     :param thresh:          The threshold in chisq above which an object is declared an outlier.
     :param ndof:            The threshold as a multiple of the model's dof.

--- a/piff/polynomial_interp.py
+++ b/piff/polynomial_interp.py
@@ -223,7 +223,7 @@ class Polynomial(Interp):
         # a reasonable guess.
         n = self._orders[parameter_index]+1
         C = np.zeros((n,n))
-        # If initilaization failed, we might get here with parameter=None.  Deal with it.
+        # If initialization failed, we might get here with parameter=None.  Deal with it.
         C[0,0] = parameter.mean() if parameter is not None else 1.0
         return C
 

--- a/piff/polynomial_interp.py
+++ b/piff/polynomial_interp.py
@@ -223,7 +223,8 @@ class Polynomial(Interp):
         # a reasonable guess.
         n = self._orders[parameter_index]+1
         C = np.zeros((n,n))
-        C[0,0] = parameter.mean()
+        # If initilaization failed, we might get here with parameter=None.  Deal with it.
+        C[0,0] = parameter.mean() if parameter is not None else 1.0
         return C
 
     def initialize(self, stars, logger=None):

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -145,7 +145,7 @@ class SimplePSF(PSF):
         fit_fn = self.model.chisq if self.quadratic_chisq else self.model.fit
 
         nremoved = 0  # For this iteration
-        use_stars = []  # Just the stars we want to use fot fitting.
+        use_stars = []  # Just the stars we want to use for fitting.
         all_stars = []  # All the stars (with appropriate flags as necessary)
         for star in stars:
             if not star.is_flagged and not star.is_reserve:

--- a/piff/star.py
+++ b/piff/star.py
@@ -437,7 +437,7 @@ class Star(object):
                     'flux', 'center', 'chisq']:
             assert key in colnames
             colnames.remove(key)
-        # These two might not be there, but it they are, remove them.
+        # These two might not be there, but if they are, remove them.
         colnames = [key for key in colnames if key not in ['reserve', 'flag_psf']]
 
         data = fits[extname].read()

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -844,6 +844,7 @@ class HSMCatalogStats(Stats):
             ra, dec,
             shapes_data[:, 0],  # flux
             np.array([s.is_reserve for s in stars], dtype=bool),  # reserve
+            np.array([s.is_flagged for s in stars], dtype=int),  # flag_psf
             shapes_data[:, 6],  # flag_data
             shapes_model[:, 6],  # flag_model
             shapes_data[:, 3],  # T_data
@@ -856,7 +857,7 @@ class HSMCatalogStats(Stats):
         self.dtypes = [('u', float), ('v', float),
                        ('x', float), ('y', float),
                        ('ra', float), ('dec', float),
-                       ('flux', float), ('reserve', bool),
+                       ('flux', float), ('reserve', bool), ('flag_psf', int),
                        ('flag_data', int), ('flag_model', int),
                        ('T_data', float), ('g1_data', float), ('g2_data', float),
                        ('T_model', float), ('g1_model', float), ('g2_model', float)]
@@ -896,7 +897,7 @@ class HSMCatalogStats(Stats):
         # Also write any other properties saved in the stars.
         prop_keys = list(stars[0].data.properties)
         # Remove all the position ones, which are handled above.
-        exclude_keys = ['x', 'y', 'u', 'v', 'ra', 'dec', 'is_reserve']
+        exclude_keys = ['x', 'y', 'u', 'v', 'ra', 'dec', 'is_reserve', 'is_flagged']
         prop_keys = [key for key in prop_keys if key not in exclude_keys]
         # Add any remaining properties
         prop_types = stars[0].data.property_types

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -95,14 +95,16 @@ def test_chisq():
     outliers1 = piff.ChisqOutliers(nsigma=5)
     stars1, nremoved1 = outliers1.removeOutliers(stars,logger=logger)
     print('nremoved1 = ',nremoved1)
-    assert len(stars1) == len(stars) - nremoved1
+    assert len(stars1) == len(stars)
+    assert nremoved1 == np.sum([s.is_flagged for s in stars1])
 
     # This is what nsigma=5 means in terms of probability
     outliers2 = piff.ChisqOutliers(prob=5.733e-7)
     stars2, nremoved2 = outliers2.removeOutliers(stars,logger=logger)
     print('nremoved2 = ',nremoved2)
-    assert len(stars2) == len(stars) - nremoved2
-    assert nremoved1 == nremoved2
+    assert len(stars2) == len(stars)
+    assert nremoved2 == np.sum([s.is_flagged for s in stars2])
+    assert nremoved2 == nremoved1
 
     # The following is nearly equivalent for this particular data set.
     # For dof=222 (what most of these have, this probability converts to
@@ -113,13 +115,15 @@ def test_chisq():
     outliers3 = piff.ChisqOutliers(thresh=455.401)
     stars3, nremoved3 = outliers3.removeOutliers(stars,logger=logger)
     print('nremoved3 = ',nremoved3)
-    assert len(stars3) == len(stars) - nremoved3
+    assert len(stars3) == len(stars)
+    assert nremoved3 == np.sum([s.is_flagged for s in stars3])
 
     outliers4 = piff.ChisqOutliers(ndof=2.05136)
     stars4, nremoved4 = outliers4.removeOutliers(stars,logger=logger)
     print('nremoved4 = ',nremoved4)
-    assert len(stars4) == len(stars) - nremoved4
-    assert nremoved3 == nremoved4
+    assert len(stars4) == len(stars)
+    assert nremoved4 == np.sum([s.is_flagged for s in stars4])
+    assert nremoved4 == nremoved3
 
     # Regression tests.  If these change, make sure we understand why.
     assert nremoved1 == nremoved2 == 58

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -1176,12 +1176,18 @@ def test_des_image():
     print('read psf')
     psf = piff.read(psf_file)
     nreserve = len([s for s in psf.stars if s.is_reserve])
+    nflagged = len([s for s in psf.stars if s.is_flagged])
+    nflagged1 = len([s for s in psf.stars if s.is_flagged and not s.is_reserve])
     ntot = len(psf.stars)
     print('nremoved = ',psf.nremoved)
     print('nreserve = ',nreserve)
+    print('nflagged = ',nflagged, nflagged1)
     print('ntot = ',ntot)
+    print('niter = ',psf.niter)
     assert nreserve == int(0.2 * nstars)
-    assert ntot == nstars - psf.nremoved
+    assert nflagged1 == psf.nremoved
+    assert nflagged >= nflagged1
+    assert ntot == nstars
 
     stars = [psf.model.initialize(s) for s in stars]
     flux = stars[0].fit.flux
@@ -1225,14 +1231,23 @@ def test_des_image():
 
     psf2 = piff.read(psf_file)
     nreserve = len([s for s in psf2.stars if s.is_reserve])
+    nflagged2 = len([s for s in psf2.stars if s.is_flagged])
+    nflagged3 = len([s for s in psf2.stars if s.is_flagged and not s.is_reserve])
     ntot = len(psf2.stars)
     print('nremoved = ',psf2.nremoved)
     print('nreserve = ',nreserve)
+    print('nflagged = ',nflagged, nflagged1)
     print('ntot = ',ntot)
     print('niter = ',psf2.niter)
-    assert ntot == nstars - psf2.nremoved
+    assert nreserve == int(0.2 * nstars)
+    assert nflagged1 == psf2.nremoved
+    assert nflagged >= nflagged1
+    assert ntot == nstars
 
-    # It also took more iterations to finish.
+    # These end up with the same objects removed, although that's not technically required.
+    assert nflagged2 == nflagged
+    assert nflagged3 == nflagged1
+    # But it took more iterations to get there.
     assert psf2.niter > psf.niter
 
 

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -1240,8 +1240,8 @@ def test_des_image():
     print('ntot = ',ntot)
     print('niter = ',psf2.niter)
     assert nreserve == int(0.2 * nstars)
-    assert nflagged1 == psf2.nremoved
-    assert nflagged >= nflagged1
+    assert nflagged3 == psf2.nremoved
+    assert nflagged2 >= nflagged3
     assert ntot == nstars
 
     # These end up with the same objects removed, although that's not technically required.

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -680,7 +680,7 @@ def test_psf():
     np.testing.assert_raises(NotImplementedError, psf.drawStarList, [star])
     np.testing.assert_raises(NotImplementedError, psf._drawStar, star)
     np.testing.assert_raises(NotImplementedError, psf._getProfile, star)
-    np.testing.assert_raises(NotImplementedError, psf.single_iteration, [star], [star], None, None)
+    np.testing.assert_raises(NotImplementedError, psf.single_iteration, [star], None, None)
 
     # Initialize doesn't do anything, but works
     stars, nremove = psf.initialize([star], None)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -818,8 +818,10 @@ def test_bad_hsm():
     # Confirm that all but one star was rejected, since that was part of the intent of this test.
     psf = piff.read(psf_file)
     print('stars = ',psf.stars)
+    print('flags = ',[s.is_flagged for s in psf.stars])
     print('nremoved = ',psf.nremoved)
-    assert len(psf.stars) == 1
+    assert len(psf.stars) == 8
+    assert np.sum([not s.is_flagged for s in psf.stars]) == 1
     assert psf.nremoved == 7    # There were 8 to start.
 
     for f in [twodhist_file, rho_file, shape_file, star_file, sizemag_file, hsm_file]:
@@ -832,11 +834,13 @@ def test_bad_hsm():
                 'T_data', 'g1_data', 'g2_data',
                 'T_model', 'g1_model', 'g2_model',
                 'flux', 'reserve', 'flag_data', 'flag_model']:
-        assert len(data[col]) == 1
+        assert len(data[col]) == 8
+    print('flag_psf = ',data['flag_psf'])
     print('flag_data = ',data['flag_data'])
     print('flag_model = ',data['flag_model'])
-    np.testing.assert_array_equal(data['flag_data'], 7)
-    np.testing.assert_array_equal(data['flag_model'], 7)
+    good_index = np.where(data['flag_psf'] == 0)[0]
+    np.testing.assert_array_equal(data['flag_data'][good_index], 7)
+    np.testing.assert_array_equal(data['flag_model'][good_index], 7)
 
 
 @timer

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -513,7 +513,7 @@ def test_parallel():
     with CaptureLog(level=2) as cl:
         psf = piff.process(config, cl.logger)
     assert "Removed 6 stars in initialize" in cl.output
-    assert "No stars.  Cannot find PSF model." in cl.output
+    assert "No stars left to fit.  Cannot find PSF model." in cl.output
     assert "Solutions failed for chipnums: [3]" in cl.output
 
     # Check that errors in the multiprocessing input get properly reported.
@@ -535,7 +535,7 @@ def test_parallel():
     config['verbose'] = 1
     with CaptureLog(level=1) as cl:
         psf = piff.process(config, logger=cl.logger)
-    assert "No stars.  Cannot find PSF model." in cl.output
+    assert "No stars left to fit.  Cannot find PSF model." in cl.output
     assert "Ignoring this failure and continuing on." in cl.output
 
 


### PR DESCRIPTION
Currently, stars that are identified as outliers get removed from the list of stars being worked on.  This means that they don't end up in the output file at all.  

This PR changes it so they do remain in the star list, but get flagged (output as `flag_psf`).  So users get more information about what stars were removed to look for potential biases (e.g. preferentially removing stars of a particular color or location on the chip).