### PR TITLE
Get weight from sky image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
                 cd ..
 
             - name: Upload coverage to codecov
-              uses: codecov/codecov-action@v3
+              uses: codecov/codecov-action@v4
               with:
                 token: ${{ secrets.CODECOV_TOKEN }}
                 files: tests/coverage.xml

--- a/piff/star_stats.py
+++ b/piff/star_stats.py
@@ -115,7 +115,8 @@ class StarStats(Stats):
                                      axis=0)
             ave_model_image = np.mean([s.image.array/np.max(s.image.array)
                                         for s in calculated_models
-                                        if s is not None and not s.is_flagged],
+                                        if s is not None and not s.is_flagged
+                                            and np.max(s.image.array) != 0.],
                                       axis=0)
             ave_star_image = galsim.Image(ave_star_image)
             ave_model_image = galsim.Image(ave_model_image)

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -357,12 +357,13 @@ class ShapeHistStats(Stats):
         positions, shapes_data, shapes_model = self.measureShapes(
                 psf, stars, model_properties=self.model_properties, logger=logger)
 
-        # Only use stars for which hsm was successful
+        # Only use stars for which hsm was successful and not flagged
         flag_data = shapes_data[:, 6]
         flag_model = shapes_model[:, 6]
-        mask = (flag_data == 0) & (flag_model == 0)
+        flag_psf = np.array([s.is_flagged for s in stars], dtype=int)
+        mask = (flag_data == 0) & (flag_model == 0) & (flag_psf == 0)
         if np.sum(mask) == 0:
-            logger.warning("All stars had hsm errors.  ShapeHist plot will be empty.")
+            logger.warning("All stars had hsm errors or were flagged. ShapeHist plot will be empty.")
             self.skip = True
 
         # define terms for the catalogs
@@ -555,12 +556,13 @@ class RhoStats(Stats):
         positions, shapes_data, shapes_model = self.measureShapes(
                 psf, stars, model_properties=self.model_properties, logger=logger)
 
-        # Only use stars for which hsm was successful
+        # Only use stars for which hsm was successful and not flagged
         flag_data = shapes_data[:, 6]
         flag_model = shapes_model[:, 6]
-        mask = (flag_data == 0) & (flag_model == 0)
+        flag_psf = np.array([s.is_flagged for s in stars], dtype=int)
+        mask = (flag_data == 0) & (flag_model == 0) & (flag_psf == 0)
         if np.sum(mask) == 0:
-            logger.warning("All stars had hsm errors.  Rho plot will be empty.")
+            logger.warning("All stars had hsm errors or were flagged. Rho plot will be empty.")
             self.skip = True
             return
 

--- a/piff/stats.py
+++ b/piff/stats.py
@@ -763,6 +763,7 @@ class HSMCatalogStats(Stats):
         :g1_model:  The g1 component of the PSF model.
         :g2_model:  The g2 component of the PSF model.
         :reserve:   Whether the star was a reserve star.
+        :flag_psf:  1 if the PSF fitter rejected the star for some reason.  0 otherwise.
         :flag_data: 0 where HSM succeeded on the observed star, >0 where it failed (see above).
         :flag_model: 0 where HSM succeeded on the PSF model, >0 where it failed (see above).
 

--- a/piff/twod_stats.py
+++ b/piff/twod_stats.py
@@ -75,13 +75,14 @@ class TwoDHistStats(Stats):
         positions, shapes_truth, shapes_model = self.measureShapes(
             psf, stars, model_properties=self.model_properties, logger=logger)
 
-        # Only use stars for which hsm was successful
+        # Only use stars for which hsm was successful and not flagged
         flag_truth = shapes_truth[:, 6]
         flag_model = shapes_model[:, 6]
-        mask = (flag_truth == 0) & (flag_model == 0)
+        flag_psf = np.array([s.is_flagged for s in stars], dtype=int)
+        mask = (flag_truth == 0) & (flag_model == 0) & (flag_psf == 0)
         logger.info("%d/%d measurements were successful",np.sum(mask),len(mask))
         if np.sum(mask) == 0:
-            logger.warning("All stars had hsm errors.  TwoDHist plot will be empty.")
+            logger.warning("All stars had hsm errors or were flagged. TwoDHist plot will be empty.")
             self.skip = True
             return
 
@@ -450,13 +451,14 @@ class WhiskerStats(Stats):
         positions, shapes_truth, shapes_model = self.measureShapes(
             psf, stars, model_properties=self.model_properties, logger=logger)
 
-        # Only use stars for which hsm was successful
+        # Only use stars for which hsm was successful and not flagged
         flag_truth = shapes_truth[:, 6]
         flag_model = shapes_model[:, 6]
-        mask = (flag_truth == 0) & (flag_model == 0)
+        flag_psf = np.array([s.is_flagged for s in stars], dtype=int)
+        mask = (flag_truth == 0) & (flag_model == 0) & (flag_psf == 0)
         logger.info("%d/%d measurements were successful",np.sum(mask),len(mask))
         if np.sum(mask) == 0:
-            logger.warning("All stars had hsm errors.  Whisker plot will be empty.")
+            logger.warning("All stars had hsm errors or were flagged. Whisker plot will be empty.")
             self.skip = True
             return
 


### PR DESCRIPTION
@esheldon had a use case where there was a sky image, but no weight map.  So this PR adds an option to compute the weight map from the sky image.

There were also a couple places where stats weren't respecting the new flagging interface, so this fixes those.