### PR TITLE
Centroid outlier

### DIFF
--- a/piff/__init__.py
+++ b/piff/__init__.py
@@ -87,7 +87,7 @@ from .knn_interp import KNNInterp, KNearestNeighbors
 from .gp_interp import GPInterp, GaussianProcess
 
 # Outlier handlers are named BlahOutliers where Blah is what they are called in teh config file
-from .outliers import Outliers, ChisqOutliers
+from .outliers import Outliers, ChisqOutliers, CentroidOutliers
 
 # Input handlers are named InputBlah where Blah is what they are called in the config file
 from .input import Input, InputFiles

--- a/piff/convolvepsf.py
+++ b/piff/convolvepsf.py
@@ -302,7 +302,7 @@ class ConvolvePSF(PSF):
         for k, comp in enumerate(self.components):
             comp._write(writer, str(k), logger=logger)
         if self.outliers:
-            self.outliers.write(writer, 'outliers')
+            Outliers.write_all(writer, 'outliers', self.outliers)
             logger.debug("Wrote the PSF outliers to extension %s", writer.get_full_name('outliers'))
 
     def _finish_read(self, reader, logger):
@@ -319,6 +319,6 @@ class ConvolvePSF(PSF):
         self.components = []
         for k in range(ncomponents):
             self.components.append(PSF._read(reader, str(k), logger=logger))
-        self.outliers = Outliers.read(reader, 'outliers')
+        self.outliers = Outliers.read_all(reader, 'outliers')
         # Set up all the num's properly now that everything is constructed.
         self.set_num(None)

--- a/piff/outliers.py
+++ b/piff/outliers.py
@@ -116,8 +116,6 @@ class Outliers(object):
         :param name:        A name to associate with the outliers in the serialized output.
         :param outliers:    A list of Outliers instances.
         """
-        if not outliers:
-            return
         if len(outliers) == 1:
             # Only 1 outlier.  Write it to this extension.
             outliers[0].write(writer, name)
@@ -187,8 +185,6 @@ class Outliers(object):
             with reader.nested(name) as r:
                 for i in range(n_outliers):
                     outlier = cls.read(r, f'outlier_{i}')
-                    if outlier is None:
-                        raise ValueError("Missing outlier_%d in serialized outliers list" % i)
                     outliers.append(outlier)
             return outliers
         else:

--- a/piff/outliers.py
+++ b/piff/outliers.py
@@ -374,3 +374,68 @@ class ChisqOutliers(Outliers):
         logger.debug("flux = %s",[s.flux for s,g in zip(stars,good) if not g])
 
         return stars, nremoved
+
+
+class CentroidOutliers(Outliers):
+    """An Outliers handler that rejects stars with large fitted centroid offsets.
+
+    Stars with ``sqrt(cen_u^2 + cen_v^2) > max_offset`` are flagged as outliers.
+    The centroid units are the same as ``star.fit.center`` (typically arcsec).
+
+    Reserve stars can also be flagged, but they do not contribute to ``nremoved``,
+    matching the behavior of :class:`ChisqOutliers`.
+
+    :param max_offset:      Required centroid offset threshold.
+    :param logger:          A logger object for logging debug info. [default: None]
+    """
+    _type_name = 'Centroid'
+
+    def __init__(self, max_offset, logger=None):
+        from .config import LoggerWrapper
+
+        if max_offset <= 0:
+            raise ValueError("max_offset must be > 0")
+
+        self.max_offset = float(max_offset)
+        self.kwargs = {
+            'max_offset': self.max_offset,
+        }
+
+    def removeOutliers(self, stars, logger=None):
+        """Remove outliers from a list of stars based on fit-center offset magnitude.
+
+        :param stars:       A list of Star instances.
+        :param logger:      A logger object for logging debug info. [default: None]
+
+        :returns: stars, nremoved
+        """
+        from .config import LoggerWrapper
+        logger = LoggerWrapper(logger)
+
+        all_offsets = np.array([np.hypot(*s.fit.center) for s in stars])
+        is_flagged = np.array([s.is_flagged for s in stars], dtype=bool)
+        is_reserve = np.array([s.is_reserve for s in stars], dtype=bool)
+        use = ~is_flagged & ~is_reserve
+        bad = all_offsets > self.max_offset
+        logger.verbose("Checking %d stars for centroid outliers", int(np.sum(use)))
+
+        nremoved = int(np.sum(use & bad))
+
+        if nremoved == 0:
+            # Flag any reserve stars that exceed max_offset.
+            new_reserve_outliers = (~is_flagged) & is_reserve & bad
+            stars = [s.flag_if(flag) for s, flag in zip(stars, new_reserve_outliers)]
+            logger.verbose("No centroid outliers found")
+            logger.debug("Flagged %d reserve stars with bad centroids",
+                         int(np.sum(new_reserve_outliers)))
+            return stars, 0
+        else:
+            # Flag only non-reserve stars that exceed max_offset.
+            new_outliers = (~is_flagged) & (~is_reserve) & bad
+            stars = [s.flag_if(flag) for s, flag in zip(stars, new_outliers)]
+            logger.verbose("Found %d centroid outliers with |center| > %s",
+                           nremoved, self.max_offset)
+            logger.debug("centroid offsets = %s", all_offsets[new_outliers])
+            logger.debug("flux = %s", [s.flux for s, flag in zip(stars, new_outliers) if flag])
+
+        return stars, nremoved

--- a/piff/outliers.py
+++ b/piff/outliers.py
@@ -18,7 +18,6 @@
 
 import math
 import numpy as np
-import math
 import galsim
 from scipy.stats import chi2
 
@@ -43,24 +42,30 @@ class Outliers(object):
 
         :returns: an Outliers instance
         """
