### PR TITLE
Have nstars mean the total nstars when running with multiple chips.

### DIFF
--- a/piff/config.py
+++ b/piff/config.py
@@ -149,7 +149,7 @@ def process(config, logger=None):
     # For the 1.x series, allow the old API, but give a warning.
     select_keys = set(Select.base_keys)
     user_input_keys = set(config['input'].keys())
-    depr_keys = select_keys & user_input_keys
+    depr_keys = (select_keys - {'nstars'}) & user_input_keys
     if len(depr_keys) > 0:
         logger.error("WARNING: Items %r should now be in the 'select' field of the config file.",
                      sorted(depr_keys))

--- a/piff/input.py
+++ b/piff/input.py
@@ -22,7 +22,7 @@ import glob
 import os
 import galsim
 
-from .util import run_multi, calculateSNR
+from .util import run_multi
 from .star import Star, StarData
 
 class Input(object):
@@ -254,8 +254,9 @@ class InputFiles(Input):
                         [default: False]
         :use_partial:   Whether to use stars whose postage stamps are only partially on the
                         full image.  [default: False]
-        :nstars:        Stop reading the input file at this many stars.  (This is applied
-                        separately to each input catalog.)  [default: None]
+        :nstars:        Stop reading each input catalog at this many stars. This legacy option
+                        is deprecated; prefer `select.nstars`, which applies globally after the
+                        selection cuts and keeps the highest-S/N stars. [default: None]
         :nproc:         How many multiprocessing processes to use for reading in data from
                         multiple files at once. [default: 1]
 
@@ -328,7 +329,7 @@ class InputFiles(Input):
                 'noise' : str,
                 'nstars' : int,
               }
-        ignore = [ 'nproc', 'nimages', 'ra', 'dec', 'wcs' ]  # These are parsed separately
+        ignore = [ 'nproc', 'nimages', 'ra', 'dec', 'wcs' ]
 
         # We're going to change the config dict a bit. Make a copy so we don't mess up the
         # user's original dict (in case they care).
@@ -348,6 +349,10 @@ class InputFiles(Input):
 
         if 'nproc' in config:
             self.nproc = galsim.config.ParseValue(config, 'nproc', base, int)[0]
+
+        if 'nstars' in config:
+            logger.warning("input.nstars is deprecated; use select.nstars for the new global "
+                           "highest-S/N behavior.")
 
         if 'nimages' in config:
             nimages = galsim.config.ParseValue(config, 'nimages', base, int)[0]
@@ -985,7 +990,7 @@ class InputFiles(Input):
         :param satur:           Either a float value for the saturation level to use or a str
                                 keyword to read a value from the FITS header.
         :param trust_pos:       Optional bool value indicating whether to trust input positions.
-        :param nstars:          Optionally a maximum number of stars to use.
+        :param nstars:          Optionally a maximum number of stars to use from this catalog.
         :param stamp_size:      The stamp size being used for the star stamps.
         :param logger:          A logger object for logging debug info. [default: None]
 
@@ -1027,7 +1032,7 @@ class InputFiles(Input):
 
         # Limit to nstars objects
         if nstars is not None and nstars < len(cat):
-            logger.verbose("Limiting to %d objects for %s",nstars,cat_file_name)
+            logger.verbose("Limiting to %d objects for %s", nstars, cat_file_name)
             cat = cat[:nstars]
 
         # Make the list of positions:

--- a/piff/select.py
+++ b/piff/select.py
@@ -55,13 +55,8 @@ class Select(object):
         self.max_pixel_cut = config.get('max_pixel_cut', None)
         self.reject_where = config.get('reject_where', None)
         self.reserve_frac = config.get('reserve_frac', 0.)
+        self.nstars = config.get('nstars', None)
         self.rng = np.random.default_rng(config.get('seed', None))
-        if 'nstars' in config:
-            self.nstars = galsim.config.ParseValue(config, 'nstars', config, int)[0]
-            if self.nstars < 0:
-                raise ValueError("select.nstars must be >= 0")
-        else:
-            self.nstars = None
 
         if self.hsm_size_reject == 1:
             # Enable True to be equivalent to 10.  True comes in as 1.0, which would be a
@@ -358,6 +353,8 @@ class Select(object):
                 good_stars = [s for f,s in zip(flux,good_stars) if f < flux_cut]
 
         if self.nstars is not None and self.nstars < len(good_stars):
