### PR TITLE
Add ConvolvePSF type

### DIFF
--- a/piff/__init__.py
+++ b/piff/__init__.py
@@ -113,6 +113,7 @@ from .optical_model import Optical, optical_templates
 
 # Composite PSFs
 from .sumpsf import SumPSF
+from .convolvepsf import ConvolvePSF
 
 # Leave these in their own namespaces
 from . import util

--- a/piff/convolvepsf.py
+++ b/piff/convolvepsf.py
@@ -187,7 +187,7 @@ class ConvolvePSF(PSF):
                     cf = lambda prof: galsim.Convolve(convert_funcs[k](prof), others)
                 new_convert_funcs.append(cf)
 
-            stars, nremoved1 = comp.single_iteration(stars, logger, new_convert_funcs, draw_method)
+            stars, nremoved1 = comp.single_iteration(stars, logger, new_convert_funcs, method)
             nremoved += nremoved1
 
             # Update the current models for later components
@@ -268,6 +268,8 @@ class ConvolvePSF(PSF):
         # Convolve them.
         if len(profiles) == 0:
             return None, method
+        elif len(profiles) == 1:
+            return profiles[0], method
         else:
             return galsim.Convolve(profiles), method
 

--- a/piff/convolvepsf.py
+++ b/piff/convolvepsf.py
@@ -237,15 +237,11 @@ class ConvolvePSF(PSF):
             star = comp.interpolateStar(star)
         return star
 
-    def _drawStar(self, star, center=None):
+    def _drawStar(self, star):
         params = star.fit.get_params(self._num)
         prof, method = self._getRawProfile(star)
         prof = prof.shift(star.fit.center) * star.fit.flux
-        if center is None:
-            center = star.image_pos
-        else:
-            center = galsim.PositionD(*center)
-        image = prof.drawImage(image=star.image.copy(), method=method, center=center)
+        image = prof.drawImage(image=star.image.copy(), method=method, center=star.image_pos)
         return Star(star.data.withNew(image=image), star.fit)
 
     def _getRawProfile(self, star, skip=None):

--- a/piff/gsobject_model.py
+++ b/piff/gsobject_model.py
@@ -166,7 +166,7 @@ class GSObjectModel(Model):
 
         return prof
 
-    def _resid(self, params, star, convert_func):
+    def _resid(self, params, star, convert_func, draw_method):
         """Residual function to use with least_squares.
 
         Essentially `chi` from `chisq`, but not summed over pixels yet.
@@ -176,6 +176,8 @@ class GSObjectModel(Model):
         :param convert_func:    An optional function to apply to the profile being fit before
                                 drawing it onto the image.  This is used by composite PSFs to
                                 isolate the effect of just this model component.
+        :param draw_method:     The method to use with the GalSim drawImage command to determine
+                                the residuals. [if draw_method is None, use self._method]
 
         :returns: `chi` as a flattened numpy array.
         """
@@ -203,9 +205,10 @@ class GSObjectModel(Model):
 
         if convert_func is not None:
             prof = convert_func(prof)
-
+        if draw_method is None:
+            draw_method = self._method
         try:
-            prof.drawImage(model_image, method=self._method, center=image_pos)
+            prof.drawImage(model_image, method=draw_method, center=image_pos)
         except galsim.GalSimError:
             # Declare this a *bad* residual if GalSim ran into some kind of error.
             # (Most typically a GalSimFFTSizeError from getting to a place with bad stepk/maxk.)
@@ -241,7 +244,7 @@ class GSObjectModel(Model):
 
         return np.array([flux, du, dv, scale, g1, g2])
 
-    def least_squares_fit(self, star, logger=None, convert_func=None):
+    def least_squares_fit(self, star, logger=None, convert_func=None, draw_method=None):
         """Fit parameters of the given star using least-squares minimization.
 
         :param star:            A Star to fit.
@@ -249,6 +252,8 @@ class GSObjectModel(Model):
         :param convert_func:    An optional function to apply to the profile being fit before
                                 drawing it onto the image.  This is used by composite PSFs to
                                 isolate the effect of just this model component. [default: None]
+        :param draw_method:     The method to use with galsim.DrawImage to determine the residuals.
+                                [default: 'auto' if include_pixel = True, else 'no_pixel']
 
         :returns: (flux, dx, dy, scale, g1, g2, flag)
         """
@@ -262,7 +267,8 @@ class GSObjectModel(Model):
         if params[3]**2 < star.data.local_wcs.pixelArea():
             params[3] = star.data.local_wcs.pixelArea()**0.5
 
