### PR TITLE
Enable single image file with multiple hdus

### DIFF
--- a/piff/input.py
+++ b/piff/input.py
@@ -354,6 +354,15 @@ class InputFiles(Input):
             if nimages < 1:
                 raise ValueError('input.nimages must be >= 1')
 
+        if 'image_hdu' in config and isinstance(config['image_hdu'], list):
+            if len(config['image_hdu']) == 0:
+                raise ValueError("image_hdu may not be an empty list")
+            if nimages is None:
+                nimages = len(config['image_hdu'])
+            elif nimages != len(config['image_hdu']):
+                raise ValueError("nimages = %s doesn't match length of image_hdu list (%d)"%(
+                                 nimages, len(config['image_hdu'])))
+
         # Deal with dir here, since sometimes we need to have it already attached for glob
         # to work.
         if 'dir' in config:
@@ -385,15 +394,15 @@ class InputFiles(Input):
 
         if image_list is not None:
             logger.debug('image_list = %s',image_list)
-            if nimages is not None and nimages != len(image_list):
+            if len(image_list) == 1 and nimages is not None and nimages > 1:
+                logger.verbose("Using the same image file for all images")
+                image_list = image_list * nimages
+            elif nimages is not None and nimages != len(image_list):
                 raise ValueError("nimages = %s doesn't match length of image_file_name list (%d)"%(
-                        config['nimages'], len(image_list)))
+                        nimages, len(image_list)))
             nimages = len(image_list)
             logger.debug('nimages = %d',nimages)
-            config['image_file_name'] = {
-                'type' : 'List_str',
-                'items' : image_list
-            }
+            config['image_file_name'] = image_list
         logger.debug('nimages = %d',nimages)
         assert nimages is not None
 
@@ -407,12 +416,53 @@ class InputFiles(Input):
             sky_list = sorted(glob.glob(sky_file_name))
             if len(sky_list) == 0:
                 raise ValueError("No files found corresponding to "+config['sky_file_name'])
-            config['sky_file_name'] = {
-                'type' : 'List_str',
-                'items' : sky_list
-            }
+            if len(sky_list) == 1 and nimages is not None and nimages > 1:
+                logger.verbose("Using the same sky file for all images")
+                sky_list = sky_list * nimages
+            elif nimages is not None and len(sky_list) != nimages:
+                raise ValueError("nimages = %s doesn't match length of sky_file_name list (%d)"%(
+                                 nimages, len(sky_list)))
+            config['sky_file_name'] = sky_list
         elif not isinstance(config['sky_file_name'], dict):
             raise ValueError("sky_file_name should be either a dict or a string")
+
+        if 'weight_file_name' not in config:
+            pass
+        elif isinstance(config['weight_file_name'], str):
+            weight_file_name = config['weight_file_name']
+            if dir is not None:
+                weight_file_name = os.path.join(dir, weight_file_name)
+            weight_list = sorted(glob.glob(weight_file_name))
+            if len(weight_list) == 0:
+                raise ValueError("No files found corresponding to "+config['weight_file_name'])
+            if len(weight_list) == 1 and nimages is not None and nimages > 1:
+                logger.verbose("Using the same weight file for all images")
+                weight_list = weight_list * nimages
+            elif nimages is not None and len(weight_list) != nimages:
+                raise ValueError("nimages = %s doesn't match length of weight_file_name list (%d)"%(
+                                 nimages, len(weight_list)))
+            config['weight_file_name'] = weight_list
+        elif not isinstance(config['weight_file_name'], dict):
+            raise ValueError("weight_file_name should be either a dict or a string")
+
+        if 'badpix_file_name' not in config:
+            pass
+        elif isinstance(config['badpix_file_name'], str):
+            badpix_file_name = config['badpix_file_name']
+            if dir is not None:
+                badpix_file_name = os.path.join(dir, badpix_file_name)
+            badpix_list = sorted(glob.glob(badpix_file_name))
+            if len(badpix_list) == 0:
+                raise ValueError("No files found corresponding to "+config['badpix_file_name'])
+            if len(badpix_list) == 1 and nimages is not None and nimages > 1:
+                logger.verbose("Using the same badpix file for all images")
+                badpix_list = badpix_list * nimages
+            elif nimages is not None and len(badpix_list) != nimages:
+                raise ValueError("nimages = %s doesn't match length of badpix_file_name list (%d)"%(
+                                 nimages, len(badpix_list)))
+            config['badpix_file_name'] = badpix_list
+        elif not isinstance(config['badpix_file_name'], dict):
+            raise ValueError("badpix_file_name should be either a dict or a string")
 
         if 'cat_file_name' not in config:
             raise TypeError('Parameter cat_file_name is required')
@@ -440,10 +490,7 @@ class InputFiles(Input):
             elif nimages != len(cat_list):
                 raise ValueError("nimages = %s doesn't match length of cat_file_name list (%d)"%(
                                  nimages, len(cat_list)))