+            if self.nstars < 0:
+                raise ValueError("nstars must be non-negative")
             snrs = np.array([star.data.properties['raw_snr'] for star in good_stars])
             keep = np.argsort(snrs)[::-1][:self.nstars]
             keep.sort()

--- a/piff/select.py
+++ b/piff/select.py
@@ -41,7 +41,7 @@ class Select(object):
     # Parameters that derived classes should ignore if they appear in the config dict
     # (since they are handled by the base class).
     base_keys= ['min_snr', 'max_snr', 'hsm_size_reject', 'max_pixel_cut', 'reject_where',
-                'max_edge_frac', 'stamp_center_size', 'max_mask_pixels',
+                'max_edge_frac', 'stamp_center_size', 'max_mask_pixels', 'nstars',
                 'reserve_frac', 'seed']
 
     def __init__(self, config, logger=None):
@@ -56,6 +56,12 @@ class Select(object):
         self.reject_where = config.get('reject_where', None)
         self.reserve_frac = config.get('reserve_frac', 0.)
         self.rng = np.random.default_rng(config.get('seed', None))
+        if 'nstars' in config:
+            self.nstars = galsim.config.ParseValue(config, 'nstars', config, int)[0]
+            if self.nstars < 0:
+                raise ValueError("select.nstars must be >= 0")
+        else:
+            self.nstars = None
 
         if self.hsm_size_reject == 1:
             # Enable True to be equivalent to 10.  True comes in as 1.0, which would be a
@@ -123,6 +129,9 @@ class Select(object):
                             are properties of each star (usually input using property_cols).
                             It should evaluate to a bool for a single star or an array of bool
                             if the variables are arrays of property values for all the stars.
+                            [default: None]
+            :nstars:        After the rejection cuts, keep at most this many stars total,
+                            choosing the ones with the highest S/N across all images.
                             [default: None]
             :reserve_frac:  Reserve a fraction of the stars from the PSF calculations, so they
                             can serve as fair points for diagnostic testing.  These stars will
@@ -345,6 +354,14 @@ class Select(object):
                                "which implies max_pixel > ~%s",
                                np.sum(flux>=flux_cut), flux_cut, self.max_pixel_cut)
                 good_stars = [s for f,s in zip(flux,good_stars) if f < flux_cut]
+
+        if self.nstars is not None and self.nstars < len(good_stars):
+            snrs = np.array([star.data.properties['snr'] for star in good_stars])
+            keep = np.argsort(snrs)[::-1][:self.nstars]
+            keep.sort()
+            logger.info("Limiting to %d stars with highest S/N out of %d candidates",
+                        self.nstars, len(good_stars))
+            good_stars = [good_stars[k] for k in keep]
 
         logger.info("Rejected a total of %d stars out of %s total candidates",
                     len(stars) - len(good_stars), len(stars))

--- a/piff/select.py
+++ b/piff/select.py
@@ -263,12 +263,13 @@ class Select(object):
                     continue
 
             # Check the snr and limit it if appropriate
-            snr = calculateSNR(star.image, star.weight)
-            logger.debug("SNR = %f",snr)
-            if self.min_snr is not None and snr < self.min_snr:
+            raw_snr = calculateSNR(star.image, star.weight)
+            logger.debug("SNR = %f", raw_snr)
+            if self.min_snr is not None and raw_snr < self.min_snr:
                 logger.verbose("Skipping star at position %f,%f with snr=%f.",
-                               star.image_pos.x, star.image_pos.y, snr)
+                               star.image_pos.x, star.image_pos.y, raw_snr)
                 continue