-        # Get the class to use for the outliers
-        if 'type' not in config_outliers:
-            raise ValueError("config['outliers'] has no type field")
+        if not isinstance(config_outliers, list):
+            config_outliers = [config_outliers]
 
-        outliers_type = config_outliers['type']
-        if outliers_type not in Outliers.valid_outliers_types:
-            raise ValueError("type %s is not a valid model type. "%outliers_type +
-                             "Expecting one of %s"%list(Outliers.valid_outliers_types.keys()))
+        all_outliers = []
+        for spec in config_outliers:
+            # Get the class to use for the outliers
+            if 'type' not in spec:
+                raise ValueError("config['outliers'] has no type field")
 
-        outliers_class = Outliers.valid_outliers_types[outliers_type]
+            outliers_type = spec['type']
+            if outliers_type not in Outliers.valid_outliers_types:
+                raise ValueError("type %s is not a valid model type. "%outliers_type +
+                                "Expecting one of %s"%list(Outliers.valid_outliers_types.keys()))
 
-        # Read any other kwargs in the outliers field
-        kwargs = outliers_class.parseKwargs(config_outliers, logger)
+            outliers_class = Outliers.valid_outliers_types[outliers_type]
 
-        # Build outliers object
-        outliers = outliers_class(**kwargs)
+            # Read any other kwargs in the outliers field
+            kwargs = outliers_class.parseKwargs(spec, logger)
 
-        return outliers
+            # Build outliers object
+            outliers = outliers_class(**kwargs)
+            all_outliers.append(outliers)
+
+        return all_outliers
 
     @classmethod
     def __init_subclass__(cls):
@@ -103,6 +108,26 @@ class Outliers(object):
         with writer.nested(name) as w:
             self._finish_write(w)
 
