### PR TITLE
Refactor write/read methods to delegate to new Writer/Reader interface.

### DIFF
--- a/piff/__init__.py
+++ b/piff/__init__.py
@@ -120,3 +120,4 @@ from . import util
 from . import des
 from . import wavefront
 from . import meta_data
+from . import writers

--- a/piff/__init__.py
+++ b/piff/__init__.py
@@ -120,4 +120,5 @@ from . import util
 from . import des
 from . import wavefront
 from . import meta_data
+from . import readers
 from . import writers

--- a/piff/basis_interp.py
+++ b/piff/basis_interp.py
@@ -434,11 +434,10 @@ class BasisPolynomial(BasisInterp):
         out[0] = value  # The constant term is always first.
         return out
 
-    def _finish_write(self, fits, extname):
-        """Write the solution to a FITS binary table.
+    def _finish_write(self, writer):
+        """Write the solution.
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The base name of the extension.
+        :param writer:      A writer object that encapsulates the serialization format.
         """
         if self.q is None:
             raise RuntimeError("Solution not set yet.  Cannot write this BasisPolynomial.")
@@ -446,7 +445,7 @@ class BasisPolynomial(BasisInterp):
         dtypes = [ ('q', float, self.q.shape) ]
         data = np.zeros(1, dtype=dtypes)
         data['q'] = self.q
-        fits.write_table(data, extname=extname + '_solution')
+        writer.write_table('solution', data)
 
     def _finish_read(self, fits, extname):
         """Read the solution from a FITS binary table.

--- a/piff/basis_interp.py
+++ b/piff/basis_interp.py
@@ -447,12 +447,12 @@ class BasisPolynomial(BasisInterp):
         data['q'] = self.q
         writer.write_table('solution', data)
 