-            config['cat_file_name'] = {
-                'type' : 'List_str',
-                'items' : cat_list
-            }
+            config['cat_file_name'] = cat_list
 
         self.nimages = nimages
         self.chipnums = list(range(nimages))

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1254,16 +1254,34 @@ def test_weight():
     assert input.image_kwargs[1]['weight_file_name'] == 'input/test_input_weight_00.fits'
     assert input.image_kwargs[0]['badpix_file_name'] == 'input/test_input_badpix_00.fits'
     assert input.image_kwargs[1]['badpix_file_name'] == 'input/test_input_badpix_00.fits'
-    expected_weight = fitsio.read('input/test_input_weight_00.fits', ext=0)
-    expected_weight[1::2, :] = 0
+    expected_weight0 = fitsio.read('input/test_input_weight_00.fits', ext=0)
+    expected_weight0[1::2, :] = 0
     _, weight, image_pos, _ = input.getRawImageData(0)
     assert len(image_pos) == 100
-    np.testing.assert_allclose(weight.array, expected_weight)
-    expected_weight = fitsio.read('input/test_input_weight_00.fits', ext=1)
-    expected_weight[1::2, :] = 0
+    np.testing.assert_allclose(weight.array, expected_weight0)
+    expected_weight1 = fitsio.read('input/test_input_weight_00.fits', ext=1)
+    expected_weight1[1::2, :] = 0
     _, weight, image_pos, _ = input.getRawImageData(1)
     assert len(image_pos) == 100
-    np.testing.assert_allclose(weight.array, expected_weight)
+    np.testing.assert_allclose(weight.array, expected_weight1)
+
+    # Both weight_file_name and badpix_file_name can be a dict using the GalSim parser
+    config['weight_file_name'] = { 'type': 'List', 'items': ['input/test_input_weight_00.fits'], }
+    config['badpix_file_name'] = { 'type': 'List', 'items': ['input/test_input_badpix_00.fits'], }
+    input = piff.InputFiles(config, logger=logger)
+    assert input.nimages == 2
+    assert input.image_file_name == ['input/test_input_image_00.fits'] * 2
+    assert input.cat_file_name == ['input/test_input_cat_00.fits'] * 2
+    assert input.image_kwargs[0]['weight_file_name'] == 'input/test_input_weight_00.fits'
+    assert input.image_kwargs[1]['weight_file_name'] == 'input/test_input_weight_00.fits'
+    assert input.image_kwargs[0]['badpix_file_name'] == 'input/test_input_badpix_00.fits'
+    assert input.image_kwargs[1]['badpix_file_name'] == 'input/test_input_badpix_00.fits'
+    _, weight, image_pos, _ = input.getRawImageData(0)
+    assert len(image_pos) == 100
+    np.testing.assert_allclose(weight.array, expected_weight0)
+    _, weight, image_pos, _ = input.getRawImageData(1)
+    assert len(image_pos) == 100
+    np.testing.assert_allclose(weight.array, expected_weight1)
 
 
 @timer

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -322,6 +322,27 @@ def test_invalid():
     config = { 'nimages' : -1, 'image_file_name' : image_files, 'cat_file_name': cat_files }
     np.testing.assert_raises(ValueError, piff.InputFiles, config)
 
+    # image_hdu can define nimages, but invalid values should raise.
+    config = {
+        'image_file_name' : os.path.join('input', image_file),
+        'image_hdu' : [],
+        'cat_file_name' : os.path.join('input', cat_file),
+    }
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+    config = {
+        'nimages' : 3,
+        'image_file_name' : os.path.join('input', image_file),
+        'image_hdu' : [0, 1],
+        'cat_file_name' : os.path.join('input', cat_file),
+    }
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+    config = {
+        'image_file_name' : 'input/test_input_image_*.fits',
+        'image_hdu' : [0, 1],
+        'cat_file_name' : os.path.join('input', cat_file),
+    }
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+
     # No images in list
     config = { 'dir' : 'input', 'image_file_name' : [], 'cat_file_name' : cat_file }
     np.testing.assert_raises(ValueError, piff.InputFiles, config)
@@ -331,6 +352,41 @@ def test_invalid():
     # Missing nimages (required when using dict)
     config = { 'image_file_name' : image_files_1, 'cat_file_name': cat_files }
     np.testing.assert_raises(TypeError, piff.InputFiles, config)