+    @classmethod
+    def write_all(cls, writer, name, outliers):
+        """Write a list of outlier handlers.
+
+        :param writer:      A writer object that encapsulates the serialization format.
+        :param name:        A name to associate with the outliers in the serialized output.
+        :param outliers:    A list of Outliers instances.
+        """
+        if not outliers:
+            return
+        if len(outliers) == 1:
+            # Only 1 outlier.  Write it to this extension.
+            outliers[0].write(writer, name)
+        else:
+            # Multiple outlier methods.  Write each to its own extension.
+            writer.write_struct(name, {'n_outliers': len(outliers)})
+            with writer.nested(name) as w:
+                for i, outlier in enumerate(outliers):
+                    outlier.write(w, f'outlier_{i}')
+
     def _finish_write(self, writer):
         """Finish the writing process with any class-specific steps.
 
@@ -144,6 +169,31 @@ class Outliers(object):
         with reader.nested(name) as r:
             outliers._finish_read(r)
         return outliers
+
+    @classmethod
+    def read_all(cls, reader, name):
+        """Read one or more outlier handlers from a FITS file.
+
+        This returns either a list of outlier handlers or None.
+        """
+        kwargs = reader.read_struct(name)
+        if kwargs is None:
+            return None
+
+        if 'n_outliers' in kwargs:
+            # Multiple outlier methods.  Read each from its own extension.
+            n_outliers = int(kwargs['n_outliers'])
+            outliers = []
+            with reader.nested(name) as r:
+                for i in range(n_outliers):
+                    outlier = cls.read(r, f'outlier_{i}')
+                    if outlier is None:
+                        raise ValueError("Missing outlier_%d in serialized outliers list" % i)
+                    outliers.append(outlier)
+            return outliers
+        else:
+            # When only 1 outlier method, it's the only thing in the extension.
+            return [cls.read(reader, name)]
 
     def _finish_read(self, reader):
         """Finish the reading process with any class-specific steps.

--- a/piff/psf.py
+++ b/piff/psf.py
@@ -38,6 +38,10 @@ class PSF(object):
     # The values in this dict will be the PSF sub-classes.
     valid_psf_types = {}
 
