### PR TITLE
Add option to include average star/model in StarImages plots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Output file changes
 API Changes
 -----------
 
+- Changed the default behavior of the StarImages plot to include the average star and model.
+  To recover the old version without these images, use ``include_ave = False``. (#167)
 
 
 Performance improvements
@@ -18,6 +20,7 @@ Performance improvements
 New features
 ------------
 
+- Added an image of the average star and model in the StarImages output plot. (#167)
 
 
 Bug fixes


### PR DESCRIPTION
When thinking about useful plots for a DE School lesson I'm doing with @arunkannawadi, I realized it would be nice to show the average star and PSF image, rather than just a sampling of them as we currently do in the StarImages plot.

This PR adds an option to include this average image as the first plot in a StarImages plot.  The default for this option is True, but you can turn it off with `include_ave=False`.

Here is an example of what the output looks like now with the average plot included:

![pixel_des_stars](https://github.com/rmjarvis/Piff/assets/623887/53d5cef4-7f01-4c19-86a6-6be0cde45a1c)