+
+    # Auxiliary file inputs should validate types and list lengths too.
+    config = {
+        'image_file_name' : os.path.join('input', image_file),
+        'image_hdu' : [0, 1],
+        'cat_file_name' : os.path.join('input', cat_file),
+        'sky_file_name' : 'input/test_input_*_00.fits',
+    }
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+    config['sky_file_name'] = 17
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+
+    config = {
+        'image_file_name' : os.path.join('input', image_file),
+        'image_hdu' : [0, 1],
+        'cat_file_name' : os.path.join('input', cat_file),
+        'weight_file_name' : 'input/test_input_*_00.fits',
+    }
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+    config['weight_file_name'] = 'input/x_test_input_weight_00.fits'
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+    config['weight_file_name'] = 17
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+
+    config = {
+        'image_file_name' : os.path.join('input', image_file),
+        'image_hdu' : [0, 1],
+        'cat_file_name' : os.path.join('input', cat_file),
+        'badpix_file_name' : 'input/test_input_*_00.fits',
+    }
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+    config['badpix_file_name'] = 'input/x_test_input_badpix_00.fits'
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
+    config['badpix_file_name'] = 17
+    np.testing.assert_raises(ValueError, piff.InputFiles, config)
 
     # Invalid input type
     config = { 'type': 'invalid' }
@@ -1151,6 +1207,64 @@ def test_weight():
     _, weight2, _, _ = input.getRawImageData(0)
     np.testing.assert_array_equal(weight.array, weight2.array)
 
+    # One image file with multiple HDUs should be treated as multiple images.
+    config = {
+                'image_file_name' : 'input/test_input_image_00.fits',
+                'image_hdu' : [0, 10],
+                'cat_file_name' : 'input/test_input_cat_00.fits',
+                'sky_file_name' : 'input/test_input_sky_00.fits.fz',
+                'weight_file_name' : 'input/test_input_weight_00.fits',
+                'weight_hdu' : [0, 1],
+             }
+    input = piff.InputFiles(config, logger=logger)
+    assert input.nimages == 2
+    assert input.image_file_name == ['input/test_input_image_00.fits'] * 2
+    assert input.cat_file_name == ['input/test_input_cat_00.fits'] * 2
+    image, weight, image_pos, _ = input.getRawImageData(0)
+    assert len(image_pos) == 100
+    np.testing.assert_allclose(image.array,
+                               fitsio.read('input/test_input_image_00.fits', ext=0) - sky)
+    np.testing.assert_allclose(weight.array,
+                               fitsio.read('input/test_input_weight_00.fits', ext=0))
+    image, weight, image_pos, _ = input.getRawImageData(1)
+    assert len(image_pos) == 100
+    np.testing.assert_allclose(image.array,
+                               fitsio.read('input/test_input_image_00.fits', ext=10) - sky)
+    np.testing.assert_allclose(weight.array,
+                               fitsio.read('input/test_input_weight_00.fits', ext=1))
+
+    # Also exercise the matching nimages branch and dir-based resolution for weight/badpix
+    # files, including broadcasting a single badpix file across multiple images.
+    config = {
+                'dir' : 'input',
+                'nimages' : 2,
+                'image_file_name' : 'test_input_image_00.fits',
+                'image_hdu' : [0, 10],
+                'cat_file_name' : 'test_input_cat_00.fits',
+                'weight_file_name' : 'test_input_weight_00.fits',
+                'weight_hdu' : [0, 1],
+                'badpix_file_name' : 'test_input_badpix_00.fits',
+                'badpix_hdu' : 0,
+             }
+    input = piff.InputFiles(config, logger=logger)
+    assert input.nimages == 2
+    assert input.image_file_name == ['input/test_input_image_00.fits'] * 2
+    assert input.cat_file_name == ['input/test_input_cat_00.fits'] * 2
+    assert input.image_kwargs[0]['weight_file_name'] == 'input/test_input_weight_00.fits'
+    assert input.image_kwargs[1]['weight_file_name'] == 'input/test_input_weight_00.fits'
+    assert input.image_kwargs[0]['badpix_file_name'] == 'input/test_input_badpix_00.fits'
+    assert input.image_kwargs[1]['badpix_file_name'] == 'input/test_input_badpix_00.fits'
+    expected_weight = fitsio.read('input/test_input_weight_00.fits', ext=0)
+    expected_weight[1::2, :] = 0
+    _, weight, image_pos, _ = input.getRawImageData(0)
+    assert len(image_pos) == 100
+    np.testing.assert_allclose(weight.array, expected_weight)
+    expected_weight = fitsio.read('input/test_input_weight_00.fits', ext=1)
+    expected_weight[1::2, :] = 0
+    _, weight, image_pos, _ = input.getRawImageData(1)
+    assert len(image_pos) == 100
+    np.testing.assert_allclose(weight.array, expected_weight)
+
 
 @timer
 def test_lsst_weight():
@@ -1245,7 +1359,6 @@ def test_lsst_weight():
     print('expected noise = ',expected_noise)
     print('var = ',1./weight.array)
     np.testing.assert_allclose(weight.array, expected_noise**-1, rtol=1.e-5)
-
 
 
 @timer


### PR DESCRIPTION
Chris packaged the 18 SCAs as a single fits file with multiple hdus.  This obviously makes a lot of sense, but (somewhat surprisingly) it wasn't an input format that Piff could handle yet.  This PR adds that capability.