### PR TITLE
Add badpix_zeros option

### DIFF
--- a/piff/input.py
+++ b/piff/input.py
@@ -213,6 +213,8 @@ class InputFiles(Input):
                         this gives the name of the file to use. [default: None]
         :badpix_file_name: If the badpix image is in a different file than the main image,
                         this gives the name of the file to use. [default: None]
+        :badpix_zeros:  Whether to treat all zeros in the input image as bad pixels.
+                        [default: False]
 
         :cat_hdu:       The hdu to use in the catalog files. [default: 1]
         :x_col:         The name of the X column in the input catalogs. [default: 'x']
@@ -299,6 +301,7 @@ class InputFiles(Input):
                 'badpix_hdu' : int,
                 'weight_file_name' : str,
                 'badpix_file_name' : str,
+                'badpix_zeros' : bool,
                 'sky_file_name' : str,
                 'sky_hdu': int,
                 'cat_hdu' : int,
@@ -462,6 +465,7 @@ class InputFiles(Input):
             weight_hdu = params.get('weight_hdu', None)
             badpix_file_name = params.get('badpix_file_name', None)
             badpix_hdu = params.get('badpix_hdu', None)
+            badpix_zeros = params.get('badpix_zeros', False)
             sky_file_name = params.get('sky_file_name', None)
             sky_hdu = params.get('sky_hdu', None)
             noise = params.get('noise', None)
@@ -474,6 +478,7 @@ class InputFiles(Input):
                     'weight_hdu' : weight_hdu,
                     'badpix_file_name' : badpix_file_name,
                     'badpix_hdu' : badpix_hdu,
+                    'badpix_zeros' : badpix_zeros,
                     'sky_file_name' : sky_file_name,
                     'sky_hdu' : sky_hdu,
                     'noise' : noise})
@@ -745,7 +750,8 @@ class InputFiles(Input):
 
     @staticmethod
     def readImage(image_file_name, image_hdu, weight_file_name, weight_hdu,
-                  badpix_file_name, badpix_hdu, sky_file_name, sky_hdu, noise, logger):
+                  badpix_file_name, badpix_hdu, badpix_zeros, sky_file_name, sky_hdu,
+                  noise, logger):
         """Read in the image and weight map (or make one if no weight information is given
 
         :param image_file_name: The name of the file to read.
@@ -754,6 +760,8 @@ class InputFiles(Input):
         :param weight_hdu:      The hdu of the weight image (if any).
         :param badpix_file_name: The name of the file with the bad pixel mask (if any).
         :param badpix_hdu:      The hdu of the bad pixel mask (if any).
+        :param badpix_zeros:    Whether to treat all zeros in the input image as bad pixels.
+                                [default: False]
         :param sky_file_name:   A file to use for a sky background to subtract from the image
                                 (if any).
         :param sky_hdu:         The hdu to use in the sky_file_name (if any).
@@ -765,13 +773,6 @@ class InputFiles(Input):
         # Read in the image
         logger.info("Reading image file %s",image_file_name)
         image = galsim.fits.read(image_file_name, hdu=image_hdu)
-
-        # If requested, subtract a sky image
-        if sky_file_name is not None:
-            hdu_str = " from hdu %s"%(sky_hdu) if sky_hdu is not None else ""
-            logger.verbose("Reading sky image %s.", sky_file_name + hdu_str)
-            sky = galsim.fits.read(sky_file_name, hdu=sky_hdu)
-            image -= sky
 
         # Either read in the weight image, or build a dummy one
         if weight_file_name is not None or weight_hdu is not None:
@@ -792,6 +793,17 @@ class InputFiles(Input):
         else:
             logger.debug("Making trivial (wt==1) weight image")
             weight = galsim.ImageF(image.bounds, init_value=1)
+
+        # Make sure to do this before anything that could modify the input image.
+        if badpix_zeros:
+            weight.array[image.array == 0] = 0
+
+        # If requested, subtract a sky image
+        if sky_file_name is not None:
+            hdu_str = " from hdu %s"%(sky_hdu) if sky_hdu is not None else ""
+            logger.verbose("Reading sky image %s.", sky_file_name + hdu_str)
+            sky = galsim.fits.read(sky_file_name, hdu=sky_hdu)
+            image -= sky
 
         # If requested, set wt=0 for any bad pixels
         if badpix_file_name is not None or badpix_hdu is not None:

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -98,6 +98,9 @@ def setup():
         wtx = f[1].read().copy()
         var = 1/wtx + (f[0].read() - sky) / gain
         f.write(var) # hdu = 10
+        imz = f[0].read().copy()
+        imz[bp != 0] = 0
+        f.write(imz) # hdu = 11
 
     weight_file = os.path.join(dir, 'input', 'test_input_weight_00.fits')
     with fitsio.FITS(weight_file, 'rw', clobber=True) as f:
@@ -1081,6 +1084,18 @@ def test_weight():
     with CaptureLog() as cl:
         _, weight, _, _  = input.getRawImageData(0, logger=cl.logger)
     assert 'Warning: weight map has invalid negative-valued pixels.' in cl.output
+
+    # If some input values are zero, they can be treated as bad pixels with badpix_zeros
+    del config['weight_hdu']
+    config['badpix_hdu'] = 9
+    input = piff.InputFiles(config, logger=logger)
+    _, weight, _, _ = input.getRawImageData(0)
+    del config['badpix_hdu']
+    config['image_hdu'] = 11
+    config['badpix_zeros'] = True
+    input = piff.InputFiles(config, logger=logger)
+    _, weight2, _, _ = input.getRawImageData(0)
+    np.testing.assert_array_equal(weight.array, weight2.array)
 
 
 @timer


### PR DESCRIPTION
I have a huge branch called roman that has a bunch of changes I made in order to read/process simulated Roman images made by Chris Hirata.  In order to make the code review feasible, I'm going to parcel out the changes in what I hope are relatively bite-sized pull requests.  This is the first one.

The simulated Roman images that Chris makes don't have an explicit bad-pixel mask.  Rather, they set the image to zero at any pixel that should be considered bad.  This PR adds the option to set badpix_zeros=True to tell Piff to consider any pixel with image value=0 to be a badpixel and thus set the pixel weight to 0.