+    # Normally overridden by subclasses.  But this gives a reasonable default for
+    # tests that bypass places where it would be potentially set in normal operations.
+    degenerate_points = False
+
     @classmethod
     def process(cls, config_psf, logger=None):
         """Process the config dict and return a PSF instance.
@@ -357,7 +361,10 @@ class PSF(object):
         # Perform outlier rejection, but not on first iteration for degenerate solvers.
         if self.outliers and (iteration > 0 or not self.degenerate_points):
             logger.debug("             Looking for outliers")
-            stars, nremoved = self.outliers.removeOutliers(stars, logger=logger)
+            nremoved = 0
+            for outliers in self.outliers:
+                stars, removed = outliers.removeOutliers(stars, logger=logger)
+                nremoved += removed
             if nremoved == 0:
                 logger.debug("             No outliers found")
             else:

--- a/piff/simplepsf.py
+++ b/piff/simplepsf.py
@@ -272,7 +272,7 @@ class SimplePSF(PSF):
         self.interp.write(writer, 'interp')
         logger.debug("Wrote the PSF interp to %s", writer.get_full_name('interp'))
         if self.outliers:
-            self.outliers.write(writer, 'outliers')
+            Outliers.write_all(writer, 'outliers', self.outliers)
             logger.debug("Wrote the PSF outliers to %s", writer.get_full_name('outliers'))
 
     def _finish_read(self, reader, logger):
@@ -287,4 +287,4 @@ class SimplePSF(PSF):
             setattr(self, key, chisq_dict[key])
         self.model = Model.read(reader, 'model')
         self.interp = Interp.read(reader, 'interp')
-        self.outliers = Outliers.read(reader, 'outliers')
+        self.outliers = Outliers.read_all(reader, 'outliers')

--- a/piff/sumpsf.py
+++ b/piff/sumpsf.py
@@ -319,7 +319,7 @@ class SumPSF(PSF):
         for k, comp in enumerate(self.components):
             comp._write(writer, str(k), logger=logger)
         if self.outliers:
-            self.outliers.write(writer, 'outliers')
+            Outliers.write_all(writer, 'outliers', self.outliers)
             logger.debug("Wrote the PSF outliers to %s", writer.get_full_name('outliers'))
 
     def _finish_read(self, reader, logger):
@@ -336,6 +336,6 @@ class SumPSF(PSF):
         self.components = []
         for k in range(ncomponents):
             self.components.append(PSF._read(reader, str(k), logger=logger))
-        self.outliers = Outliers.read(reader, 'outliers')
+        self.outliers = Outliers.read_all(reader, 'outliers')
         # Set up all the num's properly now that everything is constructed.
         self.set_num(None)

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -274,6 +274,17 @@ def test_centroid():
     assert stars5[1].is_flagged is True
     assert stars5[2].is_flagged is True
 
+    # Check that outliers round trip properly through file.
+    fn = os.path.join('output', 'outliers_writelist_test.piff')
+    psf.interp.mean = [0]
+    psf.write(fn)
+    psf2 = piff.read(fn)
+    assert isinstance(psf2.outliers, list)
+    assert len(psf2.outliers) == len(psf.outliers)
+    assert psf2.outliers[0]._type_name == 'Chisq'
+    assert psf2.outliers[1]._type_name == 'Centroid'
+
+
 
 if __name__ == '__main__':
     test_chisq()

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -155,6 +155,22 @@ def test_base():
     with np.testing.assert_raises(ValueError):
         out = piff.Outliers.process(config)
 
+    # A list of outlier handlers should build a list in the same order.
+    config = [
+        {'type': 'Chisq', 'nsigma': 4},
+        {'type': 'Centroid', 'max_offset': 0.2},
+    ]
+    out = piff.Outliers.process(config)
+    assert isinstance(out, list)
+    assert len(out) == 2
+    assert isinstance(out[0], piff.ChisqOutliers)
+    assert isinstance(out[1], piff.CentroidOutliers)
+
+    # A null list is fine.  It means there will be no outlier rejections applied.
+    out0 = piff.Outliers.process([])
+    assert isinstance(out0, list)
+    assert len(out0) == 0
+
     # Invalid to read a type that isn't a piff.Outliers type.
     # Mock this by pretending that MADOutliers is the only subclass of Outliers.
     filename = os.path.join('input','D00240560_r_c01_r2362p01_piff.fits')
@@ -189,8 +205,10 @@ def test_base():
 def test_centroid():
     """Test the Centroid outlier class."""
     out = piff.Outliers.process({'type': 'Centroid', 'max_offset': 0.2})
-    assert type(out) is piff.CentroidOutliers
-    assert out.max_offset == 0.2
+    assert isinstance(out, list)
+    assert len(out) == 1
+    assert type(out[0]) is piff.CentroidOutliers
+    assert out[0].max_offset == 0.2
 
     # max_offset is required and must be positive.
     np.testing.assert_raises(TypeError, piff.CentroidOutliers)
@@ -209,7 +227,7 @@ def test_centroid():
         piff.Star.makeTarget(x=40, y=40, scale=0.2).withFlux(1.0, (0.3, 0.0)).flag_if(True),
     ]
 
-    stars2, nremoved = out.removeOutliers(stars)
+    stars2, nremoved = out[0].removeOutliers(stars)
     assert nremoved == 1
     assert stars2[0].is_flagged is False
     assert stars2[1].is_flagged is True
@@ -222,10 +240,39 @@ def test_centroid():
         piff.Star.makeTarget(x=31, y=31, scale=0.2, properties={'is_reserve': True})
         .withFlux(1.0, (0.0, 0.3)),
     ]
-    stars4, nremoved2 = out.removeOutliers(stars3)
+    stars4, nremoved2 = out[0].removeOutliers(stars3)
     assert nremoved2 == 0
     assert stars4[0].is_flagged is False
     assert stars4[1].is_flagged is True
+
+    # Verify PSF.remove_outliers runs multiple outlier handlers in sequence and
+    # reports the total number of newly flagged non-reserve stars.
+    stars5_input = [
+        # Good star (survives both checks)
+        piff.Star.makeTarget(x=12, y=12, scale=0.2).withFlux(1.0, (0.05, 0.05)),
+        # Bad chisq, good centroid
+        piff.Star.makeTarget(x=22, y=22, scale=0.2).withFlux(1.0, (0.05, 0.05)),
+        # Good chisq, bad centroid
+        piff.Star.makeTarget(x=32, y=32, scale=0.2).withFlux(1.0, (5., 0.00)),
+    ]
+    stars5 = [
+        piff.Star(s.data, s.fit.withNew(chisq=chisq, dof=10))
+        for s, chisq in zip(stars5_input, [0.1, 5.0, 0.1])
+    ]
+    psf = piff.SimplePSF(
+        model=piff.Gaussian(),
+        interp=piff.Mean(),
+        outliers=[
+            piff.ChisqOutliers(thresh=4.0),
+            piff.CentroidOutliers(max_offset=1.0),
+        ],
+    )
+    logger = piff.config.setup_logger(log_file='output/test_single_image.log')
+    stars5, nremoved3 = piff.PSF.remove_outliers(psf, stars5, iteration=0, logger=logger)
+    assert nremoved3 == 2
+    assert stars5[0].is_flagged is False
+    assert stars5[1].is_flagged is True
+    assert stars5[2].is_flagged is True
 
 
 if __name__ == '__main__':

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -185,6 +185,50 @@ def test_base():
             pass
 
 
+@timer
+def test_centroid():
+    """Test the Centroid outlier class."""
+    out = piff.Outliers.process({'type': 'Centroid', 'max_offset': 0.2})
+    assert type(out) is piff.CentroidOutliers
+    assert out.max_offset == 0.2
+
+    # max_offset is required and must be positive.
+    np.testing.assert_raises(TypeError, piff.CentroidOutliers)
+    np.testing.assert_raises(ValueError, piff.CentroidOutliers, max_offset=0)
+    np.testing.assert_raises(ValueError, piff.CentroidOutliers, max_offset=-0.1)
+
+    stars = [
+        # Good non-reserve star
+        piff.Star.makeTarget(x=10, y=10, scale=0.2).withFlux(1.0, (0.05, 0.05)),
+        # Bad non-reserve star (counts toward nremoved)
+        piff.Star.makeTarget(x=20, y=20, scale=0.2).withFlux(1.0, (0.25, 0.0)),
+        # Bad reserve star (not flagged if usable stars are removed this iteration)
+        piff.Star.makeTarget(x=30, y=30, scale=0.2, properties={'is_reserve': True})
+        .withFlux(1.0, (0.0, 0.25)),
+        # Already-flagged bad star (stays flagged, not counted)
+        piff.Star.makeTarget(x=40, y=40, scale=0.2).withFlux(1.0, (0.3, 0.0)).flag_if(True),
+    ]
+
+    stars2, nremoved = out.removeOutliers(stars)
+    assert nremoved == 1
+    assert stars2[0].is_flagged is False
+    assert stars2[1].is_flagged is True
+    assert stars2[2].is_flagged is False
+    assert stars2[3].is_flagged is True
+
+    # No removals among usable stars should still allow reserve-star flagging.
+    stars3 = [
+        piff.Star.makeTarget(x=11, y=11, scale=0.2).withFlux(1.0, (0.05, 0.05)),
+        piff.Star.makeTarget(x=31, y=31, scale=0.2, properties={'is_reserve': True})
+        .withFlux(1.0, (0.0, 0.3)),
+    ]
+    stars4, nremoved2 = out.removeOutliers(stars3)
+    assert nremoved2 == 0
+    assert stars4[0].is_flagged is False
+    assert stars4[1].is_flagged is True
+
+
 if __name__ == '__main__':
     test_chisq()
     test_base()
+    test_centroid()


### PR DESCRIPTION
This adds a new outlier class that looks for object whose centroid has moved by more than some threshold and flags them.  This especially picks out objects that are near other objects, but didn't get removed by the initial rejections for that.  The solutions for these can slide over to become centered on the wrong object, which is clearly something we don't want.  So this flags such objects as outliers.