### PR TITLE
C++ version of _solve_direct in BasisInterp 

### DIFF
--- a/piff/basis_interp.py
+++ b/piff/basis_interp.py
@@ -104,6 +104,7 @@ class BasisInterp(Interp):
         self.q = None
         self.set_num(None)
         self._use_jax = False # The default.  May be overridden by subclasses.
+        self._use_cpp = False
 
     def initialize(self, stars, logger=None):
         """Initialize both the interpolator to some state prefatory to any solve iterations and
@@ -293,6 +294,15 @@ class BasisInterp(Interp):
         self.q += dq.reshape(self.q.shape)
 
     def _solve_direct(self, stars, logger):
+        if self._use_cpp:
+            self._solve_direct_cpp(stars, logger)
+        else:
+            self._solve_direct_pure_python(self, stars, logger)
+
+    def _solve_direct_cpp(self, stars, logger):
+        raise NotImplementedError("TO DO")
+
+    def _solve_direct_pure_python(self, stars, logger):
         """The implementation of solve() when use_qr = False.
         """
 


### PR DESCRIPTION
After discussing with Nate Lust, on accelerating Piff, he basically came to the same conclusion as me and that accelerating `PixelGrid` + `BasisInterp` meant accelerating `_solve_direct` in `BasisInterp`. As I am not a C++ expert I went through the path of implementing it in JAX in this https://github.com/rmjarvis/Piff/pull/166. 

Nate already implemented a version in C++ and Eigen that is faster than the pure python implementation even on a single core it looks like. I'll let him push his code on that branch and I'll make the test / unit test to validate the C++ implementation and clean the `_solve_direct` in regards of the last change I push (see if JAX is still worst it compared to the C++ implementation). 

Just putting this as a draft PR for the moment. 

Not ready for review. 