-        results = scipy.optimize.least_squares(self._resid, params, args=(star,convert_func),
+        results = scipy.optimize.least_squares(self._resid, params,
+                                               args=(star,convert_func,draw_method),
                                                **self._scipy_kwargs)
         #logger.debug(results)
         logger.debug("results = %s",results.x)
@@ -274,7 +280,7 @@ class GSObjectModel(Model):
 
         return flux, du, dv, scale, g1, g2, var
 
-    def fit(self, star, fastfit=None, logger=None, convert_func=None):
+    def fit(self, star, fastfit=None, logger=None, convert_func=None, draw_method=None):
         """Fit the image either using HSM or least-squares minimization.
 
         If ``fastfit`` is True, then the galsim.hsm module will be used to estimate the
@@ -289,7 +295,11 @@ class GSObjectModel(Model):
         :param logger:          A logger object for logging debug info. [default: None]
         :param convert_func:    An optional function to apply to the profile being fit before
                                 drawing it onto the image.  This is used by composite PSFs to
-                                isolate the effect of just this model component. [default: None]
+                                isolate the effect of just this model component. [default: None;
+                                if provided, fastfit is ignored and taken to be False.]
+        :param draw_method:     The method to use with the GalSim drawImage command to determine
+                                the residuals. [default: None, which uses 'auto' if
+                                include_pixel = True, else 'no_pixel']
 
         :returns: a new Star with the fitted parameters in star.fit
         """
@@ -305,8 +315,8 @@ class GSObjectModel(Model):
         if fastfit:
             flux, du, dv, scale, g1, g2, var = self.moment_fit(star, logger=logger)
         else:
-            flux, du, dv, scale, g1, g2, var = self.least_squares_fit(star, logger=logger,
-                                                                      convert_func=convert_func)
+            flux, du, dv, scale, g1, g2, var = self.least_squares_fit(
+                star, logger=logger, convert_func=convert_func, draw_method=draw_method)
 
         # Make a StarFit object with these parameters
         params = [scale, g1, g2]
@@ -330,9 +340,10 @@ class GSObjectModel(Model):
 
         if convert_func is not None:
             prof = convert_func(prof)
-
+        if draw_method is None:
+            draw_method = self._method
         try:
-            prof.drawImage(model_image, method=self._method, center=star.image_pos)
+            prof.drawImage(model_image, method=draw_method, center=star.image_pos)
         except galsim.GalSimError:
             # If we get the exception here, then set a large chisq, so it gets outlier rejected.
             chisq = 1.e300

--- a/piff/model.py
+++ b/piff/model.py
@@ -134,7 +134,7 @@ class Model(object):
         """
         raise NotImplementedError("Derived classes must define the fit function")
 
-    def draw(self, star, copy_image=True, center=None):
+    def draw(self, star, copy_image=True):
         """Draw the model on the given image.
 
         :param star:        A Star instance with the fitted parameters to use for drawing and a
@@ -142,8 +142,6 @@ class Model(object):
         :param copy_image:  If False, will use the same image object.
                             If True, will copy the image and then overwrite it.
                             [default: True]
-        :param center:      An optional tuple (x,y) location for where to center the drawn profile
-                            in the image. [default: None, which draws at the star's location.]
 
         :returns: a new Star instance with the data field having an image of the drawn model.
         """
@@ -153,11 +151,7 @@ class Model(object):
             image = star.image.copy()
         else:
             image = star.image
-        if center is None:
-            center = star.image_pos
-        else:
-            center = galsim.PositionD(*center)
-        prof.drawImage(image, method=self._method, center=center)
+        prof.drawImage(image, method=self._method, center=star.image_pos)
         return Star(star.data.withNew(image=image), star.fit)
 
     def write(self, fits, extname):

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -121,6 +121,8 @@ class Optical(Model):
     :param oversampling     Numerical factor by which to oversample the FFT [default: 1]
     :param pupil_plane_im:  The name of a file containing the pupil plane image to use instead
                             of creating one from obscuration, struts, etc. [default: None]
+    :param base_aberrations: A list of aberrations to which any fitted aberrations are added.
+                            [default: None]
 
     The next two parameters are specific to our treatment of the Optical PSF. If given,
     they are used to create an additional galsim.PhaseScreen describing the mirror's own
@@ -161,7 +163,7 @@ class Optical(Model):
     """
     _type_name = 'Optical'
     _method = 'auto'
-    _centered = True
+    _centered = False
     _model_can_be_offset = False
 
     def __init__(self, template=None, gsparams=None, atmo_type='VonKarman', logger=None, **kwargs):
@@ -217,7 +219,7 @@ class Optical(Model):
                 self.gsparams = galsim.GSParams(**gsparams_kwargs)
 
         # Check that no unexpected parameters were passed in:
-        other_keys = ('sigma', 'mirror_figure_im', 'mirror_figure_scale')
+        other_keys = ('sigma', 'mirror_figure_im', 'mirror_figure_scale', 'base_aberrations')
         extra_kwargs = [k for k in kwargs if k not in opt_keys + gsparams_keys + other_keys]
         if len(extra_kwargs) > 0:
             raise TypeError('__init__() got an unexpected keyword argument %r'%extra_kwargs[0])
@@ -271,9 +273,13 @@ class Optical(Model):
         self.idx_g1 = self.idx_L0 + 1
         self.idx_g2 = self.idx_g1 + 1
         self.param_len = self.idx_g2 + 1
+        self.base_aberrations = np.zeros(self.nZ+1)
+        base_aberrations = kwargs.get('base_aberrations', None)
+        if base_aberrations is not None:
+            self.base_aberrations[0:len(base_aberrations)] += base_aberrations
 
     # fit is currently a DUMMY routine
-    def fit(self, star):
+    def fit(self, star, logger=None, convert_func=None, draw_method=None):
         """Warning: This method just updates the fit with the chisq and dof!
 
         :param star:    A Star instance
@@ -293,6 +299,21 @@ class Optical(Model):
         var = np.zeros_like(params)
         return Star(star.data,
                     star.fit.newParams(params, params_var=var, num=self._num, chisq=chisq, dof=dof))
+
+    def initialize(self, star, logger=None, default_init=None):
+        """Initialize the given star's fit parameters.
+
+        :param star:            The Star to initialize.
+        :param logger:          A logger object for logging debug info. [default: None]
+        :param default_init:    Ignored. [default: None]
+
+        :returns: a new initialized Star.
+        """
+        params = self.kwargs_to_params()
+        params_var = np.zeros_like(params)
+        fit = star.fit.newParams(params, params_var=params_var, num=self._num)
+        star = Star(star.data, fit)
+        return star
 
     @lru_cache(maxsize=8)
     def getOptics(self, zernike_coeff):
@@ -407,6 +428,9 @@ class Optical(Model):
         # otherwise parameters are in getProfile argument list
         if params is not None :
             *zernike_coeff,r0,L0,g1,g2 = params
+        aberrations = self.base_aberrations.copy()
+        if zernike_coeff is not None:
+            aberrations[:len(zernike_coeff)] += zernike_coeff
 
         # list of PSF components
         prof = []
@@ -419,11 +443,12 @@ class Optical(Model):
             prof.append(gaussian)
 
         # atmospheric kernel
-        atmopsf = self.getAtmosphere(r0, L0, g1, g2)
-        prof.append(atmopsf)
+        if self.atmo_type not in ['None', None]:
+            atmopsf = self.getAtmosphere(r0, L0, g1, g2)
+            prof.append(atmopsf)
 
         # optics
-        prof.append(self.getOptics(tuple(zernike_coeff)))
+        prof.append(self.getOptics(tuple(aberrations)))
 
         # convolve
         prof = galsim.Convolve(prof,gsparams=self.gsparams)

--- a/piff/optical_model.py
+++ b/piff/optical_model.py
@@ -448,9 +448,10 @@ class Optical(Model):
             prof.append(atmopsf)
 
         # optics
-        prof.append(self.getOptics(tuple(aberrations)))
+        optics = self.getOptics(tuple(aberrations))
 
-        # convolve
-        prof = galsim.Convolve(prof,gsparams=self.gsparams)
-
-        return prof
+        if len(prof) == 0:
+            return optics
+        else:
+            prof.append(optics)
+            return galsim.Convolve(prof, gsparams=self.gsparams)

--- a/piff/pixelgrid.py
+++ b/piff/pixelgrid.py
@@ -318,6 +318,7 @@ class PixelGrid(Model):
             logger.debug(f'basis_profile = {basis_profile}')
             # Find the net shift from the star.fit.center and the offset.
             jac = star.data.local_wcs.jacobian().inverse().getMatrix()
+            jac_det = abs(jac[0,0]*jac[1,1] - jac[0,1]*jac[1,0])
             dx = jac[0,0]*u0 + jac[0,1]*v0 + offset.x
             dy = jac[1,0]*u0 + jac[1,1]*v0 + offset.y
             du = du.ravel() * self.scale
@@ -328,10 +329,10 @@ class PixelGrid(Model):
                 if draw_real:
                     prof._drawReal(image, jac, (dx,dy), 1.)
                     # Equivalent to:
-                    #prof = galsim._Transform(prof, jac, (dx,dy), 1.)
+                    #prof = galsim._Transform(prof, jac, (dx,dy), 1./jac_det)
                     #prof.drawReal(image)
                 else:
-                    prof = galsim._Transform(prof, jac, (dx,dy), 1.)
+                    prof = galsim._Transform(prof, jac, (dx,dy), 1./jac_det)
                     prof.drawFFT(image)
                 A[:,k] = image.array.ravel()[mask]
         else:

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -671,7 +671,7 @@ class PSF(object):
             stars = self.interpolateStarList(stars)
         return [self._drawStar(star) for star in stars]
 
-    def drawStar(self, star, copy_image=True, center=None):
+    def drawStar(self, star, copy_image=True):
         """Generate PSF image for a given star.
 
         .. note::
@@ -689,8 +689,6 @@ class PSF(object):
         :param copy_image:  If False, will use the same image object.
                             If True, will copy the image and then overwrite it.
                             [default: True]
-        :param center:      An optional tuple (x,y) location for where to center the drawn profile
-                            in the image. [default: None, which draws at the star's location.]
 
         :returns:           Star instance with its image filled with rendered PSF
         """
@@ -702,9 +700,9 @@ class PSF(object):
         if star.fit is None or star.fit.get_params(self._num) is None:
             star = self.interpolateStar(star)
         # Render the image
-        return self._drawStar(star, center=center)
+        return self._drawStar(star)
 
-    def _drawStar(self, star, center=None):
+    def _drawStar(self, star):
         # Derived classes may choose to override any of the above functions
         # But they have to at least override this one and interpolateStar to implement
         # their actual PSF model.

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -233,8 +233,8 @@ class SimplePSF(PSF):
         self.model.normalize(star)
         return star
 
-    def _drawStar(self, star, center=None):
-        return self.model.draw(star, center=center)
+    def _drawStar(self, star):
+        return self.model.draw(star)
 
     def _getRawProfile(self, star):
         return self.model.getProfile(star.fit.get_params(self._num)), self.model._method

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -162,11 +162,11 @@ class SingleChipPSF(PSF):
         chipnum = star['chipnum']
         return self.psf_by_chip[chipnum].interpolateStar(star)
 
-    def _drawStar(self, star, center=None):
+    def _drawStar(self, star):
         if 'chipnum' not in star.data.properties:
             raise ValueError("SingleChip requires the star to have a chipnum property")
         chipnum = star['chipnum']
-        return self.psf_by_chip[chipnum]._drawStar(star, center=center)
+        return self.psf_by_chip[chipnum]._drawStar(star)
 
     def _getProfile(self, star):
         chipnum = star['chipnum']

--- a/piff/sumpsf.py
+++ b/piff/sumpsf.py
@@ -245,11 +245,11 @@ class SumPSF(PSF):
             star = comp.interpolateStar(star)
         return star
 
-    def _drawStar(self, star, center=None):
+    def _drawStar(self, star):
         # Draw each component
         comp_stars = []
         for comp in self.components:
-            comp_star = comp._drawStar(star, center=center)
+            comp_star = comp._drawStar(star)
             comp_stars.append(comp_star)
 
         # Add them up.

--- a/tests/test_convolvepsf.py
+++ b/tests/test_convolvepsf.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2016 by Mike Jarvis and the other collaborators on GitHub at
+# https://github.com/rmjarvis/Piff  All rights reserved.
+#
+# Piff is free software: Redistribution and use in source and binary forms
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+
+import galsim
+import numpy as np
+import piff
+import os
+import fitsio
+
+from piff_test_helper import timer
+
+@timer
+def test_trivial_convolve1():
+    """Test the trivial case of using a Convolve of 1 component.
+    """
+    # This is essentially the same as test_single_image in test_simple.py
+
+    if __name__ == '__main__':
+        logger = piff.config.setup_logger(verbose=2)
+    else:
+        logger = piff.config.setup_logger(log_file='output/test_trivial_convolve1.log')
+
+    # Make the image
+    image = galsim.Image(2048, 2048, scale=0.26)
+
+    # Where to put the stars. (Randomish, but make sure no blending.)
+    x_list = [ 123.12, 345.98, 567.25, 1094.94, 924.15, 1532.74, 1743.11, 888.39, 1033.29, 1409.31 ]
+    y_list = [ 345.43, 567.45, 1094.32, 924.29, 1532.92, 1743.83, 888.83, 1033.19, 1409.20, 123.11 ]
+
+    # Draw a Gaussian PSF at each location on the image.
+    sigma = 1.3
+    g1 = 0.23
+    g2 = -0.17
+    psf = galsim.Gaussian(sigma=sigma).shear(g1=g1, g2=g2)
+    targets = []
+    for x,y in zip(x_list, y_list):
+        bounds = galsim.BoundsI(int(x-31), int(x+32), int(y-31), int(y+32))
+        psf.drawImage(image=image[bounds], method='no_pixel', center=(x,y))
+        targets.append(image[bounds])
+    image.addNoise(galsim.GaussianNoise(rng=galsim.BaseDeviate(1234), sigma=1e-6))
+
+    # Write out the image to a file
+    image_file = os.path.join('output','trivial_convolve1_im.fits')
+    image.write(image_file)
+
+    # Write out the catalog to a file
+    dtype = [ ('x','f8'), ('y','f8') ]
+    data = np.empty(len(x_list), dtype=dtype)
+    data['x'] = x_list
+    data['y'] = y_list
+    cat_file = os.path.join('output','trivial_convolve1_cat.fits')
+    fitsio.write(cat_file, data, clobber=True)
+
+    psf_file = os.path.join('output','trivial_convolve1_psf.fits')
+    stamp_size = 48
+    config = {
+        'input' : {
+            'image_file_name' : image_file,
+            'cat_file_name' : cat_file,
+            'stamp_size' : stamp_size
+        },
+        'psf' : {
+            'type' : 'Convolve',
+            'components': [
+                {
+                    'type' : 'Simple',
+                    'model' : { 'type' : 'Gaussian',
+                                'fastfit': True,
+                                'include_pixel': False },
+                    'interp' : { 'type' : 'Mean' },
+                }
+            ],
+            'max_iter' : 10,
+            'chisq_thresh' : 0.2,
+        },
+        'output' : { 'file_name' : psf_file },
+    }
+
+    piff.piffify(config, logger)
+    psf = piff.read(psf_file)
+
+    assert type(psf) is piff.ConvolvePSF
+    assert len(psf.components) == 1
+    assert type(psf.components[0]) is piff.SimplePSF
+    assert type(psf.components[0].model) is piff.Gaussian
+    assert type(psf.components[0].interp) is piff.Mean
+
+    assert psf.chisq_thresh == 0.2
+    assert psf.max_iter == 10
+
+    for i, star in enumerate(psf.stars):
+        target = targets[i]
+        test_star = psf.drawStar(star)
+        true_params = [ sigma, g1, g2 ]
+        np.testing.assert_almost_equal(test_star.fit.params[0], true_params, decimal=4)
+        # The drawn image should be reasonably close to the target.
+        target = target[star.image.bounds]
+        print('target max diff = ',np.max(np.abs(test_star.image.array - target.array)))
+        np.testing.assert_allclose(test_star.image.array, target.array, atol=1.e-5)
+
+        # test that draw works
+        test_image = psf.draw(x=star['x'], y=star['y'], stamp_size=config['input']['stamp_size'],
+                              flux=star.fit.flux, offset=star.fit.center/image.scale)
+        # This image should be very close to the same values as test_star
+        # Just make sure to compare over the same bounds.
+        b = test_star.image.bounds & test_image.bounds
+        print('draw/drawStar max diff = ',np.max(np.abs(test_image[b].array - test_star.image[b].array)))
+        np.testing.assert_allclose(test_image[b].array, test_star.image[b].array, atol=1.e-9)
+
+    # Outlier is a valid option
+    config['psf']['outliers'] = {
+        'type' : 'Chisq',
+        'nsigma' : 5,
+        'max_remove' : 3,
+    }
+    piff.piffify(config)
+    psf2 = piff.read(psf_file)
+    # This didn't remove anything, so the result is the same.
+    # (Use the last star from the above loop for comparison.)
+    test_star2 = psf2.drawStar(star)
+    np.testing.assert_almost_equal(test_star2.fit.params[0], true_params, decimal=4)
+    assert test_star2.image == test_star.image
+
+    test_image2 = psf2.draw(x=star['x'], y=star['y'], stamp_size=config['input']['stamp_size'],
+                           flux=star.fit.flux, offset=star.fit.center/image.scale)
+    assert test_image2 == test_image
+
+    # Error if components is missing
+    config1 = config.copy()
+    del config1['psf']['components']
+    with np.testing.assert_raises(ValueError):
+        piff.process(config)
+
+@timer
+def test_optatm():
+    # Let reality be atmospheric + optical PSF with realistic variation.
+    # And model this with a convolution of a Kolmogorov/GP SimplePSF and a fixed Optical PSF.
+
+    # Some parameters copied from psf_wf_movie.py in GalSim repo.
+    Ellerbroek_alts = [0.0, 2.58, 5.16, 7.73, 12.89, 15.46]  # km
+    Ellerbroek_weights = [0.652, 0.172, 0.055, 0.025, 0.074, 0.022]
+    Ellerbroek_interp = galsim.LookupTable(Ellerbroek_alts, Ellerbroek_weights,
+                                           interpolant='linear')
+
+    # Use given number of uniformly spaced altitudes
+    alts = np.max(Ellerbroek_alts)*np.arange(6)/5.
+    weights = Ellerbroek_interp(alts)  # interpolate the weights
+    weights /= sum(weights)  # and renormalize
+
+    spd = []  # Wind speed in m/s
+    dirn = [] # Wind direction in radians
+    r0_500 = [] # Fried parameter in m at a wavelength of 500 nm.
+    u = galsim.UniformDeviate(1234)
+    for i in range(6):
+        spd.append(u() * 20)
+        dirn.append(u() * 360*galsim.degrees)
+        r0_500.append(0.1 * weights[i]**(-3./5))
+
+    screens = galsim.Atmosphere(r0_500=r0_500, speed=spd, direction=dirn, altitude=alts, rng=u,
+                                screen_size=102.4, screen_scale=0.1)
+
+    # Add in an optical screen
+    screens.append(galsim.OpticalScreen(diam=8, defocus=0.7, astig1=-0.8, astig2=0.7,
+                                        trefoil1=-0.6, trefoil2=0.5,
+                                        coma1=0.5, coma2=0.7, spher=0.8, obscuration=0.4))
+
+    aper = galsim.Aperture(diam=8, obscuration=0.4)
+
+    if __name__ == '__main__':
+        size = 2048
+        nstars = 200
+        noise = 20
+    else:
+        size = 1024
+        nstars = 10
+        noise = 2
+
+    pixel_scale = 0.2
+    im = galsim.ImageF(size, size, scale=pixel_scale)
+
+    x = u.np.uniform(25, size-25, size=nstars)
+    y = u.np.uniform(25, size-25, size=nstars)
+
+    for k in range(nstars):
+        flux = 100000
+        theta = ((x[k] - size/2) * pixel_scale * galsim.arcsec,
+                 (y[k] - size/2) * pixel_scale * galsim.arcsec)
+
+        psf = screens.makePSF(lam=500, aper=aper, exptime=100, flux=flux, theta=theta)
+        psf.drawImage(image=im, center=(x[k],y[k]), method='phot', rng=u, add_to_image=True)
+        bounds = galsim.BoundsI(int(x[k]-33), int(x[k]+33), int(y[k]-33), int(y[k]+33))
+
+    # Add a little noise
+    noise = 10
+    im.addNoise(galsim.GaussianNoise(rng=u, sigma=noise))
+    image_file = os.path.join('output', 'convolveatmpsf_im.fits')
+    im.write(image_file)
+
+    # Write out the catalog to a file
+    dtype = [ ('x','f8'), ('y','f8') ]
+    data = np.empty(len(x), dtype=dtype)
+    data['x'] = x
+    data['y'] = y
+    cat_file = os.path.join('output','convolveatmpsf_cat.fits')
+    fitsio.write(cat_file, data, clobber=True)
+
+    psf_file = os.path.join('output','convolveatmpsf.fits')
+    stamp_size = 48
+    config = {
+        'input' : {
+            'image_file_name' : image_file,
+            'cat_file_name' : cat_file,
+            'stamp_size' : 32,
+            'noise': noise**2,
+        },
+        'select' : {
+            'max_snr': 1.e6,
+            'max_edge_frac': 0.1,
+            'hsm_size_reject': True,
+        },
+        'psf' : {
+            'type' : 'Convolve',
+            'components': [
+                {
+                    'model' : { 'type': 'Kolmogorov',
+                                'fastfit': True,
+                              },
+                    'interp' : { 'type': 'GP',
+                               },
+                },
+                {
+                    'model' : { 'type': 'Optical',
+                                'atmo_type': 'None',
+                                'lam': 500,
+                                'diam': 8,
+                                # These are the correct aberrations, not fitted.
+                                'base_aberrations': [0,0,0,0,0.7,-0.8,0.7,0.5,0.7,-0.6,0.5,0.8],
+                                'obscuration': 0.4,
+                              },
+                    'interp' : { 'type': 'Mean', },
+                }
+            ],
+            'outliers': {
+                'type' : 'Chisq',
+                'nsigma' : 5,
+                'max_remove' : 3,
+            }
+        },
+        'output' : {
+            'file_name' : psf_file,
+       },
+    }
+
+    if __name__ == '__main__':
+        logger = piff.config.setup_logger(verbose=1)
+    else:
+        logger = piff.config.setup_logger(log_file='output/test_convolveatmpsf.log')
+        logger = piff.config.setup_logger(verbose=1)
+
+    psf = piff.process(config, logger)
+
+    if __name__ == '__main__':
+        config['output']['stats'] = [{
+            'type': 'StarImages',
+            'file_name': os.path.join('output','test_convolveatmpsf_stars.png'),
+            'nplot': 10,
+            'adjust_stars': True,
+        }]
+        output = piff.Output.process(config['output'], logger=logger)
+        output.write(psf, logger=logger)
+
+    assert type(psf) is piff.ConvolvePSF
+    assert len(psf.components) == 2
+    assert type(psf.components[0]) is piff.SimplePSF
+    assert type(psf.components[0].model) is piff.Kolmogorov
+    assert type(psf.components[0].interp) is piff.GPInterp
+    assert type(psf.components[1]) is piff.SimplePSF
+    assert type(psf.components[1].model) is piff.Optical
+    assert type(psf.components[1].interp) is piff.Mean
+
+    mean_max_rel_err = 0
+    mean_mse = 0
+    count = 0
+    for i, star in enumerate(psf.stars):
+        if star.is_flagged:
+            continue
+        test_star = psf.drawStar(star)
+
+        b = star.image.bounds.withBorder(-8)
+        max_diff = np.max(np.abs(test_star.image[b].array - star.image[b].array))
+        max_val = np.max(np.abs(star.image[b].array))
+        #print('max_diff / max_val = ',max_diff, max_val, max_diff / max_val)
+        mse = np.sum((test_star.image[b].array - star.image[b].array)**2) / flux**2
+        #print('mse = ',mse)
+        mean_max_rel_err += max_diff/max_val
+        mean_mse += mse
+        count += 1
+
+    mean_max_rel_err /= count
+    mean_mse /= count
+    print('mean maximum relative error = ',mean_max_rel_err)
+    print('mean mean-squared error = ',mean_mse)
+    assert mean_max_rel_err < 0.04
+    assert mean_mse < 1.5e-5
+
+    # Without the Optical component, it's quite a bit worse.
+    config['psf'] = config['psf']['components'][0]
+    psf = piff.process(config, logger)
+
+    if __name__ == '__main__':
+        config['output']['stats'][0]['file_name'] = os.path.join('output', 'test_convolveatmpsf_stars2.png')
+        output = piff.Output.process(config['output'], logger=logger)
+        output.write(psf, logger=logger)
+
+    mean_max_rel_err = 0
+    mean_mse = 0
+    count = 0
+    for i, star in enumerate(psf.stars):
+        if star.is_flagged:
+            continue
+        test_star = psf.drawStar(star)
+
+        b = star.image.bounds.withBorder(-8)
+        max_diff = np.max(np.abs(test_star.image[b].array - star.image[b].array))
+        max_val = np.max(np.abs(star.image[b].array))
+        #print('max_diff / max_val = ',max_diff / max_val)
+        mse = np.sum((test_star.image[b].array - star.image[b].array)**2) / flux**2
+        #print('mse = ',mse)
+        mean_max_rel_err += max_diff/max_val
+        mean_mse += mse
+        count += 1
+
+    mean_max_rel_err /= count
+    mean_mse /= count
+    print('mean maximum relative error = ',mean_max_rel_err)
+    print('mean mean-squared error = ',mean_mse)
+    assert mean_max_rel_err > 0.06
+    assert mean_mse > 6.e-5
+
+
+if __name__ == '__main__':
+    test_trivial_convolve1()
+    test_optatm()

--- a/tests/test_convolvepsf.py
+++ b/tests/test_convolvepsf.py
@@ -143,7 +143,7 @@ def test_trivial_convolve1():
         piff.process(config)
 
 @timer
-def test_optatm():
+def test_convolve_optatm():
     # Let reality be atmospheric + optical PSF with realistic variation.
     # And model this with a convolution of a Kolmogorov/GP SimplePSF and a fixed Optical PSF.
 
@@ -265,7 +265,7 @@ def test_optatm():
     if __name__ == '__main__':
         logger = piff.config.setup_logger(verbose=1)
     else:
-        logger = piff.config.setup_logger(log_file='output/test_convolveatmpsf.log')
+        logger = piff.config.setup_logger(log_file='output/test_convolve_optatm.log')
         logger = piff.config.setup_logger(verbose=1)
 
     psf = piff.process(config, logger)
@@ -273,7 +273,7 @@ def test_optatm():
     if __name__ == '__main__':
         config['output']['stats'] = [{
             'type': 'StarImages',
-            'file_name': os.path.join('output','test_convolveatmpsf_stars.png'),
+            'file_name': os.path.join('output','test_convolve_optatm_stars.png'),
             'nplot': 10,
             'adjust_stars': True,
         }]
@@ -319,7 +319,7 @@ def test_optatm():
     psf = piff.process(config, logger)
 
     if __name__ == '__main__':
-        config['output']['stats'][0]['file_name'] = os.path.join('output', 'test_convolveatmpsf_stars2.png')
+        config['output']['stats'][0]['file_name'] = os.path.join('output', 'test_convolve_optatm_stars2.png')
         output = piff.Output.process(config['output'], logger=logger)
         output.write(psf, logger=logger)
 
@@ -349,6 +349,180 @@ def test_optatm():
     assert mean_mse > 6.e-5
 
 
+@timer
+def test_convolve_pixelgrid():
+    # Same as test_optatm, but use a PixelGrid for one of the components
+
+    # Some parameters copied from psf_wf_movie.py in GalSim repo.
+    Ellerbroek_alts = [0.0, 2.58, 5.16, 7.73, 12.89, 15.46]  # km
+    Ellerbroek_weights = [0.652, 0.172, 0.055, 0.025, 0.074, 0.022]
+    Ellerbroek_interp = galsim.LookupTable(Ellerbroek_alts, Ellerbroek_weights,
+                                           interpolant='linear')
+
+    # Use given number of uniformly spaced altitudes
+    alts = np.max(Ellerbroek_alts)*np.arange(6)/5.
+    weights = Ellerbroek_interp(alts)  # interpolate the weights
+    weights /= sum(weights)  # and renormalize
+
+    spd = []  # Wind speed in m/s
+    dirn = [] # Wind direction in radians
+    r0_500 = [] # Fried parameter in m at a wavelength of 500 nm.
+    u = galsim.UniformDeviate(1234)
+    for i in range(6):
+        spd.append(u() * 20)
+        dirn.append(u() * 360*galsim.degrees)
+        r0_500.append(0.1 * weights[i]**(-3./5))
+
+    screens = galsim.Atmosphere(r0_500=r0_500, speed=spd, direction=dirn, altitude=alts, rng=u,
+                                screen_size=102.4, screen_scale=0.1)
+
+    # Add in an optical screen
+    screens.append(galsim.OpticalScreen(diam=8, defocus=0.7, astig1=-0.8, astig2=0.7,
+                                        trefoil1=-0.6, trefoil2=0.5,
+                                        coma1=0.5, coma2=0.7, spher=0.8, obscuration=0.4))
+
+    aper = galsim.Aperture(diam=8, obscuration=0.4)
+
+    if __name__ == '__main__':
+        size = 2048
+        nstars = 200
+        noise = 20
+    else:
+        size = 1024
+        nstars = 10
+        noise = 2
+
+    pixel_scale = 0.2
+    im = galsim.ImageF(size, size, scale=pixel_scale)
+
+    x = u.np.uniform(25, size-25, size=nstars)
+    y = u.np.uniform(25, size-25, size=nstars)
+
+    for k in range(nstars):
+        flux = 100000
+        theta = ((x[k] - size/2) * pixel_scale * galsim.arcsec,
+                 (y[k] - size/2) * pixel_scale * galsim.arcsec)
+
+        psf = screens.makePSF(lam=500, aper=aper, exptime=100, flux=flux, theta=theta)
+        psf.drawImage(image=im, center=(x[k],y[k]), method='phot', rng=u, add_to_image=True)
+        bounds = galsim.BoundsI(int(x[k]-33), int(x[k]+33), int(y[k]-33), int(y[k]+33))
+
+    # Add a little noise
+    im.addNoise(galsim.GaussianNoise(rng=u, sigma=noise))
+    image_file = os.path.join('output', 'convolveatmpsf_im.fits')
+    im.write(image_file)
+
+    # Write out the catalog to a file
+    dtype = [ ('x','f8'), ('y','f8') ]
+    data = np.empty(len(x), dtype=dtype)
+    data['x'] = x
+    data['y'] = y
+    cat_file = os.path.join('output','convolveatmpsf_cat.fits')
+    fitsio.write(cat_file, data, clobber=True)
+
+    psf_file = os.path.join('output','convolveatmpsf.fits')
+    config = {
+        'input' : {
+            'image_file_name' : image_file,
+            'cat_file_name' : cat_file,
+            'stamp_size' : 32,
+            'noise': noise**2,
+        },
+        'select' : {
+            'max_snr': 1.e6,
+            'max_edge_frac': 0.1,
+            'hsm_size_reject': True,
+        },
+        'psf' : {
+            'type' : 'Convolve',
+            'max_iter': 5,
+            'components': [
+                {
+                    'model' : { 'type': 'PixelGrid',
+                                'scale': pixel_scale,
+                                'size': 17,
+                              },
+                    'interp' : { 'type': 'Polynomial',
+                                 'order': 1,
+                               },
+                },
+                {
+                    'model' : { 'type': 'Optical',
+                                'atmo_type': 'None',
+                                'lam': 500,
+                                'diam': 8,
+                                # These are the correct aberrations, not fitted.
+                                'base_aberrations': [0,0,0,0,0.7,-0.8,0.7,0.5,0.7,-0.6,0.5,0.8],
+                                'obscuration': 0.4,
+                              },
+                    'interp' : { 'type': 'Mean', },
+                }
+            ],
+            'outliers': {
+                'type' : 'Chisq',
+                'nsigma' : 5,
+                'max_remove' : 3,
+            }
+        },
+        'output' : {
+            'file_name' : psf_file,
+       },
+    }
+
+    if __name__ == '__main__':
+        logger = piff.config.setup_logger(verbose=1)
+    else:
+        logger = piff.config.setup_logger(log_file='output/test_convolve_pixelgrid.log')
+        logger = piff.config.setup_logger(verbose=1)
+
+    psf = piff.process(config, logger)
+
+    if __name__ == '__main__':
+        config['output']['stats'] = [{
+            'type': 'StarImages',
+            'file_name': os.path.join('output','test_convolve_pixelgrid_stars.png'),
+            'nplot': 10,
+            'adjust_stars': True,
+        }]
+        output = piff.Output.process(config['output'], logger=logger)
+        output.write(psf, logger=logger)
+
+    assert type(psf) is piff.ConvolvePSF
+    assert len(psf.components) == 2
+    assert type(psf.components[0]) is piff.SimplePSF
+    assert type(psf.components[0].model) is piff.PixelGrid
+    assert type(psf.components[0].interp) is piff.Polynomial
+    assert type(psf.components[1]) is piff.SimplePSF
+    assert type(psf.components[1].model) is piff.Optical
+    assert type(psf.components[1].interp) is piff.Mean
+
+    mean_max_rel_err = 0
+    mean_mse = 0
+    count = 0
+    for i, star in enumerate(psf.stars):
+        if star.is_flagged:
+            continue
+        test_star = psf.drawStar(star)
+
+        b = star.image.bounds.withBorder(-8)
+        max_diff = np.max(np.abs(test_star.image[b].array - star.image[b].array))
+        max_val = np.max(np.abs(star.image[b].array))
+        #print('max_diff / max_val = ',max_diff, max_val, max_diff / max_val)
+        mse = np.sum((test_star.image[b].array - star.image[b].array)**2) / flux**2
+        #print('mse = ',mse)
+        mean_max_rel_err += max_diff/max_val
+        mean_mse += mse
+        count += 1
+
+    mean_max_rel_err /= count
+    mean_mse /= count
+    print('mean maximum relative error = ',mean_max_rel_err)
+    print('mean mean-squared error = ',mean_mse)
+    assert mean_max_rel_err < 0.04
+    assert mean_mse < 2.e-5
+
+
 if __name__ == '__main__':
     test_trivial_convolve1()
-    test_optatm()
+    test_convolve_optatm()
+    test_convolve_pixelgrid()

--- a/tests/test_gsobject_model.py
+++ b/tests/test_gsobject_model.py
@@ -1091,7 +1091,7 @@ def test_fail():
         stars, _ = psf.initialize_params([star3], logger=cl.logger)
         with np.testing.assert_raises(RuntimeError):
             # Raises an error that all stars were flagged
-            psf.single_iteration(stars, logger=cl.logger, convert_func=None)
+            psf.single_iteration(stars, logger=cl.logger, convert_funcs=None, draw_method=None)
     assert "Failed fitting star" in cl.output
     print('5')
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -780,9 +780,11 @@ def test_psf():
     np.testing.assert_raises(NotImplementedError, psf.drawStarList, [star])
     np.testing.assert_raises(NotImplementedError, psf._drawStar, star)
     np.testing.assert_raises(NotImplementedError, psf._getProfile, star)
-    np.testing.assert_raises(NotImplementedError, psf.single_iteration, [star], None, None)
+    np.testing.assert_raises(NotImplementedError, psf.single_iteration, [star], None, None, None)
     with np.testing.assert_raises(NotImplementedError):
         psf.fit_center
+    with np.testing.assert_raises(NotImplementedError):
+        psf.include_model_centroid
 
     # initialize_params doesn't do anything, but works
     stars, nremove = psf.initialize_params([star], None)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -310,10 +310,6 @@ def test_single_image():
     assert test_star_nocopy.image.array[1,1] == target_star_copy.image.array[1,1]
     assert test_star_copy.image.array[1,1] == target_star_copy.image.array[1,1]
 
-    test_star_center = psf.model.draw(test_star_copy, copy_image=True, center=(x+1,y+1))
-    np.testing.assert_almost_equal(test_star_center.image.array[1:,1:],
-                                   test_star_copy.image.array[:-1,:-1])
-
     # test that draw works
     test_image = psf.draw(x=target['x'], y=target['y'], stamp_size=config['input']['stamp_size'],
                           flux=target.fit.flux, offset=target.fit.center)

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -375,6 +375,7 @@ def test_single():
     # SingleChip doesn't use code paths that hit these functions, but they are officially
     # required methods for PSF classes, so just check them directly.
     assert psf.fit_center is True
+    assert psf.include_model_centroid is False
     raw1 = psf._getRawProfile(star)
     raw2 = psf.psf_by_chip[star['chipnum']]._getRawProfile(star)
     assert raw1 == raw2


### PR DESCRIPTION
This PR adds a new composite PSF type, Convolve.  This is I think the framework into which we can move the work that @aaronroodman et al have done on the OptAtmo type.

Now we can separately specify the two or three things we want to convolve the optical PSF by and the code will separately fit each with their own interpolation scheme, etc.

For now the tests just have a fixed Optical model which is convolved by a Kolmogorov/GP model.  So my next task is to port over the OptAtmo code that fits for the aberrations into something that works in this framework.