+            snr = raw_snr
             if self.max_snr > 0 and snr > self.max_snr:
                 factor = (self.max_snr / snr)**2
                 logger.debug("Scaling noise by factor of %f to achieve snr=%f",
@@ -277,6 +278,7 @@ class Select(object):
                 snr = self.max_snr
                 logger.debug("SNR => %f",snr)
             star.data.properties['snr'] = snr
+            star.data.properties['raw_snr'] = raw_snr
 
             # Reject stars with lots of flux near the edge of the stamp.
             if self.max_edge_frac is not None and self.max_edge_frac < 1:
@@ -356,7 +358,7 @@ class Select(object):
                 good_stars = [s for f,s in zip(flux,good_stars) if f < flux_cut]
 
         if self.nstars is not None and self.nstars < len(good_stars):
-            snrs = np.array([star.data.properties['snr'] for star in good_stars])
+            snrs = np.array([star.data.properties['raw_snr'] for star in good_stars])
             keep = np.argsort(snrs)[::-1][:self.nstars]
             keep.sort()
             logger.info("Limiting to %d stars with highest S/N out of %d candidates",

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -227,16 +227,21 @@ def test_basic():
         assert len(image_pos) == 100
 
     # Can limit the number of stars
+    # *** The next bit is now deprecated.
+    #     input.nstars still works with the old per-catalog behavior, but is deprecated
+    #     in favor of the new select.nstars with (IMO) better semantics.
     config['nstars'] = 37
-    input = piff.InputFiles(config, logger=logger)
+    with CaptureLog() as cl:
+        input = piff.InputFiles(config, logger=cl.logger)
+    assert "input.nstars is deprecated" in cl.output
     assert input.nimages == 3
     for i in range(3):
         _, _, image_pos, _ = input.getRawImageData(i)
         assert len(image_pos) == 37
 
-    # Can limit stars differently on each chip
+    # input.nstars can still vary by image with the old per-catalog behavior.
     config['nstars'] = '$0 if @image_num == 1 else 20 if @image_num == 2 else 40'
-    input = piff.InputFiles(config, logger=logger)
+    input = piff.InputFiles(config)
     assert input.nimages == 3
     for i in range(3):
         _, _, image_pos, _ = input.getRawImageData(i)
@@ -247,18 +252,16 @@ def test_basic():
         else:
             assert len(image_pos) == 20
 
-    # Semi-gratuitous use of reserve_frac when one image has no stars for coverage
-    # This functionality changed location to the Select class, but keep this test nonetheless.
+    # Legacy behavior: input.nstars acts before later selection/reserve logic.
     select_config = {'reserve_frac': 0.2}
     config['use_partial'] = True
     config['ra'] = 6.0
     config['dec'] = -30.0
-    input = piff.InputFiles(config, logger=logger)
+    input = piff.InputFiles(config)
     assert input.nimages == 3
     stars = input.makeStars(logger=logger)
     select = piff.FlagSelect(select_config, logger=logger)
     select.reserveStars(stars, logger=logger)
-    print('len stars = ',len(stars))
     assert len(stars) == 60
     assert len([s for s in stars if s.chipnum == 0]) == 40
     assert len([s for s in stars if s.chipnum == 1]) == 0
@@ -269,11 +272,43 @@ def test_basic():
     assert len([s for s in reserve_stars if s['chipnum'] == 1]) == 0
     assert len([s for s in reserve_stars if s['chipnum'] == 2]) == 4
 
+    config.pop('nstars')
+    config['ra'] = 6.0
+    config['dec'] = -30.0
+    input = piff.InputFiles(config, logger=logger)
+    assert input.nimages == 3
+    objects = input.makeStars(logger=logger)
+    assert len(objects) > 100
+
+    # Now the new select.nstars tests.
+    # select.nstars applies globally after the selection cuts, which is more intuitive than
+    # setting a number for each input file when there are multiple catalogs.
+    # It also selects the N highest-S/N stars after doing all other selection/rejections steps.
+    # These are going to be the best subset to use for PSF estimation.
+    select_config = {'nstars': 37, 'max_snr': 1.e9}
+    stars = piff.Select.process(select_config, objects, logger=logger)
+    assert len(stars) == 37
+    snr_list = np.array([piff.util.calculateSNR(obj.image, obj.weight) for obj in objects])
+    selected_snr = np.array([piff.util.calculateSNR(star.image, star.weight) for star in stars])
+    cutoff = np.min(selected_snr)
+    assert np.count_nonzero(snr_list > cutoff) < len(stars)
+    assert np.count_nonzero(snr_list >= cutoff) >= len(stars)
+
+    # The nstars limit is applied after other selection cuts.
+    select_config = {'min_snr': 35, 'max_snr': 1.e9, 'nstars': 12}
+    stars = piff.Select.process(select_config, objects, logger=logger)
+    assert len(stars) == 12
+    allowed = [obj for obj in objects if piff.util.calculateSNR(obj.image, obj.weight) >= 35]
+    snr_list = np.array([piff.util.calculateSNR(obj.image, obj.weight) for obj in allowed])
+    selected_snr = np.array([piff.util.calculateSNR(star.image, star.weight) for star in stars])
+    cutoff = np.min(selected_snr)
+    assert np.count_nonzero(snr_list > cutoff) < len(stars)
+    assert np.count_nonzero(snr_list >= cutoff) >= len(stars)
+
     # If no stars, raise error
     # (normally because all stars have errors, but easier to just limit to 0 to test this.)
-    config['nstars'] = 0
     with np.testing.assert_raises(RuntimeError):
-        input = piff.Input.process(config, logger=logger)
+        piff.Select.process({'nstars': 0}, objects, logger=logger)
 
 
 @timer
@@ -319,6 +354,9 @@ def test_invalid():
     np.testing.assert_raises(ValueError, piff.InputFiles, config)
     config = { 'nimages' : 0, 'image_file_name' : image_files, 'cat_file_name': cat_files }
     np.testing.assert_raises(ValueError, piff.InputFiles, config)
+
+    # nstars now belongs in the select field, and negative values are invalid there.
+    np.testing.assert_raises(ValueError, piff.FlagSelect, {'nstars': -1})
     config = { 'nimages' : -1, 'image_file_name' : image_files, 'cat_file_name': cat_files }
     np.testing.assert_raises(ValueError, piff.InputFiles, config)
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -316,6 +316,10 @@ def test_basic():
     np.testing.assert_allclose(selected_raw, expected)
     assert np.allclose([star['snr'] for star in stars], 20)
 
+    # Negative nstars is invalid (checked when the nstars logic is used).
+    with np.testing.assert_raises(ValueError):
+        piff.Select.process({'nstars': -1}, objects, logger=logger)
+
     # If no stars, raise error
     # (normally because all stars have errors, but easier to just limit to 0 to test this.)
     with np.testing.assert_raises(RuntimeError):
@@ -366,8 +370,6 @@ def test_invalid():
     config = { 'nimages' : 0, 'image_file_name' : image_files, 'cat_file_name': cat_files }
     np.testing.assert_raises(ValueError, piff.InputFiles, config)
 
-    # nstars now belongs in the select field, and negative values are invalid there.
-    np.testing.assert_raises(ValueError, piff.FlagSelect, {'nstars': -1})
     config = { 'nimages' : -1, 'image_file_name' : image_files, 'cat_file_name': cat_files }
     np.testing.assert_raises(ValueError, piff.InputFiles, config)
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -305,6 +305,17 @@ def test_basic():
     assert np.count_nonzero(snr_list > cutoff) < len(stars)
     assert np.count_nonzero(snr_list >= cutoff) >= len(stars)
 
+    # nstars ranking should use unclipped S/N even when max_snr clips the fit weighting.
+    objects2 = input.makeStars(logger=logger)
+    snr_list2 = np.array([piff.util.calculateSNR(obj.image, obj.weight) for obj in objects2])
+    select_config = {'nstars': 12, 'max_snr': 20}
+    stars = piff.Select.process(select_config, objects2, logger=logger)
+    assert len(stars) == 12
+    expected = np.sort(np.sort(snr_list2)[::-1][:12])
+    selected_raw = np.sort(np.array([star['raw_snr'] for star in stars]))
+    np.testing.assert_allclose(selected_raw, expected)
+    assert np.allclose([star['snr'] for star in stars], 20)
+
     # If no stars, raise error
     # (normally because all stars have errors, but easier to just limit to 0 to test this.)
     with np.testing.assert_raises(RuntimeError):


### PR DESCRIPTION
The existing input.nstars specification limits the number of stars to something fewer than all the input stars.  This is usually used when testing to quickly limit the stars to a smaller selection for faster iteration.  However, it had a couple of annoying limitations when I was using it with the roman simulated images.

1. It only applied to an individual image, which in our context was a single SCA.
2. It applied that limitation before doing the various rejection steps specified in the select field, so you kind of had to guess a larger number that would end up with about the right number of stars you wanted to end up with.
3. It just took the first N stars in the list, rather than prioritizing brighter stars, which are better PSF stars.

This PR moves the nstars specification (keeping the old version as deprecated) and fixes the above issues.  It applies the selection to the full list of stars on all chips after the various rejections and preferentially selects those with high s/n.