### PR TITLE
Enable noise to be specified in FITS header

### DIFF
--- a/piff/input.py
+++ b/piff/input.py
@@ -787,6 +787,12 @@ class InputFiles(Input):
                                "Taking them to be 0.0")
                 weight.array[weight.array < 0] = 0.
         elif noise is not None:
+            try:
+                noise = float(noise)
+            except ValueError:
+                if noise not in image.header:
+                    raise KeyError("Key %s not found in FITS header"%noise)
+                noise = float(image.header[noise])
             logger.debug("Making uniform weight image based on noise variance = %f", noise)
             weight = galsim.ImageF(image.bounds, init_value=1./noise)
         else:

--- a/piff/input.py
+++ b/piff/input.py
@@ -764,7 +764,8 @@ class InputFiles(Input):
         :param sky_file_name:   A file to use for a sky background to subtract from the image
                                 (if any).
         :param sky_hdu:         The hdu to use in the sky_file_name (if any).
-        :param noise:           A constant noise value to use in lieu of a weight map.
+        :param noise:           Either a float constant noise value to use in lieu of a weight
+                                map or a str keyword to use to read a value from FITS header.
         :param logger:          A logger object for logging debug info.
 
         :returns: image, weight

--- a/piff/input.py
+++ b/piff/input.py
@@ -313,7 +313,7 @@ class InputFiles(Input):
                 'trust_pos' : bool,
                 'use_partial' : bool,
                 'sky' : str,
-                'noise' : float,
+                'noise' : str,
                 'nstars' : int,
               }
         ignore = [ 'nproc', 'nimages', 'ra', 'dec', 'wcs' ]  # These are parsed separately
@@ -530,7 +530,6 @@ class InputFiles(Input):
                     'satur' : satur,
                     'trust_pos' : trust_pos,
                     'nstars' : nstars,
-                    'image_file_name' : image_file_name,
                     'stamp_size' : self.stamp_size})
 
         self.use_partial = config.get('use_partial', False)
@@ -772,7 +771,7 @@ class InputFiles(Input):
         """
         # Read in the image
         logger.info("Reading image file %s",image_file_name)
-        image = galsim.fits.read(image_file_name, hdu=image_hdu)
+        image = galsim.fits.read(image_file_name, hdu=image_hdu, read_header=True)
 
         # Either read in the weight image, or build a dummy one
         if weight_file_name is not None or weight_hdu is not None:
@@ -849,7 +848,7 @@ class InputFiles(Input):
     def readStarCatalog(cat_file_name, cat_hdu, x_col, y_col,
                         ra_col, dec_col, ra_units, dec_units, image,
                         flag_col, skip_flag, use_flag, property_cols, sky_col, gain_col,
-                        sky, gain, satur, trust_pos, nstars, image_file_name, stamp_size, logger):
+                        sky, gain, satur, trust_pos, nstars, stamp_size, logger):
         """Read in the star catalogs and return lists of positions for each star in each image.
 
         :param cat_file_name:   The name of the catalog file to read in.
@@ -877,7 +876,6 @@ class InputFiles(Input):
                                 keyword to read a value from the FITS header.
         :param trust_pos:       Optional bool value indicating whether to trust input positions.
         :param nstars:          Optionally a maximum number of stars to use.
-        :param image_file_name: The image file name in case needed for header values.
         :param stamp_size:      The stamp size being used for the star stamps.
         :param logger:          A logger object for logging debug info. [default: None]
 
@@ -1010,12 +1008,9 @@ class InputFiles(Input):
             try:
                 sky = float(sky)
             except ValueError:
-                fits = fitsio.FITS(image_file_name)
-                hdu = 1 if image_file_name.endswith('.fz') else 0
-                header = fits[hdu].read_header()
-                if sky not in header:
+                if sky not in image.header:
                     raise KeyError("Key %s not found in FITS header"%sky)
-                sky = float(header[sky])
+                sky = float(image.header[sky])
             extra_props['sky'] = np.array([sky]*len(cat), dtype=np.float32)
 
         # Make the list of gain values:
@@ -1030,12 +1025,9 @@ class InputFiles(Input):
             try:
                 gain = float(gain)
             except ValueError:
-                fits = fitsio.FITS(image_file_name)
-                hdu = 1 if image_file_name.endswith('.fz') else 0
-                header = fits[hdu].read_header()
-                if gain not in header:
+                if gain not in image.header:
                     raise KeyError("Key %s not found in FITS header"%gain)
-                gain = float(header[gain])
+                gain = float(image.header[gain])
             extra_props['gain'] = np.array([gain]*len(cat), dtype=float)
 
         # Get the saturation level
@@ -1044,12 +1036,9 @@ class InputFiles(Input):
                 satur = float(satur)
                 logger.debug("Using given saturation value: %s",satur)
             except ValueError:
-                fits = fitsio.FITS(image_file_name)
-                hdu = 1 if image_file_name.endswith('.fz') else 0
-                header = fits[hdu].read_header()
-                if satur not in header:
+                if satur not in image.header:
                     raise KeyError("Key %s not found in FITS header"%satur)
-                satur = float(header[satur])
+                satur = float(image.header[satur])
                 logger.debug("Using saturation from header: %s",satur)
             extra_props['satur'] = np.array([satur]*len(cat), dtype=float)
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1031,6 +1031,11 @@ def test_weight():
     assert weight.array.shape == (1024, 1024)
     np.testing.assert_almost_equal(weight.array, 34.**-1)
 
+    # Error if specified noise is not found in header.
+    config['noise'] = 'invalid'
+    with np.testing.assert_raises(KeyError):
+        piff.InputFiles(config, logger=logger).getRawImageData(0)
+
     # Some old versions of fitsio had a bug where the badpix mask could be offset by 32768.
     # We move them back to 0
     config = {

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -74,6 +74,7 @@ def setup():
         f[0].write_key('SKYLEVEL', sky, 'sky level')
         f[0].write_key('GAIN_A', gain, 'gain')
         f[0].write_key('SATURAT', satur, 'saturation level')
+        f[0].write_key('NOISE', 34, 'noise level')
         f[0].write_key('RA', '06:00:00', 'telescope ra')
         f[0].write_key('DEC', '-30:00:00', 'telescope dec')
         wt = f[1].read().copy()
@@ -1017,6 +1018,18 @@ def test_weight():
     _, weight, _, _ = input.getRawImageData(0)
     assert weight.array.shape == (1024, 1024)
     np.testing.assert_almost_equal(weight.array, 32.**-1)
+
+    # Noise can be a fits header value
+    config = {
+                'image_file_name' : 'input/test_input_image_00.fits',
+                'cat_file_name' : 'input/test_input_cat_00.fits',
+                'noise' : 'NOISE',  # Set as 34 in fits file
+             }
+    input = piff.InputFiles(config, logger=logger)
+    assert input.nimages == 1
+    _, weight, _, _ = input.getRawImageData(0)
+    assert weight.array.shape == (1024, 1024)
+    np.testing.assert_almost_equal(weight.array, 34.**-1)
 
     # Some old versions of fitsio had a bug where the badpix mask could be offset by 32768.
     # We move them back to 0


### PR DESCRIPTION
Next Roman processing PR.

The Roman simulated images from Chris don't have weight maps.  Rather the noise level is to be considered a constant, and is given in the FITS header as BKGNDVAR.  The gain is also there as EQVGAIN.

We had the ability to read the gain from the fits header, but not the noise variance.  So this PR adds that capability.

(It also simplifies how the header is passed between functions.  It's now stored as image.header, which is a standard place for it in GalSim, but which we hadn't been using here.)