-    def _finish_read(self, fits, extname):
-        """Read the solution from a FITS binary table.
+    def _finish_read(self, reader):
+        """Read the solution.
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The name of the extension with the interpolator information.
+        :param reader:      A reader object that encapsulates the serialization format.
         """
-        data = fits[extname + '_solution'].read()
+        data = reader.read_table('solution')
+        assert data is not None
         self.q = data['q'][0]
 

--- a/piff/convolvepsf.py
+++ b/piff/convolvepsf.py
@@ -20,7 +20,6 @@ import numpy as np
 import galsim
 
 from .psf import PSF
-from .util import read_kwargs
 from .star import Star, StarFit
 from .outliers import Outliers
 
@@ -292,24 +291,20 @@ class ConvolvePSF(PSF):
             self.outliers._write(writer, 'outliers')
             logger.debug("Wrote the PSF outliers to extension %s", writer.get_full_name('outliers'))
 
-    def _finish_read(self, fits, extname, logger):
+    def _finish_read(self, reader, logger):
         """Finish the reading process with any class-specific steps.
 
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The base name of the extension to write to.
+        :param reader:      A reader object that encapsulates the serialization format.
         :param logger:      A logger object for logging debug info.
         """
-        chisq_dict = read_kwargs(fits, extname + '_chisq')
+        chisq_dict = reader.read_struct('chisq')
         for key in chisq_dict:
             setattr(self, key, chisq_dict[key])
 
         ncomponents = self.components
         self.components = []
         for k in range(ncomponents):
-            self.components.append(PSF._read(fits, extname + '_' + str(k), logger=logger))
-        if extname + '_outliers' in fits:
-            self.outliers = Outliers.read(fits, extname + '_outliers')
-        else:
-            self.outliers = None
+            self.components.append(PSF._read(reader, str(k), logger=logger))
+        self.outliers = Outliers._read(reader, 'outliers')
         # Set up all the num's properly now that everything is constructed.
         self.set_num(None)

--- a/piff/convolvepsf.py
+++ b/piff/convolvepsf.py
@@ -288,7 +288,7 @@ class ConvolvePSF(PSF):
         for k, comp in enumerate(self.components):
             comp._write(writer, str(k), logger=logger)
         if self.outliers:
-            self.outliers._write(writer, 'outliers')
+            self.outliers.write(writer, 'outliers')
             logger.debug("Wrote the PSF outliers to extension %s", writer.get_full_name('outliers'))
 
     def _finish_read(self, reader, logger):
@@ -305,6 +305,6 @@ class ConvolvePSF(PSF):
         self.components = []
         for k in range(ncomponents):
             self.components.append(PSF._read(reader, str(k), logger=logger))
-        self.outliers = Outliers._read(reader, 'outliers')
+        self.outliers = Outliers.read(reader, 'outliers')
         # Set up all the num's properly now that everything is constructed.
         self.set_num(None)

--- a/piff/des/decam_wavefront.py
+++ b/piff/des/decam_wavefront.py
@@ -154,13 +154,12 @@ class DECamWavefront(KNNInterp):
 
         return targets
 
-    def _finish_write(self, fits, extname):
-        """Write the solution to a FITS binary table.
+    def _finish_write(self, writer):
+        """Write the solution.
 
         Save the knn params and the locations and targets arrays
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The base name of the extension with the interp information.
+        :param writer:      A writer object that encapsulates the serialization format.
         """
 
         dtypes = [('LOCATIONS', self.locations.dtype, self.locations.shape),
@@ -175,7 +174,7 @@ class DECamWavefront(KNNInterp):
         data['MISALIGNMENT'] = self.misalignment
 
         # write to fits
-        fits.write_table(data, extname=extname + '_solution')
+        writer.write_table('solution', data)
 
     def _finish_read(self, fits, extname):
         """Read the solution from a FITS binary table.

--- a/piff/des/decam_wavefront.py
+++ b/piff/des/decam_wavefront.py
@@ -176,13 +176,13 @@ class DECamWavefront(KNNInterp):
         # write to fits
         writer.write_table('solution', data)
 
-    def _finish_read(self, fits, extname):
-        """Read the solution from a FITS binary table.
+    def _finish_read(self, reader):
+        """Read the solution.
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The name of the extension with the interp information.
+        :param reader:      A reader object that encapsulates the serialization format.
         """
-        data = fits[extname + '_solution'].read()
+        data = reader.read_table('solution')
+        assert data is not None
 
         # self.locations and self.targets assigned in _fit
         self._fit(data['LOCATIONS'][0], data['TARGETS'][0])

--- a/piff/gp_interp.py
+++ b/piff/gp_interp.py
@@ -292,11 +292,10 @@ class GPInterp(Interp):
             fitted_stars.append(Star(star.data, fit))
         return fitted_stars
 
-    def _finish_write(self, fits, extname):
+    def _finish_write(self, writer):
         """Finish the writing process with any class-specific steps.
 
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The base name of the extension
+        :param writer:      A writer object that encapsulates the serialization format.
         """
         # Note, we're only storing the training data and hyperparameters here, which means the
         # Cholesky decomposition will have to be re-computed when this object is read back from
@@ -320,7 +319,7 @@ class GPInterp(Interp):
         data['ROWS'] = self.rows
         data['OPTIMIZER'] = self.optimizer
 
-        fits.write_table(data, extname=extname+'_kernel')
+        writer.write_table('kernel', data)
 
     def _finish_read(self, fits, extname):
         """Finish the reading process with any class-specific steps.

--- a/piff/gp_interp.py
+++ b/piff/gp_interp.py
@@ -321,13 +321,13 @@ class GPInterp(Interp):
 
         writer.write_table('kernel', data)
 
-    def _finish_read(self, fits, extname):
+    def _finish_read(self, reader):
         """Finish the reading process with any class-specific steps.
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The base name of the extension.
+        :param reader:      A reader object that encapsulates the serialization format.
         """
-        data = fits[extname+'_kernel'].read()
+        data = reader.read_table('kernel')
+        assert data is not None
         # Run fit to set up GP, but don't actually do any hyperparameter optimization. Just
         # set the GP up using the current hyperparameters.
         # Need to give back average fits files if needed.

--- a/piff/interp.py
+++ b/piff/interp.py
@@ -174,7 +174,7 @@ class Interp(object):
         return [ self.interpolate(star) for star in stars ]
 
     def write(self, writer, name):
-        """Write an Interp via a Writer object.
+        """Write an Interp via a writer object.
 
         Note: this only writes the initialization kwargs to the fits extension, not the parameters.
 
@@ -207,7 +207,7 @@ class Interp(object):
 
     @classmethod
     def read(cls, reader, name):
-        """Read an Interp via a Reader object.
+        """Read an Interp via a reader object.
 
         :param reader:      A reader object that encapsulates the serialization format.
         :param name:        Name associated with this interpolator in the serialized output.

--- a/piff/interp.py
+++ b/piff/interp.py
@@ -173,19 +173,7 @@ class Interp(object):
         """
         return [ self.interpolate(star) for star in stars ]
 
-    def write(self, fits, extname):
-        """Write an Interp to a FITS file.
-
-        This method exists for backwards compatibility; subclasses should
-        reimplement _write or _finish_write instead.
-
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The name of the extension to write the interpolator information.
-        """
-        from .writers import FitsWriter
-        self._write(FitsWriter(fits, None, {}), extname)
-
-    def _write(self, writer, name):
+    def write(self, writer, name):
         """Write an Interp via a Writer object.
 
         Note: this only writes the initialization kwargs to the fits extension, not the parameters.
@@ -218,19 +206,7 @@ class Interp(object):
         raise NotImplementedError("Derived classes must define the _finish_write method.")
 
     @classmethod
-    def read(cls, fits, extname):
-        """Read an Interp from a FITS file.
-
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The name of the extension with the interpolator information.
-
-        :returns: an interpolator built with a information in the FITS file.
-        """
-        from .readers import FitsReader
-        return cls._read(FitsReader(fits, None), extname)
-
-    @classmethod
-    def _read(cls, reader, name):
+    def read(cls, reader, name):
         """Read an Interp via a Reader object.
 
         :param reader:      A reader object that encapsulates the serialization format.

--- a/piff/knn_interp.py
+++ b/piff/knn_interp.py
@@ -174,13 +174,12 @@ class KNNInterp(Interp):
 
         writer.write_table('solution', data)
 
-    def _finish_read(self, fits, extname):
-        """Read the solution from a FITS binary table.
+    def _finish_read(self, reader):
+        """Read the solution.
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The base name of the extension with the interp information.
+        :param reader:      A reader object that encapsulates the serialization format.
         """
-        data = fits[extname + '_solution'].read()
+        data = reader.read_table('solution')
 
         # self.locations and self.targets assigned in _fit
         self._fit(data['LOCATIONS'][0], data['TARGETS'][0])

--- a/piff/knn_interp.py
+++ b/piff/knn_interp.py
@@ -156,13 +156,12 @@ class KNNInterp(Interp):
             stars_fitted.append(Star(star.data, fit))
         return stars_fitted
 
-    def _finish_write(self, fits, extname):
-        """Write the solution to a FITS binary table.
+    def _finish_write(self, writer):
+        """Write the solution.
 
         Save the knn params and the locations and targets arrays
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The base name of the extension with the interp information.
+        :param writer:      A writer object that encapsulates the serialization format.
         """
 
         dtypes = [('LOCATIONS', self.locations.dtype, self.locations.shape),
@@ -173,8 +172,7 @@ class KNNInterp(Interp):
         data['LOCATIONS'] = self.locations
         data['TARGETS'] = self.targets
 
-        # write to fits
-        fits.write_table(data, extname=extname + '_solution')
+        writer.write_table('solution', data)
 
     def _finish_read(self, fits, extname):
         """Read the solution from a FITS binary table.

--- a/piff/mean_interp.py
+++ b/piff/mean_interp.py
@@ -70,11 +70,11 @@ class Mean(Interp):
         data = np.array(list(zip(*cols)), dtype=dtypes)
         writer.write_table('solution', data)
 
-    def _finish_read(self, fits, extname):
-        """Read the solution from a FITS binary table.
+    def _finish_read(self, reader):
+        """Read the solution.
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The base name of the extension
+        :param reader:      A reader object that encapsulates the serialization format.
         """
-        data = fits[extname + '_solution'].read()
+        data = reader.read_table('solution')
+        assert data is not None
         self.mean = data['mean']

--- a/piff/mean_interp.py
+++ b/piff/mean_interp.py
@@ -60,16 +60,15 @@ class Mean(Interp):
             fit = star.fit.newParams(self.mean, num=self._num)
         return Star(star.data, fit)
 
-    def _finish_write(self, fits, extname):
-        """Write the solution to a FITS binary table.
+    def _finish_write(self, writer):
+        """Write the solution.
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The base name of the extension
+        :param writer:      A writer object that encapsulates the serialization format.
         """
         cols = [ self.mean ]
         dtypes = [ ('mean', float) ]
         data = np.array(list(zip(*cols)), dtype=dtypes)
-        fits.write_table(data, extname=extname + '_solution')
+        writer.write_table('solution', data)
 
     def _finish_read(self, fits, extname):
         """Read the solution from a FITS binary table.

--- a/piff/model.py
+++ b/piff/model.py
@@ -150,19 +150,7 @@ class Model(object):
         prof.drawImage(image, method=self._method, center=star.image_pos)
         return Star(star.data.withNew(image=image), star.fit)
 
-    def write(self, fits, extname):
-        """Write a Model to a FITS file.
-
-        This method exists for backwards compatibility; subclasses should
-        reimplement _write or _finish_write instead.
-
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The name of the extension to write the model information.
-        """
-        from .writers import FitsWriter
-        self._write(FitsWriter(fits, None, {}), extname)
-
-    def _write(self, writer, name):
+    def write(self, writer, name):
         """Write a Model via a Writer object.
 
         Note: this only writes the initialization kwargs to the fits extension, not the parameters.
@@ -192,22 +180,7 @@ class Model(object):
         pass
 
     @classmethod
-    def read(cls, fits, extname):
-        """Read a Model from a FITS file.
-
-        Note: the returned Model will not have its parameters set.  This just initializes a fresh
-        model that can be used to interpret interpolated vectors.
-
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The name of the extension with the model information.
-
-        :returns: a model built with a information in the FITS file.
-        """
-        from .readers import FitsReader
-        return cls._read(FitsReader(fits, None), extname)
-
-    @classmethod
-    def _read(cls, reader, name):
+    def read(cls, reader, name):
         """Read a Model from a FITS file.
 
         Note: the returned Model will not have its parameters set.  This just initializes a fresh

--- a/piff/outliers.py
+++ b/piff/outliers.py
@@ -90,16 +90,7 @@ class Outliers(object):
         kwargs['logger'] = logger
         return kwargs
 
-    def write(self, fits, extname):
-        """Write an Outliers to a FITS file.
-
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The name of the extension to write the outliers information.
-        """
-        from .writers import FitsWriter
-        self._write(FitsWriter(fits, None, {}), extname)
-
-    def _write(self, writer, name):
+    def write(self, writer, name):
         """Write an Outers via a Writer object.
 
         :param writer:      A writer object that encapsulates the serialization format.
@@ -126,21 +117,7 @@ class Outliers(object):
         pass
 
     @classmethod
-    def read(cls, fits, extname):
-        """Read a Outliers from a FITS file.
-
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The name of the extension with the outliers information.
-
-        :returns: an Outliers handler
-        """
-        from .readers import FitsReader
-        result = cls._read(FitsReader(fits, None), extname)
-        assert result is not None
-        return result
-
-    @classmethod
-    def _read(cls, reader, name):
+    def read(cls, reader, name):
         """Read a Outliers from a FITS file.
 
         :param reader:      A reader object that encapsulates the serialization format.

--- a/piff/outliers.py
+++ b/piff/outliers.py
@@ -91,7 +91,7 @@ class Outliers(object):
         return kwargs
 
     def write(self, writer, name):
-        """Write an Outers via a Writer object.
+        """Write an Outers via a writer object.
 
         :param writer:      A writer object that encapsulates the serialization format.
         :param name:        A name to associate with the Ootliers in the serialized output.

--- a/piff/outliers.py
+++ b/piff/outliers.py
@@ -22,7 +22,7 @@ import math
 import galsim
 from scipy.stats import chi2
 
-from .util import write_kwargs, read_kwargs
+from .util import read_kwargs
 
 class Outliers(object):
     """The base class for handling outliers.
@@ -97,22 +97,32 @@ class Outliers(object):
         :param fits:        An open fitsio.FITS object
         :param extname:     The name of the extension to write the outliers information.
         """
+        from .writers import FitsWriter
+        self._write(FitsWriter(fits, None, {}), extname)
+
+    def _write(self, writer, name):
+        """Write an Outers via a Writer object.
+
+        :param writer:      A writer object that encapsulates the serialization format.
+        :param name:        A name to associate with the Ootliers in the serialized output.
+        """
         # First write the basic kwargs that works for all Outliers classes
         outliers_type = self._type_name
-        write_kwargs(fits, extname, dict(self.kwargs, type=outliers_type))
+        writer.write_struct(name, dict(self.kwargs, type=outliers_type))
 
         # Now do any class-specific steps.
-        self._finish_write(fits, extname)
+        with writer.nested(name) as w:
+            self._finish_write(w)
 
-    def _finish_write(self, fits, extname):
+    def _finish_write(self, writer):
         """Finish the writing process with any class-specific steps.
 
         The base class implementation doesn't do anything, which is often appropriate, but
         this hook exists in case any Outliers classes need to write extra information to the
         fits file.
 
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The base name of the extension
+        :param writer:      A writer object that encapsulates the serialization format.
+        :param name:        A name to associate with the outliers in the serialized output.
         """
         pass
 

--- a/piff/polynomial_interp.py
+++ b/piff/polynomial_interp.py
@@ -320,11 +320,10 @@ class Polynomial(Interp):
         # self._unpack_coefficients
         self.coeffs = coeffs
 
-    def _finish_write(self, fits, extname):
-        """Write the solution to a FITS binary table.
+    def _finish_write(self, writer):
+        """Write the solution.
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The base name of the extension
+        :param writer:      A writer object that encapsulates the serialization format.
         """
         if self.coeffs is None:
             raise RuntimeError("Coeffs not set yet.  Cannot write this Polynomial.")
@@ -368,7 +367,7 @@ class Polynomial(Interp):
 
         # Finally, write all of this to a FITS table.
         data = np.array(list(zip(*cols)), dtype=dtypes)
-        fits.write_table(data, extname=extname + '_solution', header=header)
+        writer.write_table('solution', data, metadata=header)
 
 
     def _finish_read(self, fits, extname):

--- a/piff/polynomial_interp.py
+++ b/piff/polynomial_interp.py
@@ -370,17 +370,16 @@ class Polynomial(Interp):
         writer.write_table('solution', data, metadata=header)
 
 
-    def _finish_read(self, fits, extname):
-        """Read the solution from a fits file.
+    def _finish_read(self, reader):
+        """Read the solution.
 
-        :param fits:        An open fitsio.FITS object.
-        :param extname:     The base name of the extension
+        :param reader:      A reader object that encapsulates the serialization format.
         """
         # Read the solution extension.
-        data = fits[extname + '_solution'].read()
-        header = fits[extname + '_solution'].read_header()
-
-        self.nparam = header['NPARAM']
+        metadata = {}
+        data = reader.read_table('solution', metadata=metadata)
+        assert data is not None
+        self.nparam = metadata['NPARAM']
 
         # Run setup functions to get these values right.
         self._set_function(self.poly_type)

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -719,12 +719,12 @@ class PSF(object):
         :param file_name:   The name of the file to write to.
         :param logger:      A logger object for logging debug info. [default: None]
         """
-        from .writers import Writer
+        from .writers import FitsWriter
 
         logger = galsim.config.LoggerWrapper(logger)
         logger.warning("Writing PSF to file %s",file_name)
 
-        with Writer.open(file_name) as w:
+        with FitsWriter.open(file_name) as w:
             self._write(w, 'psf', logger=logger)
 
     def _write(self, writer, name, logger):

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -741,7 +741,7 @@ class PSF(object):
         logger.info("Wrote the basic PSF information to name %s", writer.get_full_name(name))
         with writer.nested(name) as w:
             if hasattr(self, 'stars'):
-                Star._write(self.stars, w, 'stars')
+                Star.write(self.stars, w, 'stars')
                 logger.info("Wrote the PSF stars to name %s", w.get_full_name('stars'))
             if hasattr(self, 'wcs'):
                 w.write_wcs_map('wcs', self.wcs, self.pointing)
@@ -798,7 +798,7 @@ class PSF(object):
 
         with reader.nested(name) as r:
             # Read the stars, wcs, pointing values
-            stars = Star._read(r, 'stars')
+            stars = Star.read(r, 'stars')
             if stars is not None:
                 logger.debug("stars = %s", stars)
                 psf.stars = stars

--- a/piff/readers.py
+++ b/piff/readers.py
@@ -18,126 +18,15 @@
 
 from contextlib import contextmanager
 
-import os
 import fitsio
 import galsim
 import numpy as np
 
 
-class Reader:
-    """An interface for reading that abstracts the serialization format.
+class FitsReader:
+    """A reader object that reads from to multiple FITS HDUs.
 
-    The `open` static method should be used to obtain the right reader for
-    a particular file based on its extension, but specific subclasses can be
-    constructed directly as well.
-
-    A `Reader` subclass is always paired with a `Writer` subclass, and the
-    methods of `Reader` each directly correspond to a method of `Writer`.
-
-    All `Reader` and `Writer` methods take a ``name`` argument that is
-    associated with the low-level data structured being saved.  When writing,
-    an object can chose not to write a subobject at all with a given name, and
-    then check to see if the corresponding `Reader` method returns `None`, but
-    a `Reader` cannot be used to see what type of data structure was saved with
-    a given name; if this can change, the write implementation must store this
-    explicitly and use it when invoking the `Reader`.
-    """
-
-    @staticmethod
-    @contextmanager
-    def open(file_name):
-        """Return a context manager that yields a `Reader` appropriate for the
-        given filename.
-
-        :param filename:   Name of the file to open (`str`).
-
-        :returns:  A context manager that yields a `Reader`.
-        """
-        _, ext = os.path.splitext(file_name)
-        if ext == ".fits" or ext == ".piff":
-            with FitsReader._open(file_name) as reader:
-                yield reader
-            return
-        else:
-            raise NotImplementedError(f"No reader for extension {ext!r}.")
-
-    def read_struct(self, name):
-        """Load a simple flat dictionary.
-
-        :param name:   Name used to save this struct in `Writer.write_struct`.
-
-        :returns:  A `dict` with `str` keys and `int`, `float`, `str`, `bool`,
-                   or `None` values.  If nothing was stored with the given
-                   name, `None` is returned.
-        """
-        raise NotImplementedError()
-
-    def read_table(self, name, metadata=None):
-        """Load a table as a numpy array.
-
-        :param name:      Name used to save this table in `Writer.write_table`.
-        :param metadata:  If not `None`, a `dict` to be filled with any
-                          metadata associated with the table on write.  Key
-                          case may not be preserved!
-
-        :returns:  A numpy array with a structured dtype, or `None` if no
-                   object with this name was saved.
-        """
-        raise NotImplementedError()
-
-    def read_array(self, name, metadata=None):
-        """Load a regular a numpy array that does not have a structured dtype.
-
-        :param name:      Name used to save this array in `Writer.write_array`.
-        :param metadata:  If not `None`, a `dict` to be filled with any
-                          metadata associated with the array on write.  Key
-                          case may not be preserved!
-
-        :returns:  A numpy array, or `None` if no object with this name was saved.
-        """
-        raise NotImplementedError()
-
-    def read_wcs_map(self, name, logger):
-        """Load a map of WCS objects and an optional pointing coord.
-
-        :param name:      Name used to save this map in `Writer.write_array`.
-        :param logger:    A logger object for logging debug info.
-
-        :returns:  A 2-element tuple, where the first entry is a `dict` with
-                   `int` (chipnum) keys and `galsim.BaseWCS` values, and the
-                   second entry is a `galsim.CelestialCoord` object.  Both
-                   entries may be `None`, and if the WCS `dict` is `None` the
-                   pointing coord is always `None`.
-        """
-        raise NotImplementedError()
-
-    def nested(self, name):
-        """Return a context manager that yields a new `Reader` that reads
-        content written by a similarly nested `Writer`.
-
-        :param name:     Base name for all objects read with the returned object.
-
-        :returns:     A context manager that yields a nested reader object.
-        """
-        raise NotImplementedError()
-
-    def get_full_name(self, name):
-        """Return the full name of a data structure saved with the given name,
-        combining it with any base names added if this `Reader` was created by
-        the `nested` method.
-        """
-        raise NotImplementedError()
-
-
-class FitsReader(Reader):
-    """A `Reader` implementation that reads from to multiple FITS HDUs.
-
-    This reader is intended to read files written by Piff before the `Reader`
-    and `Writer` abstractions were added.
-
-    `FitsReader.nested` yields a reader that reads from the same file and
-    prepends all names with its base name to form the EXTNAME, concatenating
-    them with ``_``.
+    This reader is intended to read files written by `FitsWriter`.
 
     :param fits:        An already-open `fitsio.FITS` object.
     :param base_name:   Base name to prepend to all object names, or `None`.
@@ -148,7 +37,7 @@ class FitsReader(Reader):
 
     @classmethod
     @contextmanager
-    def _open(cls, file_name):
+    def open(cls, file_name):
         """Return a context manager that opens the given FITS file and yields
         a `FitsReader` object.
 
@@ -160,7 +49,14 @@ class FitsReader(Reader):
             yield cls(f, base_name=None)
 
     def read_struct(self, name):
-        # Docstring inherited.
+        """Load a simple flat dictionary.
+
+        :param name:   Name used to save this struct in `FitsWriter.write_struct`.
+
+        :returns:  A `dict` with `str` keys and `int`, `float`, `str`, `bool`,
+                   or `None` values.  If nothing was stored with the given
+                   name, `None` is returned.
+        """
         extname = self.get_full_name(name)
         if extname not in self._fits:
             return None
@@ -185,11 +81,28 @@ class FitsReader(Reader):
         return struct
 
     def read_table(self, name, metadata=None):
-        # Docstring inherited.
+        """Load a table as a numpy array.
+
+        :param name:      Name used to save this table in `FitsWriter.write_table`.
+        :param metadata:  If not `None`, a `dict` to be filled with any
+                          metadata associated with the table on write.  Key
+                          case may not be preserved!
+
+        :returns:  A numpy array with a structured dtype, or `None` if no
+                   object with this name was saved.
+        """
         return self.read_array(name, metadata)
 
     def read_array(self, name, metadata=None):
-        # Docstring inherited.
+        """Load a regular a numpy array that does not have a structured dtype.
+
+        :param name:      Name used to save this array in `FitsWriter.write_array`.
+        :param metadata:  If not `None`, a `dict` to be filled with any
+                          metadata associated with the array on write.  Key
+                          case may not be preserved!
+
+        :returns:  A numpy array, or `None` if no object with this name was saved.
+        """
         extname = self.get_full_name(name)
         if extname not in self._fits:
             return None
@@ -198,7 +111,17 @@ class FitsReader(Reader):
         return self._fits[extname].read()
 
     def read_wcs_map(self, name, logger):
-        # Docstring inherited.
+        """Load a map of WCS objects and an optional pointing coord.
+
+        :param name:      Name used to save this map in `FitsWriter.write_wcs_map`.
+        :param logger:    A logger object for logging debug info.
+
+        :returns:  A 2-element tuple, where the first entry is a `dict` with
+                   `int` (chipnum) keys and `galsim.BaseWCS` values, and the
+                   second entry is a `galsim.CelestialCoord` object.  Both
+                   entries may be `None`, and if the WCS `dict` is `None` the
+                   pointing coord is always `None`.
+        """
         import base64
         import pickle
 
@@ -262,9 +185,21 @@ class FitsReader(Reader):
 
     @contextmanager
     def nested(self, name):
-        # Docstring inherited.
+        """Return a context manager that yields a new `FitsReader` that reads
+        content written by a similarly nested `FitsWriter`.
+
+        :param name:     Base name for all objects read with the returned object.
+
+        :returns:     A context manager that yields a nested reader object.
+        """
         yield FitsReader(self._fits, base_name=self.get_full_name(name))
 
     def get_full_name(self, name: str) -> str:
-        # Docstring inherited.
+        """Return the full name of a data structure saved with the given name,
+        combining it with any base names added if this `FitsReader` was created
+        by the `nested` method.
+
+        The FITS implementation concatenates with ``_`` as a delimiter, and
+        uses the full name as the EXTNAME header value.
+        """
         return name if self._base_name is None else f"{self._base_name}_{name}"

--- a/piff/readers.py
+++ b/piff/readers.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2024 by Mike Jarvis and the other collaborators on GitHub at
+# https://github.com/rmjarvis/Piff  All rights reserved.
+#
+# Piff is free software: Redistribution and use in source and binary forms
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+
+"""
+.. module:: readers
+"""
+
+from contextlib import contextmanager
+
+import os
+import fitsio
+import galsim
+import numpy as np
+
+
+class Reader:
+    """An interface for reading that abstracts the serialization format.
+
+    The `open` static method should be used to obtain the right reader for
+    a particular file based on its extension, but specific subclasses can be
+    constructed directly as well.
+
+    A `Reader` subclass is always paired with a `Writer` subclass, and the
+    methods of `Reader` each directly correspond to a method of `Writer`.
+
+    All `Reader` and `Writer` methods take a ``name`` argument that is
+    associated with the low-level data structured being saved.  When writing,
+    an object can chose not to write a subobject at all with a given name, and
+    then check to see if the corresponding `Reader` method returns `None`, but
+    a `Reader` cannot be used to see what type of data structure was saved with
+    a given name; if this can change, the write implementation must store this
+    explicitly and use it when invoking the `Reader`.
+    """
+
+    @staticmethod
+    @contextmanager
+    def open(file_name):
+        """Return a context manager that yields a `Reader` appropriate for the
+        given filename.
+
+        :param filename:   Name of the file to open (`str`).
+
+        :returns:  A context manager that yields a `Reader`.
+        """
+        _, ext = os.path.splitext(file_name)
+        if ext == ".fits" or ext == ".piff":
+            with FitsReader._open(file_name) as reader:
+                yield reader
+            return
+        else:
+            raise NotImplementedError(f"No reader for extension {ext!r}.")
+
+    def read_struct(self, name):
+        """Load a simple flat dictionary.
+
+        :param name:   Name used to save this struct in `Writer.write_struct`.
+
+        :returns:  A `dict` with `str` keys and `int`, `float`, `str`, `bool`,
+                   or `None` values.  If nothing was stored with the given
+                   name, `None` is returned.
+        """
+        raise NotImplementedError()
+
+    def read_table(self, name, metadata=None):
+        """Load a table as a numpy array.
+
+        :param name:      Name used to save this table in `Writer.write_table`.
+        :param metadata:  If not `None`, a `dict` to be filled with any
+                          metadata associated with the table on write.  Key
+                          case may not be preserved!
+
+        :returns:  A numpy array with a structured dtype, or `None` if no
+                   object with this name was saved.
+        """
+        raise NotImplementedError()
+
+    def read_array(self, name, metadata=None):
+        """Load a regular a numpy array that does not have a structured dtype.
+
+        :param name:      Name used to save this array in `Writer.write_array`.
+        :param metadata:  If not `None`, a `dict` to be filled with any
+                          metadata associated with the array on write.  Key
+                          case may not be preserved!
+
+        :returns:  A numpy array, or `None` if no object with this name was saved.
+        """
+        raise NotImplementedError()
+
+    def read_wcs_map(self, name, logger):
+        """Load a map of WCS objects and an optional pointing coord.
+
+        :param name:      Name used to save this map in `Writer.write_array`.
+        :param logger:    A logger object for logging debug info.
+
+        :returns:  A 2-element tuple, where the first entry is a `dict` with
+                   `int` (chipnum) keys and `galsim.BaseWCS` values, and the
+                   second entry is a `galsim.CelestialCoord` object.  Both
+                   entries may be `None`, and if the WCS `dict` is `None` the
+                   pointing coord is always `None`.
+        """
+        raise NotImplementedError()
+
+    def nested(self, name):
+        """Return a context manager that yields a new `Reader` that reads
+        content written by a similarly nested `Writer`.
+
+        :param name:     Base name for all objects read with the returned object.
+
+        :returns:     A context manager that yields a nested reader object.
+        """
+        raise NotImplementedError()
+
+    def get_full_name(self, name):
+        """Return the full name of a data structure saved with the given name,
+        combining it with any base names added if this `Reader` was created by
+        the `nested` method.
+        """
+        raise NotImplementedError()
+
+
+class FitsReader(Reader):
+    """A `Reader` implementation that reads from to multiple FITS HDUs.
+
+    This reader is intended to read files written by Piff before the `Reader`
+    and `Writer` abstractions were added.
+
+    `FitsReader.nested` yields a reader that reads from the same file and
+    prepends all names with its base name to form the EXTNAME, concatenating
+    them with ``_``.
+
+    :param fits:        An already-open `fitsio.FITS` object.
+    :param base_name:   Base name to prepend to all object names, or `None`.
+    """
+    def __init__(self, fits, base_name):
+        self._fits = fits
+        self._base_name = base_name
+
+    @classmethod
+    @contextmanager
+    def _open(cls, file_name):
+        """Return a context manager that opens the given FITS file and yields
+        a `FitsReader` object.
+
+        :param file_name:   Name of the file to read.
+
+        :returns:  A context manager that yields a `FitsReader` instance.
+        """
+        with fitsio.FITS(file_name, "r") as f:
+            yield cls(f, base_name=None)
+
+    def read_struct(self, name):
+        # Docstring inherited.
+        extname = self.get_full_name(name)
+        if extname not in self._fits:
+            return None
+        cols = self._fits[extname].get_colnames()
+        data = self._fits[extname].read()
+        assert len(data) == 1
+        struct = dict([ (col, data[col][0]) for col in cols ])
+        for k, v in struct.items():
+            # Convert numpy scalar types to native Python types.  We assume all
+            # bytes are supposed to be strs in read_struct, but not in
+            # read_table.  Conversions from numeric types are important because
+            # numpy scalars don't always satisfy the expected isinstance
+            # checks.
+            if isinstance(v, bytes):
+                struct[k] = v.decode()
+            elif isinstance(v, np.bool_):
+                struct[k] = bool(v)
+            elif isinstance(v, np.integer):
+                struct[k] = int(v)
+            elif isinstance(v, np.floating):
+                struct[k] = float(v)
+        return struct
+
+    def read_table(self, name, metadata=None):
+        # Docstring inherited.
+        return self.read_array(name, metadata)
+
+    def read_array(self, name, metadata=None):
+        # Docstring inherited.
+        extname = self.get_full_name(name)
+        if extname not in self._fits:
+            return None
+        if metadata is not None:
+            metadata.update(self._fits[extname].read_header())
+        return self._fits[extname].read()
+
+    def read_wcs_map(self, name, logger):
+        # Docstring inherited.
+        import base64
+        try:
+            import cPickle as pickle
+        except ImportError:
+            import pickle
+
+        extname = self.get_full_name(name)
+        if extname not in self._fits:
+            return None, None
+
+        assert 'chipnums' in self._fits[extname].get_colnames()
+        assert 'nchunks' in self._fits[extname].get_colnames()
+
+        data = self._fits[extname].read()
+
+        chipnums = data['chipnums']
+        nchunks = data['nchunks']
+        nchunks = nchunks[0]  # These are all equal, so just take first one.
+
+        wcs_keys = [ 'wcs_str_%04d'%i for i in range(nchunks) ]
+        wcs_str = [ data[key] for key in wcs_keys ] # Get all wcs_str columns
+        try:
+            wcs_str = [ b''.join(s) for s in zip(*wcs_str) ]  # Rejoint into single string each
+        except TypeError:  # pragma: no cover
+            # fitsio 1.0 returns strings
+            wcs_str = [ ''.join(s) for s in zip(*wcs_str) ]  # Rejoint into single string each
+
+        wcs_str = [ base64.b64decode(s) for s in wcs_str ] # Convert back from b64 encoding
+        # Convert back into wcs objects
+        try:
+            wcs_list = [ pickle.loads(s, encoding='bytes') for s in wcs_str ]
+        except Exception:
+            # If the file was written by py2, the bytes encoding might raise here,
+            # or it might not until we try to use it.
+            wcs_list = [ pickle.loads(s, encoding='latin1') for s in wcs_str ]
+
+        wcs = dict(zip(chipnums, wcs_list))
+
+        try:
+            # If this doesn't work, then the file was probably written by py2, not py3
+            repr(wcs)
+        except Exception:
+            logger.info('Failed to decode wcs with bytes encoding.')
+            logger.info('Retry with encoding="latin1" in case file written with python 2.')
+            wcs_list = [ pickle.loads(s, encoding='latin1') for s in wcs_str ]
+            wcs = dict(zip(chipnums, wcs_list))
+            repr(wcs)
+
+        # Work-around for a change in the GalSim API with 2.0
+        # If the piff file was written with pre-2.0 GalSim, this fixes it.
+        for key in wcs:
+            w = wcs[key]
+            if hasattr(w, '_origin') and isinstance(w._origin, galsim._galsim.PositionD):
+                w._origin = galsim.PositionD(w._origin)
+
+        if 'ra' in self._fits[extname].get_colnames():
+            ra = data['ra']
+            dec = data['dec']
+            pointing = galsim.CelestialCoord(ra[0] * galsim.hours, dec[0] * galsim.degrees)
+        else:
+            pointing = None
+
+        return wcs, pointing
+
+    @contextmanager
+    def nested(self, name):
+        # Docstring inherited.
+        yield FitsReader(self._fits, base_name=self.get_full_name(name))
+
+    def get_full_name(self, name: str) -> str:
+        # Docstring inherited.
+        return name if self._base_name is None else f"{self._base_name}_{name}"

--- a/piff/readers.py
+++ b/piff/readers.py
@@ -20,7 +20,6 @@ from contextlib import contextmanager
 
 import fitsio
 import galsim
-import numpy as np
 
 
 class FitsReader:
@@ -63,13 +62,7 @@ class FitsReader:
         cols = self._fits[extname].get_colnames()
         data = self._fits[extname].read()
         assert len(data) == 1
-        struct = dict([ (col, data[col][0]) for col in cols ])
-        for k, v in struct.items():
-            # We assume all bytes are supposed to be strs in read_struct, but
-            # not in read_table.
-            if isinstance(v, bytes):
-                struct[k] = v.decode()
-        return struct
+        return dict([ (col, data[col][0]) for col in cols ])
 
     def read_table(self, name, metadata=None):
         """Load a table as a numpy array.

--- a/piff/readers.py
+++ b/piff/readers.py
@@ -91,18 +91,6 @@ class FitsReader:
         :returns:  A numpy array with a structured dtype, or `None` if no
                    object with this name was saved.
         """
-        return self.read_array(name, metadata)
-
-    def read_array(self, name, metadata=None):
-        """Load a regular a numpy array that does not have a structured dtype.
-
-        :param name:      Name used to save this array in `FitsWriter.write_array`.
-        :param metadata:  If not `None`, a `dict` to be filled with any
-                          metadata associated with the array on write.  Key
-                          case may not be preserved!
-
-        :returns:  A numpy array, or `None` if no object with this name was saved.
-        """
         extname = self.get_full_name(name)
         if extname not in self._fits:
             return None

--- a/piff/readers.py
+++ b/piff/readers.py
@@ -200,10 +200,7 @@ class FitsReader(Reader):
     def read_wcs_map(self, name, logger):
         # Docstring inherited.
         import base64
-        try:
-            import cPickle as pickle
-        except ImportError:
-            import pickle
+        import pickle
 
         extname = self.get_full_name(name)
         if extname not in self._fits:

--- a/piff/readers.py
+++ b/piff/readers.py
@@ -65,19 +65,10 @@ class FitsReader:
         assert len(data) == 1
         struct = dict([ (col, data[col][0]) for col in cols ])
         for k, v in struct.items():
-            # Convert numpy scalar types to native Python types.  We assume all
-            # bytes are supposed to be strs in read_struct, but not in
-            # read_table.  Conversions from numeric types are important because
-            # numpy scalars don't always satisfy the expected isinstance
-            # checks.
+            # We assume all bytes are supposed to be strs in read_struct, but
+            # not in read_table.
             if isinstance(v, bytes):
                 struct[k] = v.decode()
-            elif isinstance(v, np.bool_):
-                struct[k] = bool(v)
-            elif isinstance(v, np.integer):
-                struct[k] = int(v)
-            elif isinstance(v, np.floating):
-                struct[k] = float(v)
         return struct
 
     def read_table(self, name, metadata=None):

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -23,7 +23,6 @@ from .model import Model
 from .interp import Interp
 from .outliers import Outliers
 from .psf import PSF
-from .util import read_kwargs
 
 class SimplePSF(PSF):
     """A PSF class that uses a single model and interpolator.
@@ -266,19 +265,16 @@ class SimplePSF(PSF):
             self.outliers._write(writer, 'outliers')
             logger.debug("Wrote the PSF outliers to %s", writer.get_full_name('outliers'))
 
-    def _finish_read(self, fits, extname, logger):
+    def _finish_read(self, reader, logger):
         """Finish the reading process with any class-specific steps.
 
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The base name of the extension to write to.
+        :param reader:      A reader object that encapsulates the serialization format.
+        :param name:        Name associated with this PSF in the serialized output.
         :param logger:      A logger object for logging debug info.
         """
-        chisq_dict = read_kwargs(fits, extname + '_chisq')
+        chisq_dict = reader.read_struct('chisq')
         for key in chisq_dict:
             setattr(self, key, chisq_dict[key])
-        self.model = Model.read(fits, extname + '_model')
-        self.interp = Interp.read(fits, extname + '_interp')
-        if extname + '_outliers' in fits:
-            self.outliers = Outliers.read(fits, extname + '_outliers')
-        else:
-            self.outliers = None
+        self.model = Model._read(reader, 'model')
+        self.interp = Interp._read(reader, 'interp')
+        self.outliers = Outliers._read(reader, 'outliers')

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -257,12 +257,12 @@ class SimplePSF(PSF):
         }
         writer.write_struct('chisq', chisq_dict)
         logger.debug("Wrote the chisq info to %s", writer.get_full_name('chisq'))
-        self.model._write(writer, 'model')
+        self.model.write(writer, 'model')
         logger.debug("Wrote the PSF model to %s", writer.get_full_name('model'))
-        self.interp._write(writer, 'interp')
+        self.interp.write(writer, 'interp')
         logger.debug("Wrote the PSF interp to %s", writer.get_full_name('interp'))
         if self.outliers:
-            self.outliers._write(writer, 'outliers')
+            self.outliers.write(writer, 'outliers')
             logger.debug("Wrote the PSF outliers to %s", writer.get_full_name('outliers'))
 
     def _finish_read(self, reader, logger):
@@ -275,6 +275,6 @@ class SimplePSF(PSF):
         chisq_dict = reader.read_struct('chisq')
         for key in chisq_dict:
             setattr(self, key, chisq_dict[key])
-        self.model = Model._read(reader, 'model')
-        self.interp = Interp._read(reader, 'interp')
-        self.outliers = Outliers._read(reader, 'outliers')
+        self.model = Model.read(reader, 'model')
+        self.interp = Interp.read(reader, 'interp')
+        self.outliers = Outliers.read(reader, 'outliers')

--- a/piff/singlechip.py
+++ b/piff/singlechip.py
@@ -198,15 +198,16 @@ class SingleChipPSF(PSF):
         for chipnum in chipnums:
             self.psf_by_chip[chipnum]._write(writer, str(chipnum), logger)
 
-    def _finish_read(self, fits, extname, logger):
+    def _finish_read(self, reader, logger):
         """Finish the reading process with any class-specific steps.
 
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The base name of the extension to write to.
+        :param reader:      A reader object that encapsulates the serialization format.
         :param logger:      A logger object for logging debug info.
         """
-        chipnums = fits[extname + '_chipnums'].read()['chipnums']
+        table = reader.read_table('chipnums')
+        assert table is not None
+        chipnums = table['chipnums']
         self.psf_by_chip = {}
         for chipnum in chipnums:
-            self.psf_by_chip[chipnum] = PSF._read(fits, extname + '_%s'%chipnum, logger)
+            self.psf_by_chip[chipnum] = PSF._read(reader, str(chipnum), logger)
         self.single_psf = self.psf_by_chip[chipnums[0]]

--- a/piff/star.py
+++ b/piff/star.py
@@ -433,7 +433,7 @@ class Star(object):
 
     @classmethod
     def read(cls, reader, name):
-        """Read stars from a FITS file.
+        """Read a list of stars via an open reader object.
 
         :param reader:      A reader object that encapsulates the serialization format.
         :param name:         Name associated with the stars in the serialized output.

--- a/piff/star.py
+++ b/piff/star.py
@@ -328,12 +328,23 @@ class Star(object):
         return cls(data, fit)
 
     @classmethod
-    def write(self, stars, fits, extname):
+    def write(cls, stars, fits, extname):
         """Write a list of stars to a FITS file.
 
         :param stars:       A list of stars to write
         :param fits:        An open fitsio.FITS object
         :param extname:     The name of the extension to write to
+        """
+        from .writers import FitsWriter
+        cls._write(stars, FitsWriter(fits, None, {}), extname)
+
+    @classmethod
+    def _write(cls, stars, writer, name):
+        """Write a list of stars to a Writer object.
+
+        :param stars:       A list of stars to write
+        :param writer:      A writer object that encapsulates the serialization format.
+        :param name:        A name to associate with these stars in the serialized output.
         """
         # TODO This doesn't write everything out.  Probably want image as an optional I/O.
 
@@ -406,7 +417,7 @@ class Star(object):
             cols.append( [s.data.pointing.dec / galsim.degrees for s in stars ] )
 
         data = np.array(list(zip(*cols)), dtype=dtypes)
-        fits.write_table(data, extname=extname, header=header)
+        writer.write_table(name, data, metadata=header)
 
     @classmethod
     def read_coords_params(cls, fits, extname):

--- a/piff/star.py
+++ b/piff/star.py
@@ -329,7 +329,7 @@ class Star(object):
 
     @classmethod
     def write(cls, stars, writer, name):
-        """Write a list of stars to a Writer object.
+        """Write a list of stars to a writer object.
 
         :param stars:       A list of stars to write
         :param writer:      A writer object that encapsulates the serialization format.

--- a/piff/star.py
+++ b/piff/star.py
@@ -328,18 +328,7 @@ class Star(object):
         return cls(data, fit)
 
     @classmethod
-    def write(cls, stars, fits, extname):
-        """Write a list of stars to a FITS file.
-
-        :param stars:       A list of stars to write
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The name of the extension to write to
-        """
-        from .writers import FitsWriter
-        cls._write(stars, FitsWriter(fits, None, {}), extname)
-
-    @classmethod
-    def _write(cls, stars, writer, name):
+    def write(cls, stars, writer, name):
         """Write a list of stars to a Writer object.
 
         :param stars:       A list of stars to write
@@ -443,21 +432,7 @@ class Star(object):
         return coords, params
 
     @classmethod
-    def read(cls, fits, extname):
-        """Read stars from a FITS file.
-
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The name of the extension to read from
-
-        :returns: a list of Star instances
-        """
-        from .readers import FitsReader
-        result = cls._read(FitsReader(fits, None), extname)
-        assert result is not None
-        return result
-
-    @classmethod
-    def _read(cls, reader, name):
+    def read(cls, reader, name):
         """Read stars from a FITS file.
 
         :param reader:      A reader object that encapsulates the serialization format.

--- a/piff/sumpsf.py
+++ b/piff/sumpsf.py
@@ -305,7 +305,7 @@ class SumPSF(PSF):
         for k, comp in enumerate(self.components):
             comp._write(writer, str(k), logger=logger)
         if self.outliers:
-            self.outliers._write(writer, 'outliers')
+            self.outliers.write(writer, 'outliers')
             logger.debug("Wrote the PSF outliers to %s", writer.get_full_name('outliers'))
 
     def _finish_read(self, reader, logger):
@@ -322,6 +322,6 @@ class SumPSF(PSF):
         self.components = []
         for k in range(ncomponents):
             self.components.append(PSF._read(reader, str(k), logger=logger))
-        self.outliers = Outliers._read(reader, 'outliers')
+        self.outliers = Outliers.read(reader, 'outliers')
         # Set up all the num's properly now that everything is constructed.
         self.set_num(None)

--- a/piff/sumpsf.py
+++ b/piff/sumpsf.py
@@ -20,7 +20,7 @@ import numpy as np
 import galsim
 
 from .psf import PSF
-from .util import write_kwargs, read_kwargs
+from .util import read_kwargs
 from .star import Star, StarFit
 from .outliers import Outliers
 
@@ -288,11 +288,10 @@ class SumPSF(PSF):
         # Add them up.
         return galsim.Sum(profiles), method
 
-    def _finish_write(self, fits, extname, logger):
+    def _finish_write(self, writer, logger):
         """Finish the writing process with any class-specific steps.
 
-        :param fits:        An open fitsio.FITS object
-        :param extname:     The base name of the extension to write to.
+        :param writer:      A writer object that encapsulates the serialization format.
         :param logger:      A logger object for logging debug info.
         """
         logger = galsim.config.LoggerWrapper(logger)
@@ -302,13 +301,13 @@ class SumPSF(PSF):
             'dof' : self.dof,
             'nremoved' : self.nremoved,
         }
-        write_kwargs(fits, extname + '_chisq', chisq_dict)
-        logger.debug("Wrote the chisq info to extension %s",extname + '_chisq')
+        writer.write_struct('chisq', chisq_dict)
+        logger.debug("Wrote the chisq info to %s", writer.get_full_name('chisq'))
         for k, comp in enumerate(self.components):
-            comp._write(fits, extname + '_' + str(k), logger=logger)
+            comp._write(writer, str(k), logger=logger)
         if self.outliers:
-            self.outliers.write(fits, extname + '_outliers')
-            logger.debug("Wrote the PSF outliers to extension %s",extname + '_outliers')
+            self.outliers._write(writer, 'outliers')
+            logger.debug("Wrote the PSF outliers to %s", writer.get_full_name('outliers'))
 
     def _finish_read(self, fits, extname, logger):
         """Finish the reading process with any class-specific steps.

--- a/piff/util.py
+++ b/piff/util.py
@@ -101,29 +101,6 @@ def adjust_value(value, dtype):
             # For other numpy arrays, we can use astype instead.
             return np.array(value).astype(t)
 
-def write_kwargs(fits, extname, kwargs):
-    """A helper function for writing a single row table into a fits file with the values
-    and column names given by a kwargs dict.
-
-    :param fits:        An open fitsio.FITS instance
-    :param extname:     The extension to write to
-    :param kwargs:      A kwargs dict to be written as a FITS binary table.
-    """
-    from . import __version__ as piff_version
-    cols = []
-    dtypes = []
-    for key, value in kwargs.items():
-        # Don't add values that are None to the table.
-        if value is None:
-            continue
-        dt = make_dtype(key, value)
-        value = adjust_value(value,dt)
-        cols.append([value])
-        dtypes.append(dt)
-    data = np.array(list(zip(*cols)), dtype=dtypes)
-    header = {'piff_version': piff_version}
-    fits.write_table(data, extname=extname, header=header)
-
 def read_kwargs(fits, extname):
     """A helper function for reading a single row table from a fits file returning the values
     and column names as a kwargs dict.

--- a/piff/util.py
+++ b/piff/util.py
@@ -101,21 +101,6 @@ def adjust_value(value, dtype):
             # For other numpy arrays, we can use astype instead.
             return np.array(value).astype(t)
 
-def read_kwargs(fits, extname):
-    """A helper function for reading a single row table from a fits file returning the values
-    and column names as a kwargs dict.
-
-    :param fits:        An open fitsio.FITS instance
-    :param extname:     The extension to read.
-
-    :returns: A dict of the kwargs that were read from the file.
-    """
-    cols = fits[extname].get_colnames()
-    data = fits[extname].read()
-    assert len(data) == 1
-    kwargs = dict([ (col, data[col][0]) for col in cols ])
-    return kwargs
-
 def estimate_cov_from_jac(jac):
     """Estimate a covariance matrix from a jacobian as returned by scipy.optimize.least_squares
     .. math::

--- a/piff/writers.py
+++ b/piff/writers.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2024 by Mike Jarvis and the other collaborators on GitHub at
+# https://github.com/rmjarvis/Piff  All rights reserved.
+#
+# Piff is free software: Redistribution and use in source and binary forms
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the disclaimer given in the accompanying LICENSE
+#    file.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the disclaimer given in the documentation
+#    and/or other materials provided with the distribution.
+
+"""
+.. module:: writers
+"""
+
+from contextlib import contextmanager
+
+import os
+import fitsio
+import galsim
+import numpy as np
+
+from .util import make_dtype, adjust_value
+
+
+class Writer:
+    """An interface for writing that abstracts the serialization format.
+
+    The `open` static method should be used to obtain the right writer for
+    a particular file based on its extension, but specific subclasses can be
+    constructed directly as well.
+
+    A `Writer` subclass is always paired with a `Reader` subclass, and the
+    methods of `Reader` each directly correspond to a method of `Writer`.
+
+    All `Reader` and `Writer` methods take a ``name`` argument that is
+    associated with the low-level data structured being saved.  When writing,
+    an object can chose not to write a subobject at all with a given name, and
+    then check to see if the corresponding `Reader` method returns `None`, but
+    a `Reader` cannot be used to see what type of data structure was saved with
+    a given name; if this can change, the write implementation must store this
+    explicitly and use it when invoking the `Reader`.
+    """
+
+    @staticmethod
+    @contextmanager
+    def open(file_name):
+        """Return a context manager that yields a `Writer` appropriate for the
+        given filename.
+
+        :param filename:   Name of the file to open (`str`).
+
+        :returns:  A context manager that yields a `Writer`.
+        """
+        _, ext = os.path.splitext(file_name)
+        if ext == ".fits" or ext == ".piff":
+            with FitsWriter._open(file_name) as writer:
+                yield writer
+            return
+        else:
+            raise NotImplementedError(f"No writer for extension {ext!r}.")
+
+    def write_struct(self, name, struct):
+        """Write a simple flat dictionary.
+
+        :param name:        Name used to save this struct.
+        :param struct:      A `dict` with `str` keys and `int`, `float`, `str`,
+                            `bool`, or `None` values.
+        """
+        raise NotImplementedError()
+
+    def write_table(self, name, table, metadata=None):
+        """Write a table via a numpy array.
+
+        :param name:      Name used to save this table.
+        :param metadata:  A `dict` of simple metadata to save with the table.
+                          Keys must be `str` (case may not be preserved) and
+                          values must be `int`, `float`, `str`, or `bool`.
+        """
+        raise NotImplementedError()
+
+    def write_array(self, name, array, metadata=None):
+        """Write a numpy array that does not have a structured dtype.
+
+        :param name:      Name used to save this array.
+        :param metadata:  A `dict` of simple metadata to save with the array.
+                          Keys must be `str` (case may not be preserved) and
+                          values must be `int`, `float`, `str`, or `bool`.
+        """
+        raise NotImplementedError()
+
+    def write_wcs_map(self, name, wcs_map, pointing):
+        """Write a regular a map of WCS objects and an optoinal pointing coord.
+
+        :param name:      Name used to save this struct in `Writer.write_array`.
+        :param wcs_map:   A `dict` mapping `int` chipnum to `galsim.BaseWCS`.
+        :param pointing:  A `galsim.CelestialCoord`, or `None`.
+        :param logger:    A logger object for logging debug info.
+        """
+        raise NotImplementedError()
+
+    def nested(self, name):
+        """Return a context manager that yields a new `Writer` that nests all
+        names it is given within this one.
+
+        :param name:     Base name for all objects written with the returned object.
+
+        :returns:     A context manager that yields a nested writer object.
+
+        It is implementation-defined whether the content written by the nested
+        writer is actually written immediately or only when the context manager
+        exits.
+        """
+        raise NotImplementedError()
+
+    def get_full_name(self, name):
+        """Return the full name of a data structure saved with the given name,
+        combining it with any base names added if this `Writer` was created by
+        the `nested` method.
+        """
+        raise NotImplementedError()
+
+
+class FitsWriter(Writer):
+    """A `Writer` implementation that writes to multiple FITS HDUs.
+
+    This reader is intended to writes files that would be readable Piff before
+    the `Reader` and `Writer` abstractions were added.
+
+    `FitsWriter.nested` yields a writer that writes to the same file and
+    prepends all names with its base name to form the EXTNAME, concatenating
+    them with ``_``.
+
+    :param fits:        An already-open `fitsio.FITS` object.
+    :param base_name:   Base name to prepend to all object names, or `None`.
+    :param header:      Fields to be added to all FITS extension headers.
+    """
+
+    def __init__(self, fits, base_name, header):
+        self._fits = fits
+        self._base_name = base_name
+        self._header = header
+
+    @classmethod
+    @contextmanager
+    def _open(cls, file_name):
+        """Return a context manager that opens the given FITS file and yields
+        a `FitsWriter` object.
+
+        :param file_name:   Name of the file to read.
+
+        :returns:  A context manager that yields a `FitsWriter` instance.
+
+        This also adds an empty primary HDU and sets up the returned writer
+        to add the Piff version to all HDUs (including the primary).
+        """
+        from . import __version__ as piff_version
+
+        header = {"piff_version": piff_version}
+        with fitsio.FITS(file_name, "rw", clobber=True) as f:
+            if len(f) == 1:
+                f.write(data=None, header=header)
+            yield cls(f, base_name=None, header=header.copy())
+
+    def write_struct(self, name, struct):
+        # Docstring inherited.
+        cols = []
+        dtypes = []
+        for key, value in struct.items():
+            # Don't add values that are None to the table.
+            if value is None:
+                continue
+            dt = make_dtype(key, value)
+            value = adjust_value(value, dt)
+            cols.append([value])
+            dtypes.append(dt)
+        table = np.array(list(zip(*cols)), dtype=dtypes)
+        return self.write_table(name, table)
+
+    def write_table(self, name, array, metadata=None):
+        # Docstring inherited.
+        if metadata:
+            header = self._header.copy()
+            header.update(metadata)
+        else:
+            header = self._header
+        self._fits.write_table(array, extname=self.get_full_name(name), header=header)
+
+    def write_array(self, name, array, metadata=None):
+        # Docstring inherited.
+        if metadata:
+            header = self._header.copy()
+            header.update(metadata)
+        else:
+            header = self._header
+        self._fits.write_image(
+            array, extname=self.get_full_name(name), header=self._header
+        )
+
+    def write_wcs_map(self, name, wcs_map, pointing):
+        # Docstring inherited.
+        import base64
+
+        try:
+            import cPickle as pickle
+        except ImportError:
+            import pickle
+        # Start with the chipnums
+        chipnums = list(wcs_map.keys())
+        cols = [chipnums]
+        dtypes = [("chipnums", int)]
+
+        # GalSim WCS objects can be serialized via pickle
+        wcs_str = [base64.b64encode(pickle.dumps(w)) for w in wcs_map.values()]
+        max_len = np.max([len(s) for s in wcs_str])
+        # Some GalSim WCS serializations are rather long.  In particular, the Pixmappy one
+        # is longer than the maximum length allowed for a column in a fits table (28799).
+        # So split it into chunks of size 2**14 (mildly less than this maximum).
+        chunk_size = 2**14
+        nchunks = max_len // chunk_size + 1
+        cols.append([nchunks] * len(chipnums))
+        dtypes.append(("nchunks", int))
+
+        # Update to size of chunk we actually need.
+        chunk_size = (max_len + nchunks - 1) // nchunks
+
+        chunks = [
+            [s[i : i + chunk_size] for i in range(0, max_len, chunk_size)]
+            for s in wcs_str
+        ]
+        cols.extend(zip(*chunks))
+        dtypes.extend(("wcs_str_%04d" % i, bytes, chunk_size) for i in range(nchunks))
+
+        if pointing is not None:
+            # Currently, there is only one pointing for all the chips, but write it out
+            # for each row anyway.
+            dtypes.extend((("ra", float), ("dec", float)))
+            ra = [pointing.ra / galsim.hours] * len(chipnums)
+            dec = [pointing.dec / galsim.degrees] * len(chipnums)
+            cols.extend((ra, dec))
+
+        data = np.array(list(zip(*cols)), dtype=dtypes)
+        self.write_table(name, data)
+
+    @contextmanager
+    def nested(self, name):
+        # Docstring inherited.
+        yield FitsWriter(
+            self._fits, base_name=self.get_full_name(name), header=self._header
+        )
+
+    def get_full_name(self, name):
+        # Docstring inherited.
+        return name if self._base_name is None else f"{self._base_name}_{name}"

--- a/piff/writers.py
+++ b/piff/writers.py
@@ -203,11 +203,7 @@ class FitsWriter(Writer):
     def write_wcs_map(self, name, wcs_map, pointing):
         # Docstring inherited.
         import base64
-
-        try:
-            import cPickle as pickle
-        except ImportError:
-            import pickle
+        import pickle
         # Start with the chipnums
         chipnums = list(wcs_map.keys())
         cols = [chipnums]

--- a/piff/writers.py
+++ b/piff/writers.py
@@ -94,23 +94,6 @@ class FitsWriter:
             header = self._header
         self._fits.write_table(array, extname=self.get_full_name(name), header=header)
 
-    def write_array(self, name, array, metadata=None):
-        """Write a numpy array that does not have a structured dtype.
-
-        :param name:      Name used to save this array.
-        :param metadata:  A `dict` of simple metadata to save with the array.
-                          Keys must be `str` (case may not be preserved) and
-                          values must be `int`, `float`, `str`, or `bool`.
-        """
-        if metadata:
-            header = self._header.copy()
-            header.update(metadata)
-        else:
-            header = self._header
-        self._fits.write_image(
-            array, extname=self.get_full_name(name), header=self._header
-        )
-
     def write_wcs_map(self, name, wcs_map, pointing):
         """Write a regular a map of WCS objects and an optoinal pointing coord.
 

--- a/tests/test_gp_interp.py
+++ b/tests/test_gp_interp.py
@@ -224,10 +224,10 @@ def check_gp(stars_training, stars_validation, kernel, optimizer,
 
     # Check I/O.
     file_name = os.path.join('output', 'test_gp.fits')
-    with fitsio.FITS(file_name,'rw',clobber=True) as fout:
-        interp.write(fout, extname='gp')
-    with fitsio.FITS(file_name,'r') as fin:
-        interp2 = piff.Interp.read(fin, extname='gp')
+    with piff.writers.FitsWriter.open(file_name) as w:
+        interp.write(w, 'gp')
+    with piff.readers.FitsReader.open(file_name) as r:
+        interp2 = piff.Interp.read(r, 'gp')
 
     stars_test = interp2.interpolateList(stars_validation)
     y_test = np.array([star.fit.params for star in stars_test])

--- a/tests/test_gsobject_model.py
+++ b/tests/test_gsobject_model.py
@@ -163,10 +163,10 @@ def test_simple():
 
         # Also need to test ability to serialize
         outfile = os.path.join('output', 'gsobject_test.fits')
-        with fitsio.FITS(outfile, 'rw', clobber=True) as f:
-            model.write(f, 'psf_model')
-        with fitsio.FITS(outfile, 'r') as f:
-            roundtrip_model = piff.GSObjectModel.read(f, 'psf_model')
+        with piff.writers.FitsWriter.open(outfile) as w:
+            model.write(w, 'psf_model')
+        with piff.readers.FitsReader.open(outfile) as r:
+            roundtrip_model = piff.GSObjectModel.read(r, 'psf_model')
         assert model.__dict__ == roundtrip_model.__dict__
 
         # Check the deprecated name in config
@@ -903,10 +903,10 @@ def test_direct():
 
         # Also need to test ability to serialize
         outfile = os.path.join('output', 'gsobject_direct_test.fits')
-        with fitsio.FITS(outfile, 'rw', clobber=True) as f:
-            model.write(f, 'psf_model')
-        with fitsio.FITS(outfile, 'r') as f:
-            roundtrip_model = piff.GSObjectModel.read(f, 'psf_model')
+        with piff.writers.FitsWriter.open(outfile) as w:
+            model.write(w, 'psf_model')
+        with piff.readers.FitsReader.open(outfile) as r:
+            roundtrip_model = piff.GSObjectModel.read(r, 'psf_model')
         assert model.__dict__ == roundtrip_model.__dict__
 
     # repeat with fastfit=False
@@ -958,10 +958,10 @@ def test_direct():
 
         # Also need to test ability to serialize
         outfile = os.path.join('output', 'gsobject_direct_test.fits')
-        with fitsio.FITS(outfile, 'rw', clobber=True) as f:
-            model.write(f, 'psf_model')
-        with fitsio.FITS(outfile, 'r') as f:
-            roundtrip_model = piff.GSObjectModel.read(f, 'psf_model')
+        with piff.writers.FitsWriter.open(outfile) as w:
+            model.write(w, 'psf_model')
+        with piff.readers.FitsReader.open(outfile) as r:
+            roundtrip_model = piff.GSObjectModel.read(r, 'psf_model')
         assert model.__dict__ == roundtrip_model.__dict__
 
 @timer

--- a/tests/test_knn_interp.py
+++ b/tests/test_knn_interp.py
@@ -165,9 +165,10 @@ def test_disk():
     knn.initialize(star_list)
     knn.solve(star_list)
     knn_file = os.path.join('output','knn_interp.fits')
-    with fitsio.FITS(knn_file,'rw',clobber=True) as f:
-        knn.write(f, 'knn')
-        knn2 = piff.KNNInterp.read(f, 'knn')
+    with piff.writers.FitsWriter.open(knn_file) as w:
+        knn.write(w, 'knn')
+    with piff.readers.FitsReader.open(knn_file) as r:
+        knn2 = piff.KNNInterp.read(r, 'knn')
     np.testing.assert_array_equal(knn.locations, knn2.locations)
     np.testing.assert_array_equal(knn.targets, knn2.targets)
     np.testing.assert_array_equal(knn.kwargs['keys'], knn2.kwargs['keys'])
@@ -246,9 +247,10 @@ def test_decam_disk():
     knn.misalign_wavefront(misalignment)
 
     knn_file = os.path.join('output','decam_wavefront.fits')
-    with fitsio.FITS(knn_file,'rw',clobber=True) as f:
-        knn.write(f, 'decam_wavefront')
-        knn2 = piff.des.DECamWavefront.read(f, 'decam_wavefront')
+    with piff.writers.FitsWriter.open(knn_file) as w:
+        knn.write(w, 'decam_wavefront')
+    with piff.readers.FitsReader.open(knn_file) as r:
+        knn2 = piff.des.DECamWavefront.read(r, 'decam_wavefront')
     np.testing.assert_array_equal(knn.locations, knn2.locations)
     np.testing.assert_array_equal(knn.targets, knn2.targets)
     np.testing.assert_array_equal(knn.keys, knn2.keys)

--- a/tests/test_optics.py
+++ b/tests/test_optics.py
@@ -366,9 +366,10 @@ def test_disk():
     # save and load
     model = piff.Optical(lam=700.0, template='des')
     model_file = os.path.join('output','optics.fits')
-    with fitsio.FITS(model_file, 'rw', clobber=True) as f:
-        model.write(f, 'optics')
-        model2 = piff.Optical.read(f, 'optics')
+    with piff.writers.FitsWriter.open(model_file) as w:
+        model.write(w, 'optics')
+    with piff.readers.FitsReader.open(model_file) as r:
+        model2 = piff.Optical.read(r, 'optics')
 
     for key in model.kwargs:
         assert key in model2.kwargs, 'key %r missing from model2 kwargs'%key

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -159,11 +159,11 @@ def test_base():
     # Mock this by pretending that MADOutliers is the only subclass of Outliers.
     filename = os.path.join('input','D00240560_r_c01_r2362p01_piff.fits')
     with mock.patch('piff.Outliers.valid_outliers_types', {'MAD': piff.outliers.MADOutliers}):
-        with fitsio.FITS(filename,'r') as f:
-            np.testing.assert_raises(ValueError, piff.Outliers.read, f, extname='psf_outliers')
+        with piff.readers.FitsReader.open(filename) as r:
+            np.testing.assert_raises(ValueError, piff.Outliers.read, r, 'psf_outliers')
 
-    with fitsio.FITS(filename,'r') as f:
-        out = piff.Outliers.read(f, extname='psf_outliers')
+    with piff.readers.FitsReader.open(filename) as r:
+        out = piff.Outliers.read(r, 'psf_outliers')
         print(out)
 
     # Check that registering new types works correctly

--- a/tests/test_pixel.py
+++ b/tests/test_pixel.py
@@ -359,9 +359,9 @@ def test_basis_interp():
     np.testing.assert_raises(RuntimeError, basis.solve, [star])
     np.testing.assert_raises(RuntimeError, basis.interpolate, star)
     file_name = os.path.join('output','test_basis_interp.fits')
-    with fitsio.FITS(file_name,'rw',clobber=True) as fout:
+    with piff.writers.FitsWriter.open(file_name) as w:
         with np.testing.assert_raises(RuntimeError):
-            basis.write(fout, extname='basis')
+            basis.write(w, 'basis')
 
     # Other options for order
     basis = piff.BasisPolynomial(order=2)

--- a/tests/test_poly.py
+++ b/tests/test_poly.py
@@ -339,10 +339,10 @@ def poly_load_save_sub(type1, type2, fname):
     extname = "interp"
     dirname = 'output'
     filename=os.path.join(dirname, fname)
-    with fitsio.FITS(filename,'rw',clobber=True) as f:
-        interp.write(f, extname=extname)
-    with fitsio.FITS(filename, "r") as f2:
-        interp2 = piff.Polynomial.read(f2, extname=extname)
+    with piff.writers.FitsWriter.open(filename) as w:
+        interp.write(w, extname)
+    with piff.readers.FitsReader.open(filename) as r:
+        interp2 = piff.Polynomial.read(r, extname)
 
     # The type and other parameters should now have been overwritten and updated
     assert interp2.poly_type == interp.poly_type
@@ -396,9 +396,9 @@ def test_poly_raise():
 
     # Cannot write before running fit.
     filename = 'output/test_invalid.fits'
-    with fitsio.FITS(filename,'rw',clobber=True) as f:
+    with piff.writers.FitsWriter.open(filename) as w:
         with np.testing.assert_raises(RuntimeError):
-            interp.write(f, extname='junk')
+            interp.write(w, 'junk')
 
 
 @timer

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -716,8 +716,8 @@ def test_interp():
     with piff.writers.FitsWriter.open(filename1) as w:
         np.testing.assert_raises(NotImplementedError, interp._finish_write, w.nested('interp'))
     filename2 = os.path.join('input','D00240560_r_c01_r2362p01_piff.fits')
-    with fitsio.FITS(filename2,'r') as f:
-        np.testing.assert_raises(NotImplementedError, interp._finish_read, f, extname='interp')
+    with piff.readers.FitsReader.open(filename2) as r:
+        np.testing.assert_raises(NotImplementedError, interp._finish_read, r.nested('interp'))
 
     # Invalid to read a type that isn't a piff.Interp type.
     # Mock this by pretending that Mean is the only subclass of Interp.

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -665,12 +665,12 @@ def test_model():
     # Mock this by pretending that Gaussian is the only subclass of Model.
     filename = os.path.join('input','D00240560_r_c01_r2362p01_piff.fits')
     with mock.patch('piff.Model.valid_model_types', {'Gaussian': piff.Gaussian}):
-        with fitsio.FITS(filename,'r') as f:
-            np.testing.assert_raises(ValueError, piff.Model.read, f, extname='psf_model')
+        with piff.readers.FitsReader.open(filename) as r:
+            np.testing.assert_raises(ValueError, piff.Model.read, r, 'psf_model')
 
     # But normally this file can be read...
-    with fitsio.FITS(filename,'r') as f:
-        model = piff.Model.read(f, extname='psf_model')
+    with piff.readers.FitsReader.open(filename) as r:
+        model = piff.Model.read(r, 'psf_model')
         print(model)
 
     # We don't have any abstract model base classes (as we do for interp for instance),
@@ -722,12 +722,12 @@ def test_interp():
     # Invalid to read a type that isn't a piff.Interp type.
     # Mock this by pretending that Mean is the only subclass of Interp.
     with mock.patch('piff.Interp.valid_interp_types', {'Mean': piff.Mean}):
-        with fitsio.FITS(filename2,'r') as f:
-            np.testing.assert_raises(ValueError, piff.Interp.read, f, extname='psf_interp')
+        with piff.readers.FitsReader.open(filename2) as r:
+            np.testing.assert_raises(ValueError, piff.Interp.read, r, 'psf_interp')
 
     # But normally this file can be read...
-    with fitsio.FITS(filename2,'r') as f:
-        interp = piff.Interp.read(f, extname='psf_interp')
+    with piff.readers.FitsReader.open(filename2) as r:
+        interp = piff.Interp.read(r, 'psf_interp')
         print(interp)
 
     # BasisInterp is an abstract base class, so it shouldn't be in the list of valid types

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -713,8 +713,8 @@ def test_interp():
     np.testing.assert_raises(NotImplementedError, interp.interpolateList, [None])
 
     filename1 = os.path.join('output','test_interp.fits')
-    with fitsio.FITS(filename1,'rw',clobber=True) as f:
-        np.testing.assert_raises(NotImplementedError, interp._finish_write, f, extname='interp')
+    with piff.writers.FitsWriter.open(filename1) as w:
+        np.testing.assert_raises(NotImplementedError, interp._finish_write, w.nested('interp'))
     filename2 = os.path.join('input','D00240560_r_c01_r2362p01_piff.fits')
     with fitsio.FITS(filename2,'r') as f:
         np.testing.assert_raises(NotImplementedError, interp._finish_read, f, extname='interp')

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -478,12 +478,12 @@ def test_io():
 
         file_name = os.path.join('output','star_io.fits')
         print('Writing stars to ',file_name)
-        with fitsio.FITS(file_name,'rw',clobber=True) as fout:
-            piff.Star.write(stars, fout, extname='stars')
+        with piff.writers.FitsWriter.open(file_name) as w:
+            piff.Star.write(stars, w, 'stars')
 
         print('Reading from ',file_name)
-        with fitsio.FITS(file_name,'r') as fin:
-            stars2 = piff.Star.read(fin, extname='stars')
+        with piff.readers.FitsReader.open(file_name) as r:
+            stars2 = piff.Star.read(r, 'stars')
 
         for s1, s2 in zip(stars,stars2):
             assert s1.data['x'] == s2.data['x']
@@ -560,12 +560,12 @@ def test_multifit_io():
 
     file_name = os.path.join('output','star_multifit_io.fits')
     print('Writing stars to ',file_name)
-    with fitsio.FITS(file_name,'rw',clobber=True) as fout:
-        piff.Star.write(stars, fout, extname='stars')
+    with piff.writers.FitsWriter.open(file_name) as w:
+        piff.Star.write(stars, w, 'stars')
 
     print('Reading from ',file_name)
-    with fitsio.FITS(file_name,'r') as fin:
-        stars2 = piff.Star.read(fin, extname='stars')
+    with piff.readers.FitsReader.open(file_name) as r:
+        stars2 = piff.Star.read(r, 'stars')
 
     for s1, s2 in zip(stars,stars2):
         assert s1.data['x'] == s2.data['x']


### PR DESCRIPTION
See #168 for motivation.

This refactors the current FITS read/write code to delegate to new `Reader` and `Writer` classes that have FITS implementations, with a JSON-like alternate implementation envisioned but not implemented.  The FITS implementations should write files that are readable by older versions of Piff (the only change to the outputs is that the Piff version is now written to all of the extension headers, not just some of them), and of course read files written by older versions of Piff.